### PR TITLE
Use published Workforce harness kit for persona repair

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,19 +1,19 @@
 {
   "name": "@agentworkforce/ricky",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@agentworkforce/ricky",
-      "version": "0.1.4",
+      "version": "0.1.5",
       "license": "Apache-2.0",
       "dependencies": {
         "@agent-assistant/turn-context": "^0.3.11",
         "@agent-relay/cloud": "^6.0.6",
         "@agent-relay/sdk": "^6.0.6",
-        "@agentworkforce/harness-kit": "^0.3.1",
-        "@agentworkforce/workload-router": "^0.5.1",
+        "@agentworkforce/harness-kit": "^0.5.5",
+        "@agentworkforce/workload-router": "^0.5.4",
         "@inquirer/prompts": "^8.4.2",
         "ssh2": "^1.17.0"
       },
@@ -466,17 +466,17 @@
       "integrity": "sha512-Fu2GJWkIiSUxXawhk9SW+btDz5WDzI6RGKyugG12+wm4CDJ4rnDY9Xg8FGDugzOHL8EasWFvtF6pztZTzjJOSQ=="
     },
     "node_modules/@agentworkforce/harness-kit": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/@agentworkforce/harness-kit/-/harness-kit-0.3.1.tgz",
-      "integrity": "sha512-/vmmQS+hd9CDCcvm4BeYG0IzqWymSSwvRViZRNfTQnw2pbL5PlgPQ7fn7FIMTF6L+ivVWm3vQh1yz9ovGJHjdQ==",
+      "version": "0.5.5",
+      "resolved": "https://registry.npmjs.org/@agentworkforce/harness-kit/-/harness-kit-0.5.5.tgz",
+      "integrity": "sha512-SQdbjWx7Nbod/BSswto9sT62k2HUMiCs/n36W22p1npOvOylo6/Zb2osrsZP+0o+07fXj5SQUANkU+fSw+yrXw==",
       "dependencies": {
-        "@agentworkforce/workload-router": "0.5.1"
+        "@agentworkforce/workload-router": "^0.5.4"
       }
     },
     "node_modules/@agentworkforce/workload-router": {
-      "version": "0.5.1",
-      "resolved": "https://registry.npmjs.org/@agentworkforce/workload-router/-/workload-router-0.5.1.tgz",
-      "integrity": "sha512-6YyDSIna32G5J7qNI0rPlqvg6jelZGHLUkiqR4Hcm6YXVLvOQEUOJavNQ48tMA9EgHtsHPPy4PJHGj0UyCurVw=="
+      "version": "0.5.4",
+      "resolved": "https://registry.npmjs.org/@agentworkforce/workload-router/-/workload-router-0.5.4.tgz",
+      "integrity": "sha512-q4wcY3C5+sDhfbbSrY/SkRK7wZl8Gpu/Ylg2hhyA3kvR/O4bcchO1GLHdAqihGpefH9HO2poOywzDQqZKkNwgw=="
     },
     "node_modules/@aws-crypto/crc32": {
       "version": "5.2.0",

--- a/package.json
+++ b/package.json
@@ -34,8 +34,8 @@
     "@agent-assistant/turn-context": "^0.3.11",
     "@agent-relay/cloud": "^6.0.6",
     "@agent-relay/sdk": "^6.0.6",
-    "@agentworkforce/harness-kit": "^0.3.1",
-    "@agentworkforce/workload-router": "^0.5.1",
+    "@agentworkforce/harness-kit": "^0.5.5",
+    "@agentworkforce/workload-router": "^0.5.4",
     "@inquirer/prompts": "^8.4.2",
     "ssh2": "^1.17.0"
   },

