### PR TITLE
Stabilize Ricky CLI tests in CI

### DIFF
--- a/src/surfaces/cli/cli/onboarding.test.ts
+++ b/src/surfaces/cli/cli/onboarding.test.ts
@@ -243,6 +243,7 @@ describe('runOnboarding', () => {
       input: inputStream('1'),
       output,
       isTTY: true,
+      env: {},
       configStore: store,
     });
 
@@ -438,6 +439,7 @@ describe('runOnboarding', () => {
       input,
       output,
       isTTY: true,
+      env: {},
       configStore: store,
     });
 
@@ -456,6 +458,7 @@ describe('runOnboarding', () => {
     const result = await runOnboarding({
       output,
       isTTY: true,
+      env: {},
       configStore: store,
       promptShell,
     });
@@ -481,6 +484,7 @@ describe('runOnboarding', () => {
     const result = await runOnboarding({
       output,
       isTTY: true,
+      env: {},
       configStore: store,
       promptShell,
     });
@@ -501,6 +505,7 @@ describe('runOnboarding', () => {
       runOnboarding({
         output: new PassThrough(),
         isTTY: true,
+        env: {},
         configStore: mockConfigStore(),
         promptShell,
         verbose: true,
@@ -530,7 +535,9 @@ describe('runOnboarding', () => {
 
     const ambientOutput = new PassThrough();
     const previousNoColor = process.env.NO_COLOR;
+    const previousCi = process.env.CI;
     process.env.NO_COLOR = '1';
+    delete process.env.CI;
 
     try {
       const ambientEnvResult = await runOnboarding({
@@ -547,6 +554,11 @@ describe('runOnboarding', () => {
         delete process.env.NO_COLOR;
       } else {
         process.env.NO_COLOR = previousNoColor;
+      }
+      if (previousCi === undefined) {
+        delete process.env.CI;
+      } else {
+        process.env.CI = previousCi;
       }
     }
   });

--- a/src/surfaces/cli/commands/cli-main.test.ts
+++ b/src/surfaces/cli/commands/cli-main.test.ts
@@ -1907,6 +1907,11 @@ describe('cliMain', () => {
     await cliMain({
       argv: ['cloud', '--spec', 'build a workflow', '--login'],
       runInteractive: runner,
+      cloudRequest: {
+        auth: { token: 'stored-token' },
+        workspace: { workspaceId: 'workspace-from-test' },
+        body: { spec: 'placeholder', mode: 'cloud' },
+      },
     });
     const deps = runner.mock.calls[0][0];
     expect(typeof deps.recoverCloudLogin).toBe('function');
@@ -1917,6 +1922,11 @@ describe('cliMain', () => {
     await cliMain({
       argv: ['cloud', '--spec', 'build a workflow', '--connect-missing'],
       runInteractive: runner,
+      cloudRequest: {
+        auth: { token: 'stored-token' },
+        workspace: { workspaceId: 'workspace-from-test' },
+        body: { spec: 'placeholder', mode: 'cloud' },
+      },
     });
     const deps = runner.mock.calls[0][0];
     expect(typeof deps.connectCloudAgents).toBe('function');


### PR DESCRIPTION
## Summary
- make interactive onboarding tests deterministic under ambient `CI=1` by injecting explicit env fixtures
- inject Cloud request fixtures into shim wiring tests so they do not depend on stored local Cloud auth

## Validation
- `CI=1 npm test -- --run src/surfaces/cli/cli/onboarding.test.ts src/surfaces/cli/commands/cli-main.test.ts`
- `npm run typecheck`
- `git diff --check origin/main..HEAD`
