### PR TITLE
chore(deps): add ssh2 as a regular dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,10 +13,11 @@
       ],
       "dependencies": {
         "@agent-assistant/turn-context": "^0.3.11",
-        "@agent-relay/sdk": "^5.0.0"
+        "@agent-relay/sdk": "^5.0.0",
+        "ssh2": "^1.17.0"
       },
       "bin": {
-        "ricky": "bin/ricky"
+        "ricky": "dist/ricky.js"
       },
       "devDependencies": {
         "@types/node": "^24.5.2",
@@ -1504,6 +1505,15 @@
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
+    "node_modules/asn1": {
+      "version": "0.2.6",
+      "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.6.tgz",
+      "integrity": "sha512-ix/FxPn0MDjeyJ7i/yoHGFt/EX6LyNbxSEhPPXODPL+KB0VPk86UYfL0lMdy+KCnv+fmvIzySwaK5COwqVbWTQ==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": "~2.1.0"
+      }
+    },
     "node_modules/assertion-error": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
@@ -1512,6 +1522,24 @@
       "license": "MIT",
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/bcrypt-pbkdf": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz",
+      "integrity": "sha512-qeFIXtP4MSoi6NLqO12WfqARWWuCKi2Rn/9hJLEmtB5yTNr9DqFWkJRCf2qShWzPeAMRnOgCrq0sg/KLv5ES9w==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "tweetnacl": "^0.14.3"
+      }
+    },
+    "node_modules/buildcheck": {
+      "version": "0.0.7",
+      "resolved": "https://registry.npmjs.org/buildcheck/-/buildcheck-0.0.7.tgz",
+      "integrity": "sha512-lHblz4ahamxpTmnsk+MNTRWsjYKv965MwOrSJyeD588rR3Jcu7swE+0wN5F+PbL5cjgu/9ObkhfzEPuofEMwLA==",
+      "optional": true,
+      "engines": {
+        "node": ">=10.0.0"
       }
     },
     "node_modules/cac": {
@@ -1632,6 +1660,20 @@
       "license": "MIT",
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/cpu-features": {
+      "version": "0.0.10",
+      "resolved": "https://registry.npmjs.org/cpu-features/-/cpu-features-0.0.10.tgz",
+      "integrity": "sha512-9IkYqtX3YHPCzoVg1Py+o9057a3i0fp7S530UWokCSaFVTc7CwXPRiOjRjBQQ18ZCNafx78YfnG+HALxtVmOGA==",
+      "hasInstallScript": true,
+      "optional": true,
+      "dependencies": {
+        "buildcheck": "~0.0.6",
+        "nan": "^2.19.0"
+      },
+      "engines": {
+        "node": ">=10.0.0"
       }
     },
     "node_modules/debug": {
@@ -2007,6 +2049,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/nan": {
+      "version": "2.26.2",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.26.2.tgz",
+      "integrity": "sha512-0tTvBTYkt3tdGw22nrAy50x7gpbGCCFH3AFcyS5WiUu7Eu4vWlri1woE6qHBSfy11vksDqkiwjOnlR7WV8G1Hw==",
+      "license": "MIT",
+      "optional": true
+    },
     "node_modules/nanoid": {
       "version": "3.3.11",
       "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
@@ -2183,6 +2232,12 @@
         "fsevents": "~2.3.2"
       }
     },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "license": "MIT"
+    },
     "node_modules/siginfo": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
@@ -2244,6 +2299,23 @@
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/ssh2": {
+      "version": "1.17.0",
+      "resolved": "https://registry.npmjs.org/ssh2/-/ssh2-1.17.0.tgz",
+      "integrity": "sha512-wPldCk3asibAjQ/kziWQQt1Wh3PgDFpC0XpwclzKcdT1vql6KeYxf5LIt4nlFkUeR8WuphYMKqUA56X4rjbfgQ==",
+      "hasInstallScript": true,
+      "dependencies": {
+        "asn1": "^0.2.6",
+        "bcrypt-pbkdf": "^1.0.2"
+      },
+      "engines": {
+        "node": ">=10.16.0"
+      },
+      "optionalDependencies": {
+        "cpu-features": "~0.0.10",
+        "nan": "^2.23.0"
       }
     },
     "node_modules/stackback": {
@@ -2896,6 +2968,12 @@
         "@esbuild/win32-ia32": "0.27.7",
         "@esbuild/win32-x64": "0.27.7"
       }
+    },
+    "node_modules/tweetnacl": {
+      "version": "0.14.5",
+      "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
+      "integrity": "sha512-KXXFFdAbFXY4geFIwoyNK+f5Z1b7swfXABfL7HXCmoIWMKU3dmS26672A4EeQtDzLKy7SXmfBu51JolvEKwtGA==",
+      "license": "Unlicense"
     },
     "node_modules/typescript": {
       "version": "5.9.3",

--- a/package.json
+++ b/package.json
@@ -37,7 +37,8 @@
   },
   "dependencies": {
     "@agent-assistant/turn-context": "^0.3.11",
-    "@agent-relay/sdk": "^5.0.0"
+    "@agent-relay/sdk": "^5.0.0",
+    "ssh2": "^1.17.0"
   },
   "devDependencies": {
     "@types/node": "^24.5.2",


### PR DESCRIPTION
## Summary

Adds `ssh2` (^1.17.0) as a regular dependency of `@agentworkforce/ricky` so that globally-installed users get the native SSH path for the upcoming `ricky connect <provider>` flow.

## Why

Once we wire up `ricky connect` to `connectProvider()` from `@agent-relay/cloud` (relay PR [#798](https://github.com/AgentWorkforce/relay/pull/798)), ricky will depend on `ssh2` *transitively* through `@agent-relay/cloud`. But the cloud package declares `ssh2` as an `optionalDependency` — and "optional" means **failure-is-non-fatal**, not skipped. The realistic failure modes for globally-installed ricky users:

- `npm install -g ricky --omit=optional` (or `npm config set omit optional`) → ssh2 silently skipped
- Corporate / restricted CI installs that disable optional deps
- Windows users without OpenSSH installed (the system-`ssh` fallback in the cloud SDK uses an `SSH_ASKPASS` script, which is a Linux/macOS pattern)
- Future native build regressions on exotic arches

When `ssh2` is missing the cloud SDK's `loadSSH2()` returns `null` and the code falls back to spawning system `ssh`, which fails silently in the environments above.

Pinning `ssh2` as a regular dep at the ricky package root guarantees the native SSH path on every install. This mirrors the pattern in the relay CLI repo, where `ssh2` is a regular dep at the package root for the same reason — even though `@agent-relay/cloud` (its bundled dep) declares ssh2 as optional.

## Test plan

- [x] `npm install` resolves `ssh2@^1.17.0` cleanly
- [x] `package-lock.json` updated
- [ ] Once `connectProvider()` integration lands, smoke test `ricky connect claude` end-to-end

## Compatibility

Additive — no removed deps, no API surface change. Bundle size grows by `ssh2` (~150KB gzipped, plus its native `cpu-features` helper).
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/agentworkforce/ricky/pull/23" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
