### PR TITLE
Surface Agent Assistant turn provenance

### DIFF
--- a/docs/product/ricky-agent-assistant-adoption-proof.md
+++ b/docs/product/ricky-agent-assistant-adoption-proof.md
@@ -27,11 +27,13 @@ The shared turn context preserves the local request envelope data that issues #9
 - request metadata
 - spec text
 
-Those fields are carried in the shared turn context metadata and bounded enrichment blocks. They are not converted into Ricky's public response contract.
+Those fields are carried in the shared turn context metadata and bounded enrichment blocks. Ricky now also surfaces a compact `generation.decisions.assistant_turn_context` summary with the assistant id, turn id, adapter package, context block ids, and enrichment ids. The full turn context remains internal to the adapter boundary; Ricky's product response still owns the workflow-specific semantics.
 
 ## Still Ricky-owned
 
 Ricky still owns the public `LocalResponse` shape, including artifacts, logs, warnings, next actions, generation stage, execution stage, and exit code semantics.
+
+Ricky uses the shared turn context as provenance instead of as a product decision engine. The local executor records a compact summary in generation decisions and carries the same summary into local coordinator run metadata, so generated artifacts and local runs can be traced back to the Agent Assistant turn envelope without moving generation, execution, blockers, or evidence into `agent-assistant`.
 
 Ricky still owns local request normalization. Raw CLI, MCP, Claude, structured, free-form, and workflow-artifact handoffs continue through `normalizeRequest()` before the shared turn context adapter runs.
 

--- a/docs/product/ricky-agent-assistant-live-proof.md
+++ b/docs/product/ricky-agent-assistant-live-proof.md
@@ -6,7 +6,7 @@ GitHub issue #13 verdict: the agent-assistant adoption is real in Ricky's local 
 
 Ricky adopted `@agent-assistant/turn-context` as a bounded request/turn envelope primitive in the local runtime path. The adapter maps Ricky's normalized `LocalInvocationRequest` into a shared turn context and preserves request id, source metadata, structured spec data, invocation root, execution mode, stage mode, spec path, request metadata, and spec text as metadata/enrichment context.
 
-The adoption does not move Ricky's public response contract, local request normalization, workflow artifact contract, runtime precheck behavior, blocker taxonomy, recovery wording, or coordinator execution semantics into `agent-assistant`.
+The local executor now records the assembled context as compact provenance through `generation.decisions.assistant_turn_context` and local coordinator run metadata. The adoption still does not move Ricky's local request normalization, workflow artifact contract, runtime precheck behavior, blocker taxonomy, recovery wording, or coordinator execution semantics into `agent-assistant`.
 
 ## Product path exercised
 