--- a/src/local/auto-fix-loop.ts
+++ b/src/local/auto-fix-loop.ts
@@ -208,6 +208,7 @@ export async function runWithAutoFix(
         continue;
       } catch (error) {
         attemptSummary.fix_error = error instanceof Error ? error.message : String(error);
+        warnings.push(...warningsFromError(error));
         const escalated = withAutoFix(response, maxAttempts, attempts, attemptSummary.status, warnings, trackingRunId);
         escalated.nextActions = [
           ...escalated.nextActions,
@@ -515,6 +516,14 @@ function levenshtein(a: string, b: string): number {
     previous.splice(0, previous.length, ...current);
   }
   return previous[b.length];
+}
+
+function warningsFromError(error: unknown): string[] {
+  if (!error || typeof error !== 'object' || !('warnings' in error)) return [];
+  const warnings = (error as { warnings?: unknown }).warnings;
+  return Array.isArray(warnings)
+    ? warnings.filter((warning): warning is string => typeof warning === 'string' && warning.trim().length > 0)
+    : [];
 }
 
 function cleanShellPath(value: string | undefined): string | null {

--- a/src/product/generation/types.ts
+++ b/src/product/generation/types.ts
@@ -200,7 +200,7 @@ export interface WorkforcePersonaGenerationMetadata {
   promptDigest: string;
   warnings: string[];
   runId: string | null;
-  source: 'package' | 'local-dev';
+  source: 'package';
   selectedIntent: string;
   responseFormat: 'structured-json' | 'fenced-artifact';
   outputPath: string;

--- a/src/product/generation/workforce-persona-writer.test.ts
+++ b/src/product/generation/workforce-persona-writer.test.ts
@@ -5,6 +5,8 @@ import { generate, generateWithWorkforcePersona } from './pipeline.js';
 import type { WorkforcePersonaExecution, WorkforcePersonaResolver } from './workforce-persona-writer.js';
 import {
   buildWorkflowPersonaTask,
+  loadWorkforcePersonaModule,
+  loadWorkforceSelectionModule,
   parsePersonaWorkflowResponse,
   resolveWorkforcePersonaContextWithModules,
   WORKFORCE_PERSONA_INTENT_CANDIDATES,
@@ -368,6 +370,58 @@ describe('workforce persona workflow writer', () => {
     ]);
     const result = await resolved.context.sendMessage('task');
     expect(result.status).toBe('completed');
+  });
+
+  it('preserves npm load failure wording when harness-kit cannot be imported', async () => {
+    const failImport = async () => {
+      throw new Error('simulated package load failure');
+    };
+
+    await expect(loadWorkforcePersonaModule(failImport)).rejects.toMatchObject({
+      name: 'WorkforcePersonaWriterError',
+      message: expect.stringContaining('@agentworkforce/harness-kit could not be loaded'),
+      warnings: [expect.stringContaining('simulated package load failure')],
+    });
+  });
+
+  it('preserves missing-export wording when harness-kit imports but lacks runnable APIs', async () => {
+    const importWrongShape = async () => ({
+      buildInteractiveSpec() {
+        return {};
+      },
+    });
+
+    await expect(loadWorkforcePersonaModule(importWrongShape)).rejects.toMatchObject({
+      name: 'WorkforcePersonaWriterError',
+      message: expect.stringContaining('does not expose the runnable persona API'),
+      warnings: [expect.stringContaining('exports: buildInteractiveSpec')],
+    });
+  });
+
+  it('preserves npm load failure wording when workload-router cannot be imported', async () => {
+    const failImport = async () => {
+      throw new Error('simulated router load failure');
+    };
+
+    await expect(loadWorkforceSelectionModule(failImport)).rejects.toMatchObject({
+      name: 'WorkforcePersonaWriterError',
+      message: expect.stringContaining('@agentworkforce/workload-router could not be loaded'),
+      warnings: [expect.stringContaining('simulated router load failure')],
+    });
+  });
+
+  it('preserves missing-export wording when workload-router imports but lacks usePersona', async () => {
+    const importWrongShape = async () => ({
+      resolvePersona() {
+        return {};
+      },
+    });
+
+    await expect(loadWorkforceSelectionModule(importWrongShape)).rejects.toMatchObject({
+      name: 'WorkforcePersonaWriterError',
+      message: expect.stringContaining('does not expose the persona selection API'),
+      warnings: [expect.stringContaining('exports: resolvePersona')],
+    });
   });
 });
 

