### PR TITLE
fix(build): use @ricky/runtime workspace alias for RunRetryMetadata import

### DIFF
--- a/packages/local/src/request-normalizer.ts
+++ b/packages/local/src/request-normalizer.ts
@@ -7,7 +7,7 @@
  */
 
 import { isAbsolute, resolve } from 'node:path';
-import type { RunRetryMetadata } from '../runtime/types.js';
+import type { RunRetryMetadata } from '@ricky/runtime/types';
 
 // ---------------------------------------------------------------------------
 // Source types — the intake surfaces that can hand off to Ricky locally


### PR DESCRIPTION
## Summary

Hotfix for the publish workflow build failure on \`main\` after #18 merged.

\`packages/local/src/request-normalizer.ts\` had a leftover relative import \`from '../runtime/types.js'\` that breaks tsc's project-references build under the workspace layout. The reference cannot resolve a sibling-package source path that way; it must use the workspace alias \`@ricky/runtime/types\`.

\`\`\`
Error: packages/local/src/request-normalizer.ts(10,39): error TS2307:
  Cannot find module '../runtime/types.js' or its corresponding type declarations.
\`\`\`

## Fix

One-line change: \`from '../runtime/types.js'\` → \`from '@ricky/runtime/types'\`.

## Validation

- \`npm run clean && npm run build\` — clean.
- All other workspace boundaries already use \`@ricky/*\` aliases; this was the lone holdout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/agentworkforce/ricky/pull/19" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