--- a/src/local/entrypoint.test.ts
+++ b/src/local/entrypoint.test.ts
@@ -3049,6 +3049,21 @@ describe('runLocal', () => {
 
         expect(result.ok).toBe(true);
         expectNoTurnContextFallback(result.logs);
+        expect(result.generation?.decisions?.assistant_turn_context).toMatchObject({
+          assistant_id: 'ricky',
+          turn_id: 'req-issue-11-live-adapter',
+          adapter: 'ricky-local-turn-context-adapter',
+          package: '@agent-assistant/turn-context',
+          context_blocks: expect.arrayContaining([
+            'enrichment-ricky-request-summary',
+            'enrichment-ricky-spec-text',
+          ]),
+          enrichment_ids: expect.arrayContaining([
+            'ricky-request-summary',
+            'ricky-spec-text',
+            'ricky-request-metadata',
+          ]),
+        });
         expect(localExecutor.runner.invocations).toHaveLength(0);
         expect(assembledInputs).toHaveLength(1);
 
@@ -3140,6 +3155,14 @@ describe('runLocal', () => {
         next: {
           run_command: `ricky run ${result.generation?.artifact?.path}`,
           run_mode_hint: `ricky run ${result.generation?.artifact?.path}`,
+        },
+        decisions: {
+          assistant_turn_context: {
+            assistant_id: 'ricky',
+            turn_id: 'req-issue-11-generate',
+            adapter: 'ricky-local-turn-context-adapter',
+            package: '@agent-assistant/turn-context',
+          },
         },
       });
       expect(result.execution).toBeUndefined();
@@ -3246,6 +3269,12 @@ describe('runLocal', () => {
           requestId: 'req-issue-11-artifact',
           source: 'workflow-artifact',
           route: 'execute',
+          assistantTurnContext: {
+            assistant_id: 'ricky',
+            turn_id: 'req-issue-11-artifact',
+            adapter: 'ricky-local-turn-context-adapter',
+            package: '@agent-assistant/turn-context',
+          },
         },
       });
       expect(result.logs).toEqual(

--- a/src/local/entrypoint.ts
+++ b/src/local/entrypoint.ts
@@ -9,6 +9,7 @@
 import type { ArtifactReader, LocalInvocationRequest, LocalStageMode, RawHandoff } from './request-normalizer.js';
 import { assembleRickyTurnContext } from './assistant-turn-context-adapter.js';
 import { normalizeRequest } from './request-normalizer.js';
+import type { TurnContextAssembly } from '@agent-assistant/turn-context';
 import { spawn } from 'node:child_process';
 import { createHash, randomUUID } from 'node:crypto';
 import { createRequire } from 'node:module';
@@ -57,6 +58,15 @@ export interface LocalResponseArtifact {
 export type LocalGenerationStatus = 'ok' | 'error';
 export type LocalExecutionStatus = 'success' | 'blocker' | 'error';
 
+export interface LocalAssistantTurnContextDecision {
+  assistant_id: string;
+  turn_id: string;
+  adapter: string;
+  package: string;
+  context_blocks: string[];
+  enrichment_ids: string[];
+}
+
 export interface LocalGenerationStageResult {
   stage: 'generate';
   status: LocalGenerationStatus;
@@ -75,6 +85,7 @@ export interface LocalGenerationStageResult {
     tool_selection?: unknown;
     refinement?: unknown;
     workforce_persona?: unknown;
+    assistant_turn_context?: LocalAssistantTurnContextDecision;
   };
 }
 
@@ -818,7 +829,7 @@ export function createLocalExecutor(options: LocalExecutorOptions = {}): LocalEx
       const specDigest = digestSpec(request.spec);
       let generationStage: LocalGenerationStageResult | undefined;
 
-      await observeRickyTurnContext(request, logs);
+      const assistantTurnContext = await observeRickyTurnContext(request, logs);
 
       logs.push(`[local] received spec from ${request.source}`);
       logs.push(`[local] mode: ${request.mode}`);
@@ -850,6 +861,7 @@ export function createLocalExecutor(options: LocalExecutorOptions = {}): LocalEx
           stage: 'generate',
           status: 'error',
           error: warnings[0] ?? 'Spec intake could not produce an executable workflow artifact.',
+          ...decisionsForAssistantTurnContext(assistantTurnContext),
         };
         return { ok: false, artifacts, logs, warnings, nextActions, ...stageResponse(includeStageContract, generationStage, undefined, 1) };
       }
@@ -899,7 +911,14 @@ export function createLocalExecutor(options: LocalExecutorOptions = {}): LocalEx
         if (!generationResult.success || !artifact) {
           warnings.push(...generationResult.validation.errors);
           nextActions.push('Fix the generated workflow validation errors before local execution.');
-          generationStage = createGenerationStage('error', artifact, specDigest, generationResult.validation.errors[0], generationResult);
+          generationStage = createGenerationStage(
+            'error',
+            artifact,
+            specDigest,
+            generationResult.validation.errors[0],
+            generationResult,
+            assistantTurnContext,
+          );
           return { ok: false, artifacts, logs, warnings, nextActions, ...stageResponse(includeStageContract, generationStage, undefined, 1) };
         }
 
@@ -908,7 +927,7 @@ export function createLocalExecutor(options: LocalExecutorOptions = {}): LocalEx
           await writeGenerationMetadataArtifacts(generationResult, artifactWriter, cwd);
         }
         logs.push(`[local] wrote workflow artifact: ${artifact.artifactPath}`);
-        generationStage = createGenerationStage('ok', artifact, specDigest, undefined, generationResult);
+        generationStage = createGenerationStage('ok', artifact, specDigest, undefined, generationResult, assistantTurnContext);
       }
 
       const runTarget = artifact?.artifactPath ?? workflowFile;
@@ -919,12 +938,13 @@ export function createLocalExecutor(options: LocalExecutorOptions = {}): LocalEx
           stage: 'generate',
           status: 'error',
           error: 'No executable local workflow artifact was available.',