--- a/src/product/generation/workforce-persona-writer.test.ts
+++ b/src/product/generation/workforce-persona-writer.test.ts
@@ -272,9 +272,9 @@ describe('workforce persona workflow writer', () => {
 
     const calls: Array<{ intents: readonly string[]; task: string }> = [];
     const resolver: WorkforcePersonaResolver = async (intents) => ({
-      source: 'local-dev',
+      source: 'package',
       intent: 'agent-relay-workflow',
-      warnings: ['using local ../workforce workload-router'],
+      warnings: ['resolver warning'],
       context: {
         selection: {
           personaId: 'agent-relay-workflow',
@@ -326,13 +326,13 @@ describe('workforce persona workflow writer', () => {
       harness: 'codex',
       model: 'openai-codex/gpt-5.3-codex',
       runId: 'persona-run-001',
-      source: 'local-dev',
+      source: 'package',
       selectedIntent: 'agent-relay-workflow',
       responseFormat: 'structured-json',
       outputPath: 'workflows/generated/workforce-writer.ts',
     });
     expect(result.workforcePersona?.promptDigest).toMatch(/^[a-f0-9]{64}$/);
-    expect(result.workforcePersona?.warnings).toEqual(['using local ../workforce workload-router']);
+    expect(result.workforcePersona?.warnings).toEqual(['resolver warning']);
     expect(result.artifact?.content).toBe(base.artifact!.content);
   });
 
@@ -346,8 +346,8 @@ describe('workforce persona workflow writer', () => {
         module: {},
       },
       async () => ({
-        source: 'local-dev',
-        warnings: ['using local ../workforce workload-router'],
+        source: 'package',
+        warnings: ['using packaged workload-router fallback'],
         module: {
           usePersona(intent, options) {
             return runnableContext({ personaId: intent, tier: options?.tier ?? 'minimum' });
@@ -356,7 +356,7 @@ describe('workforce persona workflow writer', () => {
       }),
     );
 
-    expect(resolved.source).toBe('local-dev');
+    expect(resolved.source).toBe('package');
     expect(resolved.intent).toBe('agent-relay-workflow');
     expect(resolved.context.selection).toMatchObject({
       personaId: 'agent-relay-workflow',
@@ -364,7 +364,7 @@ describe('workforce persona workflow writer', () => {
     });
     expect(resolved.warnings).toEqual([
       'harness-kit unavailable',
-      'using local ../workforce workload-router',
+      'using packaged workload-router fallback',
     ]);
     const result = await resolved.context.sendMessage('task');
     expect(result.status).toBe('completed');

--- a/src/product/generation/workforce-persona-writer.ts
+++ b/src/product/generation/workforce-persona-writer.ts
@@ -151,6 +151,8 @@ export type WorkforcePersonaResolver = (
   options: { tier?: string; installRoot?: string },
 ) => Promise<ResolvedWorkforcePersonaContext>;
 
+type WorkforcePackageImporter = (packageName: string) => Promise<object>;
+
 export class WorkforcePersonaWriterError extends Error {
   readonly warnings: string[];
 
@@ -379,52 +381,48 @@ export async function resolveWorkforcePersonaContextWithModules(
   );
 }
 
-export async function loadWorkforcePersonaModule(): Promise<{
+export async function loadWorkforcePersonaModule(importPackage: WorkforcePackageImporter = importWorkforcePackage): Promise<{
   module: WorkforcePersonaModule;
   source: 'package';
   warnings: string[];
 }> {
   const warnings: string[] = [];
+  let importFailure: string | undefined;
   try {
     const packageName = '@agentworkforce/harness-kit';
-    const module = await import(packageName) as WorkforcePersonaModule;
+    const module = await importPackage(packageName) as WorkforcePersonaModule;
     if (isRunnablePersonaModule(module)) return { module, source: 'package', warnings };
     warnings.push(`@agentworkforce/harness-kit did not export useRunnablePersona() or useRunnableSelection(); exports: ${moduleExports(module)}.`);
   } catch (error) {
-    warnings.push(`Package Workforce harness-kit unavailable: ${errorMessage(error)}`);
+    importFailure = errorMessage(error);
+    warnings.push(`Package Workforce harness-kit unavailable: ${importFailure}`);
   }
 
   throw new WorkforcePersonaWriterError(
-    [
-      '@agentworkforce/harness-kit is installed but does not expose the runnable persona API Ricky needs.',
-      'Install a published npm version that exports useRunnablePersona() or useRunnableSelection().',
-      'Ricky only resolves npm packages for Workforce persona execution; local ../workforce checkouts are intentionally ignored.',
-    ].join(' '),
+    workforcePersonaModuleLoadError(importFailure),
     warnings,
   );
 }
 
-export async function loadWorkforceSelectionModule(): Promise<{
+export async function loadWorkforceSelectionModule(importPackage: WorkforcePackageImporter = importWorkforcePackage): Promise<{
   module: WorkforceSelectionModule;
   source: 'package';
   warnings: string[];
 }> {
   const warnings: string[] = [];
+  let importFailure: string | undefined;
   try {
     const packageName = '@agentworkforce/workload-router';
-    const module = await import(packageName) as WorkforceSelectionModule;
+    const module = await importPackage(packageName) as WorkforceSelectionModule;
     if (typeof module.usePersona === 'function') return { module, source: 'package', warnings };
     warnings.push(`@agentworkforce/workload-router did not export usePersona(); exports: ${moduleExports(module)}.`);
   } catch (error) {
-    warnings.push(`Package Workforce router unavailable: ${errorMessage(error)}`);
+    importFailure = errorMessage(error);
+    warnings.push(`Package Workforce router unavailable: ${importFailure}`);
   }
 
   throw new WorkforcePersonaWriterError(
-    [
-      '@agentworkforce/workload-router is installed but does not expose the persona selection API Ricky needs.',
-      'Install a published npm version that exports usePersona().',
-      'Ricky only resolves npm packages for Workforce persona selection; local ../workforce checkouts are intentionally ignored.',
-    ].join(' '),
+    workforceSelectionModuleLoadError(importFailure),
     warnings,
   );
 }
@@ -646,9 +644,43 @@ function isRunnablePersonaModule(value: WorkforcePersonaModule): boolean {
   );
 }
 
+function workforcePersonaModuleLoadError(importFailure: string | undefined): string {
+  if (importFailure) {
+    return [
+      '@agentworkforce/harness-kit could not be loaded from the installed npm dependencies.',
+      'Try reinstalling @agentworkforce/ricky (`npm install` in this project).',
+      'Ricky only resolves npm packages for Workforce persona execution; local ../workforce checkouts are intentionally ignored.',
+    ].join(' ');
+  }
+  return [
+    '@agentworkforce/harness-kit is installed but does not expose the runnable persona API Ricky needs.',
+    'Install a published npm version that exports useRunnablePersona() or useRunnableSelection().',
+    'Ricky only resolves npm packages for Workforce persona execution; local ../workforce checkouts are intentionally ignored.',
+  ].join(' ');
+}
+
+function workforceSelectionModuleLoadError(importFailure: string | undefined): string {
+  if (importFailure) {
+    return [
+      '@agentworkforce/workload-router could not be loaded from the installed npm dependencies.',
+      'Try reinstalling @agentworkforce/ricky (`npm install` in this project).',
+      'Ricky only resolves npm packages for Workforce persona selection; local ../workforce checkouts are intentionally ignored.',
+    ].join(' ');
+  }
+  return [
+    '@agentworkforce/workload-router is installed but does not expose the persona selection API Ricky needs.',
+    'Install a published npm version that exports usePersona().',
+    'Ricky only resolves npm packages for Workforce persona selection; local ../workforce checkouts are intentionally ignored.',
+  ].join(' ');
+}
+
 function moduleExports(value: object): string {
   const exports = Object.keys(value).sort();
   return exports.length > 0 ? exports.join(', ') : 'none';
+}
+
+async function importWorkforcePackage(packageName: string): Promise<object> {
+  return await import(packageName) as object;
 }
 
 function runnablePersonaOptions(

--- a/src/product/generation/workforce-persona-writer.ts
+++ b/src/product/generation/workforce-persona-writer.ts
@@ -1,7 +1,6 @@
 import { createHash } from 'node:crypto';
-import { access, readFile } from 'node:fs/promises';
-import { dirname, isAbsolute, join, resolve } from 'node:path';
-import { fileURLToPath, pathToFileURL } from 'node:url';
+import { readFile } from 'node:fs/promises';
+import { isAbsolute, resolve } from 'node:path';
 
 import type { NormalizedWorkflowSpec } from '../spec-intake/types.js';
 import type { RenderedArtifact, WorkflowExecutionTarget } from './types.js';
@@ -120,7 +119,7 @@ export interface WorkforcePersonaWriterMetadata {
   promptDigest: string;
   warnings: string[];
   runId: string | null;
-  source: 'package' | 'local-dev';
+  source: 'package';
   selectedIntent: string;
   responseFormat: 'structured-json' | 'fenced-artifact';
   outputPath: string;
@@ -141,7 +140,7 @@ export interface WorkforcePersonaWriterResult {
 }
 
 export interface ResolvedWorkforcePersonaContext {
-  source: 'package' | 'local-dev';
+  source: 'package';
   intent: string;
   context: WorkforcePersonaContext;
   warnings: string[];
@@ -252,7 +251,7 @@ export async function defaultWorkforcePersonaResolver(
 ): Promise<ResolvedWorkforcePersonaContext> {
   let moduleResult: {
     module: WorkforcePersonaModule;
-    source: 'package' | 'local-dev';
+    source: 'package';
     warnings: string[];
   };
   try {
@@ -276,12 +275,12 @@ export async function resolveWorkforcePersonaContextWithModules(
   options: { tier?: string; installRoot?: string },
   moduleResult: {
     module: WorkforcePersonaModule;
-    source: 'package' | 'local-dev';
+    source: 'package';
     warnings: string[];
   },
   loadSelectionModule: () => Promise<{
     module: WorkforceSelectionModule;
-    source: 'package' | 'local-dev';
+    source: 'package';
     warnings: string[];
   }> = loadWorkforceSelectionModule,
 ): Promise<ResolvedWorkforcePersonaContext> {
@@ -295,9 +294,7 @@ export async function resolveWorkforcePersonaContextWithModules(
         const selected = selectionModule.module.usePersona(intent, selectionOptions(options));
         if (isUsablePersonaContext(selected)) {
           return {
-            source: moduleResult.source === 'local-dev' || selectionModule.source === 'local-dev'
-              ? 'local-dev'
-              : 'package',
+            source: 'package',
             intent,
             context: selected,
             warnings,
@@ -310,9 +307,7 @@ export async function resolveWorkforcePersonaContextWithModules(
         );
         if (isUsablePersonaContext(context)) {
           return {
-            source: moduleResult.source === 'local-dev' || selectionModule.source === 'local-dev'
-              ? 'local-dev'
-              : 'package',
+            source: 'package',
             intent,
             context,
             warnings,
@@ -386,37 +381,24 @@ export async function resolveWorkforcePersonaContextWithModules(
 
 export async function loadWorkforcePersonaModule(): Promise<{
   module: WorkforcePersonaModule;
-  source: 'package' | 'local-dev';
+  source: 'package';
   warnings: string[];
 }> {
   const warnings: string[] = [];
-  for (const candidate of await localWorkforceHarnessKitModuleCandidates()) {
-    const module = await importLocalWorkforceModule<WorkforcePersonaModule>(
-      candidate,
-      warnings,
-      'harness-kit',
-    );
-    if (!module) continue;
-    if (isRunnablePersonaModule(module)) {
-      return { module, source: 'local-dev', warnings };
-    }
-    warnings.push(`Local Workforce harness-kit at ${candidate} did not export runnable persona APIs.`);
-  }
-
   try {
     const packageName = '@agentworkforce/harness-kit';
     const module = await import(packageName) as WorkforcePersonaModule;
     if (isRunnablePersonaModule(module)) return { module, source: 'package', warnings };
-    warnings.push('@agentworkforce/harness-kit did not export useRunnablePersona() or useRunnableSelection().');
+    warnings.push(`@agentworkforce/harness-kit did not export useRunnablePersona() or useRunnableSelection(); exports: ${moduleExports(module)}.`);
   } catch (error) {
     warnings.push(`Package Workforce harness-kit unavailable: ${errorMessage(error)}`);
   }
 
   throw new WorkforcePersonaWriterError(
     [
-      '@agentworkforce/harness-kit is bundled as a Ricky dependency but could not be loaded.',
-      'Try reinstalling @agentworkforce/ricky (`npm install` in this project).',
-      'If you develop Ricky locally with a sibling ../workforce clone, publish or link that harness-kit.',
+      '@agentworkforce/harness-kit is installed but does not expose the runnable persona API Ricky needs.',
+      'Install a published npm version that exports useRunnablePersona() or useRunnableSelection().',
+      'Ricky only resolves npm packages for Workforce persona execution; local ../workforce checkouts are intentionally ignored.',
     ].join(' '),
     warnings,
   );
@@ -424,37 +406,24 @@ export async function loadWorkforcePersonaModule(): Promise<{
 
 export async function loadWorkforceSelectionModule(): Promise<{
   module: WorkforceSelectionModule;
-  source: 'package' | 'local-dev';
+  source: 'package';
   warnings: string[];
 }> {
   const warnings: string[] = [];
-  for (const candidate of await localWorkforceRouterModuleCandidates()) {
-    const module = await importLocalWorkforceModule<WorkforceSelectionModule>(
-      candidate,
-      warnings,
-      'workload-router',
-    );
-    if (!module) continue;
-    if (typeof module.usePersona === 'function') {
-      return { module, source: 'local-dev', warnings };
-    }
-    warnings.push(`Local Workforce router at ${candidate} did not export usePersona().`);
-  }
-
   try {
     const packageName = '@agentworkforce/workload-router';
     const module = await import(packageName) as WorkforceSelectionModule;
     if (typeof module.usePersona === 'function') return { module, source: 'package', warnings };
-    warnings.push('@agentworkforce/workload-router did not export usePersona().');
+    warnings.push(`@agentworkforce/workload-router did not export usePersona(); exports: ${moduleExports(module)}.`);
   } catch (error) {
     warnings.push(`Package Workforce router unavailable: ${errorMessage(error)}`);
   }
 
   throw new WorkforcePersonaWriterError(
     [
-      '@agentworkforce/workload-router is bundled as a Ricky dependency but could not be loaded.',
-      'Try reinstalling @agentworkforce/ricky (`npm install` in this project).',
-      'If you develop Ricky locally with a sibling ../workforce clone, publish or link that workload-router.',
+      '@agentworkforce/workload-router is installed but does not expose the persona selection API Ricky needs.',
+      'Install a published npm version that exports usePersona().',
+      'Ricky only resolves npm packages for Workforce persona selection; local ../workforce checkouts are intentionally ignored.',
     ].join(' '),
     warnings,
   );
@@ -670,50 +639,16 @@ async function resolveRelevantFiles(
   return contexts;
 }
 
-async function localWorkforceHarnessKitModuleCandidates(): Promise<string[]> {
-  const here = dirname(fileURLToPath(import.meta.url));
-  const repoRoot = resolve(here, '../../..');
-  const siblingWorkforce = resolve(repoRoot, '../workforce/packages/harness-kit');
-  return [
-    join(siblingWorkforce, 'dist/index.js'),
-    join(siblingWorkforce, 'src/index.ts'),
-  ];
-}
-
-async function importLocalWorkforceModule<T>(
-  candidate: string,
-  warnings: string[],
-  label: string,
-): Promise<T | null> {
-  try {
-    await access(candidate);
-  } catch {
-    return null;
-  }
-
-  try {
-    return await import(pathToFileURL(candidate).href) as T;
-  } catch (error) {
-    warnings.push(`Local Workforce ${label} unavailable at ${candidate}: ${errorMessage(error)}`);
-    return null;
-  }
-}
-
-async function localWorkforceRouterModuleCandidates(): Promise<string[]> {
-  const here = dirname(fileURLToPath(import.meta.url));
-  const repoRoot = resolve(here, '../../..');
-  const siblingWorkforce = resolve(repoRoot, '../workforce/packages/workload-router');
-  return [
-    join(siblingWorkforce, 'dist/index.js'),
-    join(siblingWorkforce, 'src/index.ts'),
-  ];
-}
-
 function isRunnablePersonaModule(value: WorkforcePersonaModule): boolean {
   return (
     typeof value.useRunnablePersona === 'function' ||
     typeof value.useRunnableSelection === 'function'
   );
+}
+
+function moduleExports(value: object): string {
+  const exports = Object.keys(value).sort();
+  return exports.length > 0 ? exports.join(', ') : 'none';
 }
 
 function runnablePersonaOptions(

--- a/src/surfaces/cli/commands/cli-main.test.ts
+++ b/src/surfaces/cli/commands/cli-main.test.ts
@@ -1304,9 +1304,9 @@ describe('cliMain', () => {
 
     const output = result.output.join('\n');
     expect(output).toContain('Ricky reviewed the logs but could not safely finish the repair.');
-    expect(output).toContain('Auto-fix: blocker after 1/3 attempt(s) (MISSING_ENV_VAR)');
-    expect(output).toContain('Try: export TEST_TOKEN=...');
-    expect(output).toContain('Try: ricky status --run ricky-local-options');
+    expect(output).toContain('Auto-fix: stopped after 1/3 attempt(s) (MISSING_ENV_VAR)');
+    expect(output).toContain('Next:\n  export TEST_TOKEN=...');
+    expect(output).toContain('  ricky status --run ricky-local-options');
     expect(output).not.toContain('Relevant logs:');
     expect(output).not.toContain('Options:');
   });
@@ -1340,7 +1340,7 @@ describe('cliMain', () => {
     });
 
     const output = result.output.join('\n');
-    expect(output).toContain('Auto-fix: ok after 2/3 attempt(s)');
+    expect(output).toContain('Auto-fix: repaired after 2/3 attempt(s)');
     expect(output).toContain('Repair: deterministic — Aligned deterministic workflow checks.');
   });
 

--- a/src/surfaces/cli/commands/cli-main.ts
+++ b/src/surfaces/cli/commands/cli-main.ts
@@ -29,7 +29,7 @@ import type {
 import { readFileSync } from 'node:fs';
 import { readFile } from 'node:fs/promises';
 import { dirname, isAbsolute, join, resolve } from 'node:path';
-import { fileURLToPath, pathToFileURL } from 'node:url';
+import { fileURLToPath } from 'node:url';
 import { defaultCloudIntegrationConnector, runInteractiveCli } from '../entrypoint/interactive-cli.js';
 import { parsePowerUserArgs, type ConnectTarget, type PowerUserSurface } from '../flows/power-user-parser.js';
 import {
@@ -1772,16 +1772,20 @@ function renderLocalHuman(localResult: NonNullable<InteractiveCliResult['localRe
       }
     }
     if (localResult.execution.blocker) {
-      lines.push(`Reason: ${compactSentence(localResult.execution.blocker.message)}`);
+      lines.push(`Cause: ${compactSentence(executionCause(localResult), 300)}`);
     }
   }
 
   if (localResult.auto_fix) {
     const finalAttempt = localResult.auto_fix.attempts.at(-1);
     const finalBlocker = finalAttempt?.blocker_code ? ` (${String(finalAttempt.blocker_code)})` : '';
-    lines.push(`Auto-fix: ${localResult.auto_fix.final_status} after ${localResult.auto_fix.attempts.length}/${localResult.auto_fix.max_attempts} attempt(s)${finalBlocker}`);
+    lines.push(`Auto-fix: ${autoFixStatusLabel(localResult.auto_fix.final_status)} after ${localResult.auto_fix.attempts.length}/${localResult.auto_fix.max_attempts} attempt(s)${finalBlocker}`);
     const fixError = typeof finalAttempt?.fix_error === 'string' ? finalAttempt.fix_error : undefined;
-    if (fixError) lines.push(`Repair issue: ${compactSentence(fixError)}`);
+    if (fixError) {
+      lines.push(`Repair blocked: ${compactSentence(repairIssueSummary(fixError), 300)}`);
+      const detail = repairIssueDetail(localResult.warnings);
+      if (detail) lines.push(`Repair detail: ${compactSentence(detail, 300)}`);
+    }
     const appliedFix = finalAttempt?.applied_fix;
     if (appliedFix && typeof appliedFix === 'object') {
       const fix = appliedFix as { mode?: unknown; summary?: unknown; artifact_path?: unknown };
@@ -1791,8 +1795,9 @@ function renderLocalHuman(localResult: NonNullable<InteractiveCliResult['localRe
     }
     if (localResult.auto_fix.escalation) {
       lines.push(`Ricky reviewed the logs but could not safely finish the repair.`);
+      lines.push('Next:');
       for (const option of localResult.auto_fix.escalation.options.slice(0, 3)) {
-        lines.push(option.command ? `Try: ${option.command}` : `Try: ${option.description}`);
+        lines.push(`  ${option.command ?? option.description}`);
       }
     }
   }
@@ -1828,7 +1833,8 @@ function executionFailureSummary(localResult: NonNullable<InteractiveCliResult['
   const blocker = execution.blocker?.code ? ` — ${execution.blocker.code}` : '';
   const failedStep = failedStepFromTail(execution.evidence?.logs.tail ?? [])
     ?? execution.evidence?.failed_step?.id;
-  return `Execution: ${execution.status}${blocker}${failedStep ? ` at ${failedStep}` : ''}`;
+  const status = execution.status === 'blocker' ? 'blocked' : execution.status;
+  return `Execution: ${status}${blocker}${failedStep ? ` at ${failedStep}` : ''}`;
 }
 
 function failedStepFromTail(tail: string[]): string | undefined {
@@ -1844,6 +1850,43 @@ function compactSentence(value: string, maxLength = 220): string {
   const compact = value.replace(/\s+/g, ' ').trim();
   if (compact.length <= maxLength) return compact;
   return `${compact.slice(0, maxLength - 1).trimEnd()}…`;
+}
+
+function executionCause(localResult: NonNullable<InteractiveCliResult['localResult']>): string {
+  const tailCause = conciseFailureFromTail(localResult.execution?.evidence?.logs.tail ?? []);
+  return tailCause ?? localResult.execution?.blocker?.message ?? 'Workflow execution failed.';
+}
+
+function conciseFailureFromTail(tail: string[]): string | undefined {
+  for (const line of [...tail].reverse()) {
+    const trimmed = line.trim();
+    if (!trimmed) continue;
+    if (/^\[/.test(trimmed)) continue;
+    if (/^[✓●]/.test(trimmed)) continue;
+    if (/^failed$/i.test(trimmed)) continue;
+    const commandFailure = trimmed.match(/Command failed with exit code \d+:\s*(.+)$/i);
+    if (commandFailure?.[1]) return commandFailure[1].replace(/\.+$/, '.');
+    if (/Workflow runtime reported failure|Workflow reported a failed run|Shutting down broker/i.test(trimmed)) continue;
+    return trimmed.replace(/\.+$/, '.');
+  }
+  return undefined;
+}
+
+function autoFixStatusLabel(status: 'ok' | 'blocker' | 'error'): string {
+  if (status === 'ok') return 'repaired';
+  if (status === 'blocker') return 'stopped';
+  return 'errored';
+}
+
+function repairIssueSummary(issue: string): string {
+  if (/@agentworkforce\/harness-kit/i.test(issue) && /runnable persona API|useRunnablePersona|useRunnableSelection/i.test(issue)) {
+    return 'npm @agentworkforce/harness-kit does not expose the runnable persona APIs Ricky needs.';
+  }
+  return issue;
+}
+
+function repairIssueDetail(warnings: string[]): string | undefined {
+  return warnings.find((warning) => /@agentworkforce\/harness-kit/i.test(warning) && /exports:/i.test(warning));
 }
 
 function localGenerationAuthor(generation: NonNullable<InteractiveCliResult['localResult']>['generation']): string {
@@ -1864,7 +1907,7 @@ function isAutoFixValue(value: string): boolean {
   return /^-?\d+$/.test(value);
 }
 
-if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+if (isDirectCliMainInvocation()) {
   cliMain()
     .then((result) => {
       if (result.output.length > 0) {
@@ -1877,4 +1920,12 @@ if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) 
       process.stderr.write(`${message}\n`);
       process.exitCode = 1;
     });
+}
+
+function isDirectCliMainInvocation(): boolean {
+  if (!process.argv[1]) return false;
+  const entryPath = resolve(process.argv[1]);
+  const modulePath = fileURLToPath(import.meta.url);
+  if (resolve(modulePath) !== entryPath) return false;
+  return /(?:^|[/\\])commands[/\\]cli-main\.(?:ts|js)$/.test(modulePath);
 }


### PR DESCRIPTION
## Summary
- bump Ricky to @agentworkforce/harness-kit@0.5.5 and @agentworkforce/workload-router@0.5.4
- remove local ../workforce fallback loading so Workforce persona execution resolves npm packages only
- carry Workforce loader warnings into auto-fix summaries and tighten foreground output
- prevent the bundled CLI from executing cli-main twice

## Verification
- node import proof: useRunnablePersona/useRunnableSelection are exported from installed @agentworkforce/harness-kit
- npx vitest run src/product/generation/workforce-persona-writer.test.ts src/product/generation/workforce-persona-repairer.test.ts src/local/auto-fix-loop.test.ts src/surfaces/cli/commands/cli-main.test.ts
- npm run typecheck
- npm run bundle && node dist/ricky.js run workflows/demo-persona-repair/semantic-contract.ts --foreground
  - repaired after 2/3 attempts; execution success run ecc8c6c5c8b2e5b2b63ab298
- npm test

Note: install used npm --userconfig=/dev/null only to bypass this machine's stale npm before cutoff; package resolution is still from npm registry only, with no overrides or local paths.