### PR TITLE
fix(local): align ENOENT next-action wording with proof expectation

### DIFF
--- a/packages/local/src/entrypoint.ts
+++ b/packages/local/src/entrypoint.ts
@@ -578,7 +578,7 @@ export async function runLocal(
       ],
       nextActions: [
         isMissingFile
-          ? 'Confirm the artifact path exists and retry the command.'
+          ? 'Confirm the artifact path exists and rerun the command.'
           : 'Check the spec content or artifact path and retry.',
       ],
     };


### PR DESCRIPTION
## Summary

Follow-up to #19. The \`error-path-normalization-failure\` proof in \`packages/local/src/proof/local-entrypoint-proof.ts\` asserts that \`response.nextActions[0]\` contains both \`'artifact path exists'\` AND \`'rerun'\` when normalization fails with ENOENT. The current message says \`'retry the command'\`, so the proof fails:

\`\`\`
✗ Ricky local/BYOH entrypoint proof > proves normalization failure returns actionable error response
  AssertionError: expected false to be true
  expect(evidence).toContain('ENOENT');
\`\`\`

(The actual missing assertion was the \`rerun\` substring inside next-action — the test name is misleading.)

## Fix

One word change in \`packages/local/src/entrypoint.ts:581\`: \`'retry the command'\` → \`'rerun the command'\`. Both wordings are clear; the proof picked \`rerun\` so we match.

\`\`\`diff
       nextActions: [
         isMissingFile
-          ? 'Confirm the artifact path exists and retry the command.'
+          ? 'Confirm the artifact path exists and rerun the command.'
           : 'Check the spec content or artifact path and retry.',
       ],
\`\`\`

## Validation

- \`npm test\` — **616/616 pass** locally
- \`npm run build\` — clean
- The proof case (\`error-path-normalization-failure\`) now passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/agentworkforce/ricky/pull/20" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
