### PR TITLE
Fix workspace manager proof contract

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7,7 +7,7 @@
     "": {
       "name": "@agentworkforce/ricky",
       "version": "0.1.1",
-      "license": "UNLICENSED",
+      "license": "Apache-2.0",
       "workspaces": [
         "packages/*"
       ],

--- a/test/workspace-layout-proof/workspace-layout-proof.test.ts
+++ b/test/workspace-layout-proof/workspace-layout-proof.test.ts
@@ -42,7 +42,10 @@ describe('Ricky workspace layout proof', () => {
 
   it.each([
     ['workspace-packages-exist', ['required packages: packages/shared', 'packages/cli', 'all required package src dirs have .ts files: true']],
-    ['workspace-manager-truthful', ['package.json workspaces: ["packages/*"]', 'root private: true', 'package-lock.json exists: true']],
+    [
+      'workspace-manager-truthful',
+      ['package.json name: @agentworkforce/ricky', 'package.json workspaces: ["packages/*"]', 'root publishable: true', 'package-lock.json exists: true'],
+    ],
     ['package-manifests-complete', ['workspace package manifests checked: 6', 'packages/shared/package.json: exists=true']],
     ['typescript-config-covers-workspace', ['tsconfig.base.json exists: true', 'root references packages: true']],
     ['vitest-config-covers-workspace', ['picks up packages/*/src/**/*.test.ts: true', 'picks up test/**/*.test.ts: true']],

--- a/test/workspace-layout-proof/workspace-layout-proof.ts
+++ b/test/workspace-layout-proof/workspace-layout-proof.ts
@@ -2,7 +2,7 @@
  * Ricky workspace layout proof surface.
  *
  * Proves the package split contract from docs/architecture/ricky-package-split-migration-spec.md:
- * - root is a private npm workspace orchestrator
+ * - root is a publishable npm package and workspace orchestrator
  * - source lives under packages/{shared,runtime,product,cloud,local,cli}/src
  * - workspace package dependencies point in the intended direction
  */
@@ -196,6 +196,7 @@ function workspaceImports(relPath: string): Array<{ file: string; specifier: str
 
 export function getWorkspaceLayoutProofCases(): WorkspaceLayoutProofCase[] {
   const rootPkg = readJson<{
+    name?: unknown;
     private?: unknown;
     workspaces?: unknown;
     packageManager?: unknown;
@@ -236,27 +237,30 @@ export function getWorkspaceLayoutProofCases(): WorkspaceLayoutProofCase[] {
     },
     {
       name: 'workspace-manager-truthful',
-      description: 'The root declares npm workspaces, package manager, and lockfile state.',
+      description: 'The publishable root package declares npm workspaces, package manager, and lockfile state.',
       evaluate: () => {
         const workspaces = Array.isArray(rootPkg.workspaces) ? rootPkg.workspaces : [];
         const hasPackagesGlob = workspaces.includes('packages/*');
-        const privateRoot = rootPkg.private === true;
+        const packageName = rootPkg.name === '@agentworkforce/ricky';
+        const publishableRoot = rootPkg.private !== true;
         const npmManager = typeof rootPkg.packageManager === 'string' && rootPkg.packageManager.startsWith('npm@');
         const lockfileExists = fileExists('package-lock.json');
 
         return result(
           'workspace-manager-truthful',
-          [hasPackagesGlob, privateRoot, npmManager, lockfileExists],
+          [packageName, hasPackagesGlob, publishableRoot, npmManager, lockfileExists],
           [
+            `package.json name: ${String(rootPkg.name ?? '(missing)')}`,
             `package.json workspaces: ${JSON.stringify(workspaces)}`,
-            `root private: ${privateRoot}`,
+            `root publishable: ${publishableRoot}`,
             `packageManager: ${String(rootPkg.packageManager ?? '(missing)')}`,
             `package-lock.json exists: ${lockfileExists}`,
           ],
           [],
           [
+            ...(packageName ? [] : ['Root package name is not @agentworkforce/ricky']),
             ...(hasPackagesGlob ? [] : ['Root package.json does not include packages/* workspaces']),
-            ...(privateRoot ? [] : ['Root package is not private']),
+            ...(publishableRoot ? [] : ['Root package is private and cannot be published']),
             ...(npmManager ? [] : ['Root packageManager is not npm@...']),
             ...(lockfileExists ? [] : ['Missing package-lock.json']),
           ],


### PR DESCRIPTION
## Summary
- update the workspace-manager proof to reflect the current publishable root package contract instead of requiring private: true
- prove the root npm package identity, workspace glob, npm package manager, publishability, and lockfile presence with visible evidence
- refresh package-lock root metadata so the lockfile license matches package.json

## Validation
- npm exec vitest -- run test/workspace-layout-proof/workspace-layout-proof.test.ts
- npm test
- npm run typecheck