### PR TITLE
Stabilize E2E cancellation test in CI

### DIFF
--- a/test/simplified-workflow-cli.e2e.test.ts
+++ b/test/simplified-workflow-cli.e2e.test.ts
@@ -24,6 +24,7 @@ describe('simplified workflow CLI E2E paths', () => {
     const result = await runOnboarding({
       output: new PassThrough(),
       isTTY: true,
+      env: {},
       configStore: configStore(),
       promptShell,
     });


### PR DESCRIPTION
## Summary
- make the simplified workflow cancellation E2E deterministic under ambient `CI=1` by injecting an explicit interactive env fixture

## Validation
- `CI=1 npm test -- --run test/simplified-workflow-cli.e2e.test.ts`
- `npm run typecheck`
- `git diff --check`