+          ...decisionsForAssistantTurnContext(assistantTurnContext),
         };
         return { ok: false, artifacts, logs, warnings, nextActions, ...stageResponse(includeStageContract, generationStage, undefined, 1) };
       }
 
       if (!generationStage) {
-        generationStage = createArtifactReferenceGenerationStage(runTarget, request.requestId, specDigest);
+        generationStage = createArtifactReferenceGenerationStage(runTarget, request.requestId, specDigest, assistantTurnContext);
       }
 
       if (stageMode === 'generate') {
@@ -985,6 +1005,7 @@ export function createLocalExecutor(options: LocalExecutorOptions = {}): LocalEx
           source: request.source,
           route: intakeResult.routing.target,
           generatedWorkflowId: artifact?.workflowId,
+          ...(assistantTurnContext ? { assistantTurnContext } : {}),
         },
       });
 
@@ -1033,12 +1054,16 @@ export function createLocalExecutor(options: LocalExecutorOptions = {}): LocalEx
   };
 }
 
-async function observeRickyTurnContext(request: LocalInvocationRequest, logs: string[]): Promise<void> {
+async function observeRickyTurnContext(
+  request: LocalInvocationRequest,
+  logs: string[],
+): Promise<LocalAssistantTurnContextDecision | undefined> {
   try {
-    await assembleRickyTurnContext(request);
+    return summarizeRickyTurnContext(await assembleRickyTurnContext(request));
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error);
     logs.push(`[local] turn context adapter skipped: ${message}`);
+    return undefined;
   }
 }
 
@@ -1362,6 +1387,7 @@ function createGenerationStage(
   specDigest: string,
   error?: string,
   generationResult?: GenerationResult,
+  assistantTurnContext?: LocalAssistantTurnContextDecision,
 ): LocalGenerationStageResult {
   return {
     stage: 'generate',
@@ -1391,9 +1417,10 @@ function createGenerationStage(
             tool_selection: generationResult.toolSelection.selections,
             ...(generationResult.refinement ? { refinement: generationResult.refinement } : {}),
             ...(generationResult.workforcePersona ? { workforce_persona: generationResult.workforcePersona } : {}),
+            ...(assistantTurnContext ? { assistant_turn_context: assistantTurnContext } : {}),
           },
         }
-      : {}),
+      : decisionsForAssistantTurnContext(assistantTurnContext)),
   };
 }
 
@@ -1418,6 +1445,7 @@ function createArtifactReferenceGenerationStage(
   artifactPath: string,
   requestId: string | undefined,
   specDigest: string,
+  assistantTurnContext?: LocalAssistantTurnContextDecision,
 ): LocalGenerationStageResult {
   return {
     stage: 'generate',
@@ -1431,6 +1459,30 @@ function createArtifactReferenceGenerationStage(
       run_command: localRunCommand(artifactPath),
       run_mode_hint: `ricky run ${artifactPath}`,
     },
+    ...decisionsForAssistantTurnContext(assistantTurnContext),
+  };
+}
+
+function decisionsForAssistantTurnContext(
+  assistantTurnContext: LocalAssistantTurnContextDecision | undefined,
+): Pick<LocalGenerationStageResult, 'decisions'> {
+  if (!assistantTurnContext) return {};
+  return {
+    decisions: {
+      assistant_turn_context: assistantTurnContext,
+    },
+  };
+}
+
+function summarizeRickyTurnContext(assembly: TurnContextAssembly): LocalAssistantTurnContextDecision {
+  const metadata = assembly.metadata as { adapter?: { name?: unknown; package?: unknown } } | undefined;
+  return {
+    assistant_id: assembly.assistantId,
+    turn_id: assembly.turnId,
+    adapter: typeof metadata?.adapter?.name === 'string' ? metadata.adapter.name : 'unknown',
+    package: typeof metadata?.adapter?.package === 'string' ? metadata.adapter.package : '@agent-assistant/turn-context',
+    context_blocks: assembly.context.blocks.map((block) => block.id),
+    enrichment_ids: [...assembly.provenance.usedEnrichmentIds],
   };
 }
 


### PR DESCRIPTION
## Summary
- record compact @agent-assistant/turn-context provenance in local generation decisions
- carry the same turn-context summary into local coordinator run metadata
- update adoption proof docs to reflect the provenance boundary

## Tests
- npx tsc --noEmit
- npx vitest run src/local/assistant-turn-context-adapter.test.ts src/local/entrypoint.test.ts src/local/entrypoint-turn-context-resilience.test.ts
- npm test