### PR TITLE
Add foreground progress spinner

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@agentworkforce/ricky",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@agentworkforce/ricky",
-      "version": "0.1.5",
+      "version": "0.1.6",
       "license": "Apache-2.0",
       "dependencies": {
         "@agent-assistant/turn-context": "^0.3.11",
@@ -15,6 +15,7 @@
         "@agentworkforce/harness-kit": "^0.5.5",
         "@agentworkforce/workload-router": "^0.5.4",
         "@inquirer/prompts": "^8.4.2",
+        "ora": "^8.2.0",
         "ssh2": "^1.17.0"
       },
       "bin": {
@@ -3635,6 +3636,18 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/cli-spinners": {
+      "version": "2.9.2",
+      "resolved": "https://registry.npmjs.org/cli-spinners/-/cli-spinners-2.9.2.tgz",
+      "integrity": "sha512-ywqV+5MmyL4E7ybXgKys4DugZbX0FC6LnwrhjuykIjnK9k8OQacQ7axGKnjDXWNhns0xot3bZI5h55H8yo9cJg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/cli-truncate": {
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/cli-truncate/-/cli-truncate-5.2.0.tgz",
@@ -3989,6 +4002,30 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/is-interactive": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/is-interactive/-/is-interactive-2.0.0.tgz",
+      "integrity": "sha512-qP1vozQRI+BMOPcjFzrjXuQvdak2pHNUMZoeG2eRbiSqyvbEf/wQtEOTOX1guk6E3t36RkaqiSt8A/6YElNxLQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/is-unicode-supported": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-2.1.0.tgz",
+      "integrity": "sha512-mE00Gnza5EEB3Ds0HfMyllZzbBrmLOX3vfWoj9A9PEnTfratQ/BcaJOuMhnkhjXvb2+FkY3VuHqtAGpTPmglFQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/js-tokens": {
       "version": "9.0.1",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-9.0.1.tgz",
@@ -4010,6 +4047,46 @@
       },
       "engines": {
         "node": ">=22.13.0"
+      }
+    },
+    "node_modules/log-symbols": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-6.0.0.tgz",
+      "integrity": "sha512-i24m8rpwhmPIS4zscNzK6MSEhk0DUWa/8iYQWxhffV8jkI4Phvs3F+quL5xvS0gdQR0FyTCMMH33Y78dDTzzIw==",
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "^5.3.0",
+        "is-unicode-supported": "^1.3.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/log-symbols/node_modules/chalk": {
+      "version": "5.6.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.6.2.tgz",
+      "integrity": "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==",
+      "license": "MIT",
+      "engines": {
+        "node": "^12.17.0 || ^14.13 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/log-symbols/node_modules/is-unicode-supported": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-1.3.0.tgz",
+      "integrity": "sha512-43r2mRvz+8JRIKnWJ+3j8JtjRKZ6GmjzfaE/qiBJnikNnYv/6bagRJ1kUhNk8R5EX/GkobD+r+sfxCPJsiKBLQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/log-update": {
@@ -4192,6 +4269,58 @@
       "license": "MIT",
       "dependencies": {
         "mimic-function": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/ora": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/ora/-/ora-8.2.0.tgz",
+      "integrity": "sha512-weP+BZ8MVNnlCm8c0Qdc1WSWq4Qn7I+9CJGm7Qali6g44e/PUzbjNqJX5NJ9ljlNMosfJvg1fKEGILklK9cwnw==",
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "^5.3.0",
+        "cli-cursor": "^5.0.0",
+        "cli-spinners": "^2.9.2",
+        "is-interactive": "^2.0.0",
+        "is-unicode-supported": "^2.0.0",
+        "log-symbols": "^6.0.0",
+        "stdin-discarder": "^0.2.2",
+        "string-width": "^7.2.0",
+        "strip-ansi": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/ora/node_modules/chalk": {
+      "version": "5.6.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.6.2.tgz",
+      "integrity": "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==",
+      "license": "MIT",
+      "engines": {
+        "node": "^12.17.0 || ^14.13 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/ora/node_modules/string-width": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-7.2.0.tgz",
+      "integrity": "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==",
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^10.3.0",
+        "get-east-asian-width": "^1.0.0",
+        "strip-ansi": "^7.1.0"
       },
       "engines": {
         "node": ">=18"
@@ -4456,6 +4585,18 @@
       "integrity": "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/stdin-discarder": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/stdin-discarder/-/stdin-discarder-0.2.2.tgz",
+      "integrity": "sha512-UhDfHmA92YAlNnCfhmq0VeNL5bDbiZGg7sZ2IvPsXubGkiNa9EC+tUTsjBRsYUAz87btI6/1wf4XoVvQ3uRnmQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     },
     "node_modules/string-width": {
       "version": "8.2.0",

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "@agentworkforce/harness-kit": "^0.5.5",
     "@agentworkforce/workload-router": "^0.5.4",
     "@inquirer/prompts": "^8.4.2",
+    "ora": "^8.2.0",
     "ssh2": "^1.17.0"
   },
   "devDependencies": {

--- a/src/local/auto-fix-loop.test.ts
+++ b/src/local/auto-fix-loop.test.ts
@@ -109,7 +109,7 @@ describe('runWithAutoFix', () => {
 
     expect(progress).toEqual([
       'Running workflow (attempt 1/3)...',
-      'Workflow failed at install-deps; preparing repair...',
+      'Ricky is fixing the workflow...',
       'Retrying workflow from install-deps...',
       'Running workflow (attempt 2/3)...',
     ]);

--- a/src/local/auto-fix-loop.ts
+++ b/src/local/auto-fix-loop.ts
@@ -135,10 +135,10 @@ export async function runWithAutoFix(
     const classification = classifyFailure(evidence);
     const debuggerResult = debugWorkflowRun({ evidence, classification });
     const repairTarget = await resolveWorkflowRepairTarget(currentRequest, response);
-    onProgress?.(`Workflow failed${failedStep ? ` at ${failedStep}` : ''}; preparing repair...`);
 
     if (repairTarget) {
       try {
+        onProgress?.('Ricky is fixing the workflow...');
         const repair = await workflowRepairer({
           request: currentRequest,
           response,
@@ -307,13 +307,11 @@ function isV1DirectBlocker(code: string | undefined): boolean {
 async function defaultWorkflowRepairer(input: WorkflowRepairInput): Promise<WorkflowRepairResult> {
   const deterministicRepair = repairWorkflowDeterministically(input);
   if (deterministicRepair) {
-    input.onProgress?.('Applying deterministic workflow repair...');
     return deterministicRepair;
   }
 
   let result: Awaited<ReturnType<typeof repairWorkflowWithWorkforcePersona>>;
   try {
-    input.onProgress?.('Asking Workforce persona to repair the workflow...');
     result = await repairWorkflowWithWorkforcePersona({
       repoRoot: input.cwd,
       artifactPath: input.artifactPath,

--- a/src/local/entrypoint.test.ts
+++ b/src/local/entrypoint.test.ts
@@ -1163,6 +1163,25 @@ describe('runLocal', () => {
     expect(result.warnings.some((w) => w.includes('Cloud API surface'))).toBe(false);
   });
 
+  it('emits concise progress while generating and running locally', async () => {
+    const progress: string[] = [];
+    const localExecutor = memoryLocalExecutorOptions({ stdout: ['local run completed'] });
+
+    const result = await runLocal(
+      { source: 'cli', spec: 'generate a local workflow for packages/local/src/entrypoint.ts', stageMode: 'run' },
+      {
+        localExecutor,
+        onProgress: (message) => progress.push(message),
+      },
+    );
+
+    expect(result.ok).toBe(true);
+    expect(progress).toEqual([
+      'Writing workflow...',
+      'Running workflow...',
+    ]);
+  });
+
   it('can return a generated artifact without launching the local runtime', async () => {
     const localExecutor = memoryLocalExecutorOptions({ stdout: ['local run completed'] });
     const result = await runLocal(
@@ -2648,11 +2667,15 @@ describe('runLocal', () => {
         { source: 'workflow-artifact', artifactPath, stageMode: 'run' },
         {
           artifactReader: mockArtifactReader('import { workflow } from "@agent-relay/sdk/workflows";'),
+          onRuntimeOutput: (stream, line) => {
+            calls.push({ workflowFile: `${stream}:${line}`, cwd: 'streamed' });
+          },
           localExecutor: {
             cwd: repo,
             scriptWorkflowRunner: async (workflowFile, options) => {
               calls.push({ workflowFile, cwd: options.cwd, env: options.env });
               options.onStdout?.('sdk runner accepted workflow');
+              options.onStderr?.('sdk runner warning');
               if (options.env?.AGENT_RELAY_RUN_ID_FILE) {
                 await writeFile(options.env.AGENT_RELAY_RUN_ID_FILE, 'runtime-from-sdk\n', 'utf8');
               }
@@ -2662,7 +2685,11 @@ describe('runLocal', () => {
       );
 
       expect(result.ok).toBe(true);
-      expect(calls).toEqual([expect.objectContaining({ workflowFile: artifactPath, cwd: repo })]);
+      expect(calls).toEqual([
+        expect.objectContaining({ workflowFile: artifactPath, cwd: repo }),
+        { workflowFile: 'stdout:sdk runner accepted workflow', cwd: 'streamed' },
+        { workflowFile: 'stderr:sdk runner warning', cwd: 'streamed' },
+      ]);
       expect(result.execution).toMatchObject({
         stage: 'execute',
         status: 'success',

--- a/src/local/entrypoint.ts
+++ b/src/local/entrypoint.ts
@@ -253,6 +253,10 @@ export interface LocalExecutorOptions {
     NonNullable<GenerationInput['workforcePersonaWriter']>,
     'repoRoot' | 'targetMode' | 'outputPath'
   >;
+  /** Concise phase updates for foreground CLI progress indicators. */
+  onProgress?: (message: string) => void;
+  /** Foreground workflow runtime output stream, separate from Ricky progress. */
+  onRuntimeOutput?: (stream: 'stdout' | 'stderr', line: string) => void;
 }
 
 export interface ScriptWorkflowRunnerOptions {
@@ -335,7 +339,10 @@ export function createProcessCommandRunner(): CommandRunner {
 }
 
 class SdkScriptWorkflowCoordinator implements CoordinatorLauncher {
-  constructor(private readonly runner: ScriptWorkflowRunner) {}
+  constructor(
+    private readonly runner: ScriptWorkflowRunner,
+    private readonly onRuntimeOutput?: (stream: 'stdout' | 'stderr', line: string) => void,
+  ) {}
 
   async launch(request: RunRequest): Promise<CoordinatorResult> {
     const runId = request.runId ?? cryptoRunId();
@@ -372,10 +379,12 @@ class SdkScriptWorkflowCoordinator implements CoordinatorLauncher {
           previousRunId: retry.previousRunId,
           onStdout: (line) => {
             stdout.push(line);
+            this.onRuntimeOutput?.('stdout', line);
             emit('stdout', line, { stream: 'stdout' });
           },
           onStderr: (line) => {
             stderr.push(line);
+            this.onRuntimeOutput?.('stderr', line);
             emit('stderr', line, { stream: 'stderr' });
           },
         }),
@@ -818,12 +827,13 @@ export function createLocalExecutor(options: LocalExecutorOptions = {}): LocalEx
       const warnings: string[] = [];
       const nextActions: string[] = [];
       const cwd = request.invocationRoot ?? options.cwd ?? process.cwd();
+      const onProgress = options.onProgress;
       const artifactWriter = options.artifactWriter ?? defaultArtifactWriter;
       const coordinator =
         options.coordinator ??
         (options.commandRunner || options.route
           ? new LocalCoordinator(options.commandRunner ?? createProcessCommandRunner())
-          : new SdkScriptWorkflowCoordinator(options.scriptWorkflowRunner ?? createSdkScriptWorkflowRunner()));
+          : new SdkScriptWorkflowCoordinator(options.scriptWorkflowRunner ?? createSdkScriptWorkflowRunner(), options.onRuntimeOutput));
       const stageMode = resolveStageMode(request.stageMode, options.returnGeneratedArtifactOnly);
       const includeStageContract = true;
       const specDigest = digestSpec(request.spec);
@@ -888,6 +898,9 @@ export function createLocalExecutor(options: LocalExecutorOptions = {}): LocalEx
           refine: request.refine,
           ...(workforcePersonaWriter ? { workforcePersonaWriter } : {}),
         };
+        onProgress?.(generationInput.workforcePersonaWriter
+          ? 'Writing workflow with Workforce persona...'
+          : 'Writing workflow...');
         generationResult = generationInput.workforcePersonaWriter
           ? await generateWithWorkforcePersona(generationInput)
           : generate(generationInput);
@@ -992,6 +1005,11 @@ export function createLocalExecutor(options: LocalExecutorOptions = {}): LocalEx
 
       const runtimeRunIdFile = runtimeRunIdFilePath(cwd, workflowId);
       await ensureParentDir(runtimeRunIdFile);
+      if (request.metadata.autoFixProgressOwner !== true) {
+        onProgress?.(request.retry?.startFromStep
+          ? `Running workflow from ${request.retry.startFromStep}...`
+          : 'Running workflow...');
+      }
       const runResult = await coordinator.launch({
         workflowFile: runTarget,
         cwd,
@@ -1099,6 +1117,7 @@ export interface LocalEntrypointOptions {
   artifactReader?: ArtifactReader;
   localExecutor?: LocalExecutorOptions;
   onProgress?: (message: string) => void;
+  onRuntimeOutput?: (stream: 'stdout' | 'stderr', line: string) => void;
 }
 
 export type LocalEntrypointInput = RawHandoff | LocalInvocationRequest;
@@ -1119,7 +1138,7 @@ export async function runLocal(
   handoff: LocalEntrypointInput,
   options: LocalEntrypointOptions = {},
 ): Promise<LocalResponse> {
-  const { executor, artifactReader, localExecutor, onProgress } = options;
+  const { executor, artifactReader, localExecutor, onProgress, onRuntimeOutput } = options;
 
   // Normalize
   let request: LocalInvocationRequest;
@@ -1147,10 +1166,12 @@ export async function runLocal(
 
   const resolvedExecutor =
     executor ??
-    (localExecutor
+    (localExecutor || onProgress || onRuntimeOutput
       ? createLocalExecutor({
-          ...localExecutor,
-          cwd: localExecutor.cwd ?? request.invocationRoot,
+          ...(localExecutor ?? {}),
+          cwd: localExecutor?.cwd ?? request.invocationRoot,
+          ...(onProgress ? { onProgress } : {}),
+          ...(onRuntimeOutput ? { onRuntimeOutput } : {}),
         })
       : getDefaultExecutor());
 
@@ -1175,6 +1196,10 @@ export async function runLocal(
         resolvedExecutor.execute({
           ...attemptRequest,
           autoFix: undefined,
+          metadata: {
+            ...attemptRequest.metadata,
+            autoFixProgressOwner: true,
+          },
         }),
     });
   }

--- a/src/shared/constants.ts
+++ b/src/shared/constants.ts
@@ -21,6 +21,8 @@ export const DEFAULT_STEP_TIMEOUT_MS = 300_000;
 
 export const DEFAULT_RETRY_MAX_ATTEMPTS = 2;
 
+export const DEFAULT_AUTO_FIX_ATTEMPTS = 7;
+
 export const DEFAULT_RETRY_BACKOFF_MS = 1_000;
 
 export const DEFAULT_VALIDATION_POLICY = {

--- a/src/surfaces/cli/commands/cli-main.test.ts
+++ b/src/surfaces/cli/commands/cli-main.test.ts
@@ -1,11 +1,12 @@
 import { describe, expect, it, vi } from 'vitest';
 import { readFileSync } from 'node:fs';
+import { Writable } from 'node:stream';
 import { fileURLToPath } from 'node:url';
 
 import type { InteractiveCliResult } from '../entrypoint/interactive-cli.js';
 import type { OnboardingResult } from '../cli/onboarding.js';
 import type { LocalResponse } from '../../../local/entrypoint.js';
-import { cliMain, parseArgs, renderHelp } from './cli-main.js';
+import { cliMain, parseArgs, renderHelp, type CliProgressSpinner } from './cli-main.js';
 
 // ---------------------------------------------------------------------------
 // parseArgs
@@ -14,7 +15,7 @@ import { cliMain, parseArgs, renderHelp } from './cli-main.js';
 describe('parseArgs', () => {
   // Auto-fix is default-on for local run flows. Refinement stays opt-in so
   // omitted generation flags remain fast and deterministic.
-  const RUN_DEFAULTS = { autoFix: 3 };
+  const RUN_DEFAULTS = { autoFix: 7 };
 
   it('defaults to run command with auto-fix enabled and refinement omitted', () => {
     expect(parseArgs([])).toEqual({ command: 'run', ...RUN_DEFAULTS });
@@ -94,7 +95,7 @@ describe('parseArgs', () => {
       command: 'run',
       artifact: 'workflows/generated/example.ts',
       runRequested: true,
-      autoFix: 3,
+      autoFix: 7,
     });
     expect(parseArgs(['run', 'workflows/generated/example.ts', '--auto-fix=5'])).toMatchObject({
       autoFix: 5,
@@ -160,7 +161,7 @@ describe('parseArgs', () => {
     expect(parsed).toMatchObject({
       command: 'run',
       spec: 'build a workflow',
-      autoFix: 3,
+      autoFix: 7,
     });
     expect(parsed).not.toHaveProperty('refine');
   });
@@ -176,7 +177,7 @@ describe('parseArgs', () => {
   it('disables refine when --no-refine or --no-with-llm is passed', () => {
     const opted = parseArgs(['--spec', 'build a workflow', '--no-refine']);
     expect(opted).not.toHaveProperty('refine');
-    expect(opted).toMatchObject({ autoFix: 3 });
+    expect(opted).toMatchObject({ autoFix: 7 });
     const noLlm = parseArgs(['--spec', 'build a workflow', '--no-with-llm']);
     expect(noLlm).not.toHaveProperty('refine');
   });
@@ -196,7 +197,7 @@ describe('parseArgs', () => {
       spec: 'build a workflow',
       workflowName: 'release-health',
       noRun: true,
-      autoFix: 3,
+      autoFix: 7,
     });
 
     expect(parseArgs(['cloud', '--workflow', 'workflows/generated/release-health.ts', '--run', '--yes', '--json'])).toMatchObject({
@@ -464,6 +465,29 @@ function restoreEnv(name: string, value: string | undefined): void {
   process.env[name] = value;
 }
 
+function ttyOutputSink(): NodeJS.WritableStream & { isTTY: true } {
+  const output = new Writable({
+    write(_chunk, _encoding, callback): void {
+      callback();
+    },
+  }) as unknown as NodeJS.WritableStream & { isTTY: true };
+  output.isTTY = true;
+  return output;
+}
+
+function capturedTtyOutputSink(): (NodeJS.WritableStream & { isTTY: true; chunks: string[] }) {
+  const chunks: string[] = [];
+  const output = new Writable({
+    write(chunk, _encoding, callback): void {
+      chunks.push(String(chunk));
+      callback();
+    },
+  }) as unknown as NodeJS.WritableStream & { isTTY: true; chunks: string[] };
+  output.isTTY = true;
+  output.chunks = chunks;
+  return output;
+}
+
 describe('cliMain', () => {
   it('returns help output with exit code 0 for --help', async () => {
     const result = await cliMain({ argv: ['--help'] });
@@ -729,6 +753,7 @@ describe('cliMain', () => {
     const output = result.output.join('\n');
 
     expect(result.exitCode).toBe(1);
+    expect(output).toContain('Status: failed — generation did not complete');
     expect(output).toContain('Author: Workforce persona writer failed before authoring completed');
     expect(output).toContain('Generation: failed (status: error).');
     expect(output).toContain('Reason: WORKFORCE_PERSONA_WRITER_FAILED');
@@ -921,7 +946,7 @@ describe('cliMain', () => {
         handoff: expect.objectContaining({
           source: 'cli',
           stageMode: 'run',
-          autoFix: { maxAttempts: 3 },
+          autoFix: { maxAttempts: 7 },
         }),
       }),
     );
@@ -940,7 +965,7 @@ describe('cliMain', () => {
     expect(handoff).toMatchObject({
       source: 'cli',
       stageMode: 'run',
-      autoFix: { maxAttempts: 3 },
+      autoFix: { maxAttempts: 7 },
       cliMetadata: {
         handoff: 'inline-spec',
         workflowName: 'release-health',
@@ -961,7 +986,7 @@ describe('cliMain', () => {
     expect(runner.mock.calls[0][0].handoff).toMatchObject({
       source: 'cli',
       stageMode: 'run',
-      autoFix: { maxAttempts: 3 },
+      autoFix: { maxAttempts: 7 },
       refine: { model: 'sonnet' },
       cliMetadata: { handoff: 'inline-spec' },
     });
@@ -1272,7 +1297,7 @@ describe('cliMain', () => {
         },
       },
       auto_fix: {
-        max_attempts: 3,
+        max_attempts: 7,
         final_status: 'blocker',
         resumed: false,
         run_id: 'ricky-local-options',
@@ -1304,7 +1329,7 @@ describe('cliMain', () => {
 
     const output = result.output.join('\n');
     expect(output).toContain('Ricky reviewed the logs but could not safely finish the repair.');
-    expect(output).toContain('Auto-fix: stopped after 1/3 attempt(s) (MISSING_ENV_VAR)');
+    expect(output).toContain('Auto-fix: stopped after 1/7 attempt(s) (MISSING_ENV_VAR)');
     expect(output).toContain('Next:\n  export TEST_TOKEN=...');
     expect(output).toContain('  ricky status --run ricky-local-options');
     expect(output).not.toContain('Relevant logs:');
@@ -1314,7 +1339,7 @@ describe('cliMain', () => {
   it('renders auto-fix repair mode and summary for applied workflow repairs', async () => {
     const localResult = stagedLocalResult({
       auto_fix: {
-        max_attempts: 3,
+        max_attempts: 7,
         final_status: 'ok',
         resumed: true,
         run_id: 'ricky-local-repaired',
@@ -1340,7 +1365,7 @@ describe('cliMain', () => {
     });
 
     const output = result.output.join('\n');
-    expect(output).toContain('Auto-fix: repaired after 2/3 attempt(s)');
+    expect(output).toContain('Auto-fix: repaired after 2/7 attempt(s)');
     expect(output).toContain('Repair: deterministic — Aligned deterministic workflow checks.');
   });
 
@@ -1552,6 +1577,155 @@ describe('cliMain', () => {
     expect(runner.mock.calls[1][0].handoff.cliMetadata).toMatchObject({
       runMode: 'foreground',
     });
+  });
+
+  it('uses a TTY spinner for foreground local progress and stops before the final summary', async () => {
+    const events: string[] = [];
+    let spinnerText = '';
+    const spinner: CliProgressSpinner = {
+      get text(): string {
+        return spinnerText;
+      },
+      set text(value: string) {
+        spinnerText = value;
+        events.push(`text:${value}`);
+      },
+      start(): CliProgressSpinner {
+        events.push(`start:${spinnerText}`);
+        return spinner;
+      },
+      stop(): CliProgressSpinner {
+        events.push(`stop:${spinnerText}`);
+        return spinner;
+      },
+    };
+    const createProgressSpinner = vi.fn(({ text }: { text: string; stream: NodeJS.WritableStream }) => {
+      spinnerText = text;
+      events.push(`create:${text}`);
+      return spinner;
+    });
+    const runner = vi.fn(async (deps) => {
+      deps.localProgress?.('Writing workflow with Workforce persona...');
+      deps.localProgress?.('Ricky is fixing the workflow...');
+      deps.localProgress?.('Retrying workflow from install-deps...');
+      return fakeInteractiveResult({
+        ok: true,
+        localResult: stagedLocalResult({
+          auto_fix: {
+            max_attempts: 7,
+            final_status: 'ok',
+            resumed: true,
+            attempts: [
+              { attempt: 1, status: 'blocker', blocker_code: 'INVALID_ARTIFACT' },
+              { attempt: 2, status: 'ok' },
+            ],
+          },
+        }),
+      });
+    });
+
+    const result = await cliMain({
+      argv: ['run', 'workflows/generated/issue-3.ts', '--foreground'],
+      output: ttyOutputSink(),
+      isTTY: true,
+      createProgressSpinner,
+      runInteractive: runner,
+    });
+
+    expect(createProgressSpinner).toHaveBeenCalledTimes(1);
+    expect(events).toEqual([
+      'create:Writing workflow with Workforce persona...',
+      'start:Writing workflow with Workforce persona...',
+      'text:Ricky is fixing the workflow...',
+      'text:Retrying workflow from install-deps...',
+      'stop:Retrying workflow from install-deps...',
+    ]);
+    const output = result.output.join('\n');
+    expect(output).toContain('Generation: ok — workflows/generated/issue-3.ts');
+    expect(output).toContain('Auto-fix: repaired after 2/7 attempt(s)');
+    expect(output).not.toContain('Ricky is fixing the workflow');
+    expect(output).not.toContain('Retrying workflow from install-deps');
+  });
+
+  it('streams foreground workflow output and clears the spinner first', async () => {
+    const events: string[] = [];
+    let spinnerText = '';
+    const spinner: CliProgressSpinner = {
+      get text(): string {
+        return spinnerText;
+      },
+      set text(value: string) {
+        spinnerText = value;
+        events.push(`text:${value}`);
+      },
+      start(): CliProgressSpinner {
+        events.push(`start:${spinnerText}`);
+        return spinner;
+      },
+      stop(): CliProgressSpinner {
+        events.push(`stop:${spinnerText}`);
+        return spinner;
+      },
+    };
+    const createProgressSpinner = vi.fn(({ text }: { text: string; stream: NodeJS.WritableStream }) => {
+      spinnerText = text;
+      events.push(`create:${text}`);
+      return spinner;
+    });
+    const output = capturedTtyOutputSink();
+    const runner = vi.fn(async (deps) => {
+      deps.localProgress?.('Running workflow (attempt 1/7)...');
+      deps.localRuntimeOutput?.('stdout', '[workflow] run relay-run-1');
+      deps.localRuntimeOutput?.('stdout', '  ✓ build — completed');
+      deps.localProgress?.('Ricky is fixing the workflow...');
+      deps.localRuntimeOutput?.('stderr', '[workflow] retrying failed step');
+      return fakeInteractiveResult({ ok: true, localResult: stagedLocalResult() });
+    });
+
+    await cliMain({
+      argv: ['run', 'workflows/generated/issue-3.ts', '--foreground'],
+      output,
+      isTTY: true,
+      createProgressSpinner,
+      runInteractive: runner,
+    });
+
+    expect(output.chunks.join('')).toContain('[workflow] run relay-run-1\n  ✓ build — completed\n[workflow] retrying failed step\n');
+    expect(events).toEqual([
+      'create:Running workflow (attempt 1/7)...',
+      'start:Running workflow (attempt 1/7)...',
+      'stop:Running workflow (attempt 1/7)...',
+      'create:Ricky is fixing the workflow...',
+      'start:Ricky is fixing the workflow...',
+      'stop:Ricky is fixing the workflow...',
+    ]);
+  });
+
+  it('does not attach spinner progress for JSON, quiet, non-TTY, background, or ordinary injected output streams', async () => {
+    const cases = [
+      { argv: ['run', 'workflows/generated/issue-3.ts', '--json'], isTTY: true, output: undefined, create: true },
+      { argv: ['run', 'workflows/generated/issue-3.ts', '--quiet'], isTTY: true, output: undefined, create: true },
+      { argv: ['run', 'workflows/generated/issue-3.ts', '--foreground'], isTTY: false, output: undefined, create: true },
+      { argv: ['run', 'workflows/generated/issue-3.ts', '--background'], isTTY: true, output: undefined, create: true },
+      { argv: ['run', 'workflows/generated/issue-3.ts', '--foreground'], isTTY: true, output: ttyOutputSink(), create: false },
+    ];
+
+    for (const testCase of cases) {
+      const createProgressSpinner = vi.fn();
+      const runner = vi.fn().mockResolvedValue(fakeInteractiveResult({ localResult: stagedLocalResult() }));
+
+      await cliMain({
+        argv: testCase.argv,
+        isTTY: testCase.isTTY,
+        ...(testCase.output ? { output: testCase.output } : {}),
+        ...(testCase.create ? { createProgressSpinner } : {}),
+        runInteractive: runner,
+      });
+
+      expect(runner.mock.calls[0][0].localProgress).toBeUndefined();
+      expect(runner.mock.calls[0][0].localRuntimeOutput).toBeUndefined();
+      expect(createProgressSpinner).not.toHaveBeenCalled();
+    }
   });
 
   it('derives power-user cloud inline requests from stored auth and workspace without injected cloudRequest', async () => {

--- a/src/surfaces/cli/commands/cli-main.ts
+++ b/src/surfaces/cli/commands/cli-main.ts
@@ -30,6 +30,7 @@ import { readFileSync } from 'node:fs';
 import { readFile } from 'node:fs/promises';
 import { dirname, isAbsolute, join, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
+import ora from 'ora';
 import { defaultCloudIntegrationConnector, runInteractiveCli } from '../entrypoint/interactive-cli.js';
 import { parsePowerUserArgs, type ConnectTarget, type PowerUserSurface } from '../flows/power-user-parser.js';
 import {
@@ -42,6 +43,7 @@ import { runLocalPreflight, type LocalPreflightCheck, type LocalPreflightResult 
 import { defaultArtifactPathForWorkflowName } from '../flows/spec-intake-flow.js';
 import { CLOUD_IMPLEMENTATION_AGENTS, CLOUD_OPTIONAL_INTEGRATIONS } from '../flows/cloud-workflow-flow.js';
 import { resolvePreferWorkforcePersonaWorkflowWriter } from '../flows/workforce-persona-cli-preference.js';
+import { DEFAULT_AUTO_FIX_ATTEMPTS } from '../../../shared/constants.js';
 
 // ---------------------------------------------------------------------------
 // Parsed CLI arguments
@@ -93,6 +95,18 @@ export interface CliMainResult {
 export type RelayCloudConnectProvider = (options: ConnectProviderOptions) => Promise<ConnectProviderResult>;
 export type RelayCloudAuthenticator = () => Promise<StoredAuth>;
 
+export interface CliProgressSpinner {
+  text: string;
+  start(text?: string): CliProgressSpinner;
+  stop(): CliProgressSpinner;
+  fail?(text?: string): CliProgressSpinner;
+}
+
+export type CliProgressSpinnerFactory = (options: {
+  text: string;
+  stream: NodeJS.WritableStream;
+}) => CliProgressSpinner;
+
 // ---------------------------------------------------------------------------
 // Injectable dependencies
 // ---------------------------------------------------------------------------
@@ -118,6 +132,8 @@ export interface CliMainDeps extends InteractiveCliDeps {
   connectApiUrl?: string;
   /** Provider auth timeout override passed through to the Relay Cloud connector. */
   connectTimeoutMs?: number;
+  /** Spinner factory override for focused progress tests. */
+  createProgressSpinner?: CliProgressSpinnerFactory;
 }
 
 let cachedPackageVersion: string | undefined;
@@ -223,14 +239,13 @@ function parseAutoFix(argv: string[]): number | undefined {
       rawValue = next && !next.startsWith('--') ? next : undefined;
     }
 
-    if (rawValue === undefined || rawValue === '') return 3;
+    if (rawValue === undefined || rawValue === '') return DEFAULT_AUTO_FIX_ATTEMPTS;
     const parsed = Number.parseInt(rawValue, 10);
     if (!Number.isFinite(parsed) || parsed <= 0) return undefined;
     return Math.min(10, Math.max(1, parsed));
   }
-  // Default-on: 3 attempts of diagnose/repair/resume on directly-fixable
-  // blockers (MISSING_BINARY, NETWORK_TRANSIENT). Disable with --no-auto-fix.
-  return 3;
+  // Default-on diagnose/repair/resume loop. Disable with --no-auto-fix.
+  return DEFAULT_AUTO_FIX_ATTEMPTS;
 }
 
 function readPackageVersion(readPackageJsonText?: (path: string) => string): string | undefined {
@@ -321,7 +336,7 @@ export function renderHelp(): string[] {
     '  --with-llm[=model]  Alias for --refine',
     '  --workforce-persona Use Workforce personas to author the workflow',
     '  --no-workforce-persona Disable Workforce persona authoring',
-    '  --auto-fix[=N]      Local diagnose/repair/resume loop (default 3 attempts, max 10)',
+    `  --auto-fix[=N]      Local diagnose/repair/resume loop (default ${DEFAULT_AUTO_FIX_ATTEMPTS} attempts, max 10)`,
     '  --no-auto-fix       Disable the repair loop; first failure surfaces immediately',
     '  --repair[=N]        Alias for --auto-fix',
     '  --login             Power-user Cloud: re-probe readiness after a real Cloud login',
@@ -1564,10 +1579,12 @@ export async function cliMain(deps: CliMainDeps = {}): Promise<CliMainResult> {
     };
   }
 
-  const localProgress = deps.localProgress ??
-    (shouldStreamLocalProgress(parsed, cliHandoff)
-      ? (message: string) => (deps.output ?? process.stdout).write(`${message}\n`)
-      : undefined);
+  const progressReporter = deps.localProgress
+    ? undefined
+    : createLocalProgressReporter(parsed, cliHandoff, deps);
+  const localProgress = deps.localProgress ?? progressReporter?.onProgress;
+  const localRuntimeOutput = deps.localRuntimeOutput ??
+    createLocalRuntimeOutputReporter(parsed, cliHandoff, deps, progressReporter);
 
   const interactiveDeps: InteractiveCliDeps = {
     ...deps,
@@ -1577,13 +1594,21 @@ export async function cliMain(deps: CliMainDeps = {}): Promise<CliMainResult> {
     ...(cliHandoff ? { handoff: cliHandoff } : {}),
     ...(cloudRequest ? { cloudRequest } : {}),
     ...(localProgress ? { localProgress } : {}),
+    ...(localRuntimeOutput ? { localRuntimeOutput } : {}),
     ...cloudRecoveryDeps,
     preferWorkforcePersonaWorkflowWriter:
       deps.preferWorkforcePersonaWorkflowWriter ??
       resolvePreferWorkforcePersonaWorkflowWriter({ workforcePersonaWriterCli: parsed.workforcePersonaWriterCli }),
   };
 
-  const interactiveResult = await runner(interactiveDeps);
+  let interactiveResult: InteractiveCliResult;
+  try {
+    interactiveResult = await runner(interactiveDeps);
+    progressReporter?.stop();
+  } catch (error) {
+    progressReporter?.stop();
+    throw error;
+  }
   const output: string[] = [];
 
   if (interactiveResult.onboarding.mode === 'status') {
@@ -1675,6 +1700,7 @@ function renderLocalWorkflowHuman(result: NonNullable<InteractiveCliResult['loca
     '',
     `Goal: ${result.summary.goal}`,
     `Artifact: ${result.summary.artifactPath}`,
+    `Status: ${localWorkflowStatus(result)}`,
   ];
 
   if (result.generation?.generation?.artifact?.workflow_id) {
@@ -1718,6 +1744,22 @@ function renderLocalWorkflowHuman(result: NonNullable<InteractiveCliResult['loca
     '  ricky status --run <run-id>',
   );
   return lines;
+}
+
+function localWorkflowStatus(result: NonNullable<InteractiveCliResult['localWorkflowResult']>): string {
+  if (result.generation && !result.generation.ok) {
+    return 'failed — generation did not complete';
+  }
+  if (result.monitoredRun) {
+    return `${result.monitoredRun.status} — background monitor`;
+  }
+  if (result.run) {
+    if (result.run.ok && result.run.execution?.status === 'success') {
+      return 'success — workflow executed';
+    }
+    return 'failed — workflow execution did not complete';
+  }
+  return 'ready — workflow generated';
 }
 
 function renderLocalJson(localResult: NonNullable<InteractiveCliResult['localResult']>): string {
@@ -1818,12 +1860,71 @@ function renderLocalHuman(localResult: NonNullable<InteractiveCliResult['localRe
   return lines;
 }
 
-function shouldStreamLocalProgress(parsed: ParsedArgs, handoff: RawHandoff | undefined): boolean {
+function createLocalProgressReporter(
+  parsed: ParsedArgs,
+  handoff: RawHandoff | undefined,
+  deps: CliMainDeps,
+): { onProgress: (message: string) => void; stop: () => void } | undefined {
+  if (!shouldStreamLocalProgress(parsed, handoff, deps)) return undefined;
+
+  const stream = deps.output ?? process.stdout;
+  const createSpinner: CliProgressSpinnerFactory = deps.createProgressSpinner ??
+    ((options) => ora({
+      text: options.text,
+      stream: options.stream,
+      isEnabled: true,
+      discardStdin: false,
+    }));
+  let spinner: CliProgressSpinner | undefined;
+
+  return {
+    onProgress(message: string): void {
+      const text = progressSpinnerText(message);
+      if (!spinner) {
+        spinner = createSpinner({ text, stream });
+        spinner.start();
+        return;
+      }
+      spinner.text = text;
+    },
+    stop(): void {
+      spinner?.stop();
+      spinner = undefined;
+    },
+  };
+}
+
+function progressSpinnerText(message: string): string {
+  return message.replace(/\s+/g, ' ').trim() || 'Ricky is working...';
+}
+
+function createLocalRuntimeOutputReporter(
+  parsed: ParsedArgs,
+  handoff: RawHandoff | undefined,
+  deps: CliMainDeps,
+  progressReporter: { stop: () => void } | undefined,
+): ((stream: 'stdout' | 'stderr', line: string) => void) | undefined {
+  if (!shouldStreamLocalProgress(parsed, handoff, deps)) return undefined;
+
+  const output = deps.output ?? process.stdout;
+  return (_stream, line) => {
+    progressReporter?.stop();
+    output.write(`${line}\n`);
+  };
+}
+
+function shouldStreamLocalProgress(parsed: ParsedArgs, handoff: RawHandoff | undefined, deps: CliMainDeps): boolean {
+  const stream = deps.output ?? process.stdout;
+  const isTTY = deps.isTTY ?? ((stream as NodeJS.WritableStream & { isTTY?: boolean }).isTTY === true);
+  const injectedOutputExplicitlyCovered = deps.output === undefined || (deps.createProgressSpinner !== undefined && deps.isTTY === true);
+
   return Boolean(
     handoff &&
     !parsed.json &&
     !parsed.quiet &&
-    parsed.background !== true,
+    parsed.background !== true &&
+    isTTY &&
+    injectedOutputExplicitlyCovered,
   );
 }
 

--- a/src/surfaces/cli/entrypoint/interactive-cli.ts
+++ b/src/surfaces/cli/entrypoint/interactive-cli.ts
@@ -197,6 +197,9 @@ export interface InteractiveCliDeps extends CloudWorkflowFlowDeps {
 
   /** Concise local-run progress updates for foreground CLI execution. */
   localProgress?: (message: string) => void;
+
+  /** Foreground local workflow stdout/stderr passthrough. */
+  localRuntimeOutput?: (stream: 'stdout' | 'stderr', line: string) => void;
 }
 
 function applyCliWorkforcePersonaPreferenceToLocalExecutor(
@@ -282,6 +285,7 @@ async function executeLocalPath(
   const localResult = await runLocal(handoff, {
     executor: deps.localExecutor,
     ...(deps.localProgress ? { onProgress: deps.localProgress } : {}),
+    ...(deps.localRuntimeOutput ? { onRuntimeOutput: deps.localRuntimeOutput } : {}),
     localExecutor: deps.localExecutor
       ? undefined
       : applyCliWorkforcePersonaPreferenceToLocalExecutor(deps.preferWorkforcePersonaWorkflowWriter, {

--- a/src/surfaces/cli/flows/local-run-monitor.test.ts
+++ b/src/surfaces/cli/flows/local-run-monitor.test.ts
@@ -73,7 +73,7 @@ describe('local run monitor', () => {
       expect(await readFile(join(state.artifactDir, 'generated-artifacts', 'workflows__generated__release-health.ts'), 'utf8')).toContain('workflow("x")');
       expect(runLocalFn.mock.calls[0][0]).toMatchObject({
         stageMode: 'run',
-        autoFix: { maxAttempts: 3 },
+        autoFix: { maxAttempts: 7 },
         metadata: {
           autoFixPolicy: 'bounded-safe-only',
           destructiveActionsApproved: false,

--- a/src/surfaces/cli/flows/local-run-monitor.ts
+++ b/src/surfaces/cli/flows/local-run-monitor.ts
@@ -5,6 +5,7 @@ import { randomUUID } from 'node:crypto';
 import type { RawHandoff } from '../../../local/request-normalizer.js';
 import type { LocalEntrypointOptions, LocalResponse } from '../../../local/entrypoint.js';
 import { runLocal } from '../../../local/entrypoint.js';
+import { DEFAULT_AUTO_FIX_ATTEMPTS } from '../../../shared/constants.js';
 export { legacyLocalRunStatePath, localRunStatePath, localRunStateRoot } from '../../../shared/state-paths.js';
 
 export type LocalRunMode = 'background' | 'foreground';
@@ -121,7 +122,7 @@ export function withSafeRunOptions(
   autoFixAttempts: number | undefined,
   trackingRunId?: string,
 ): RawHandoff {
-  const maxAttempts = clampAutoFixAttempts(autoFixAttempts ?? 3);
+  const maxAttempts = clampAutoFixAttempts(autoFixAttempts ?? DEFAULT_AUTO_FIX_ATTEMPTS);
   return {
     ...handoff,
     stageMode: 'run',

--- a/src/surfaces/cli/flows/power-user-parser.test.ts
+++ b/src/surfaces/cli/flows/power-user-parser.test.ts
@@ -12,7 +12,7 @@ describe('power user parser defaults', () => {
       mode: 'local',
       spec: 'build a workflow',
       runRequested: true,
-      autoFix: 3,
+      autoFix: 7,
     });
     expect(parsed).not.toHaveProperty('refine');
   });

--- a/src/surfaces/cli/flows/power-user-parser.ts
+++ b/src/surfaces/cli/flows/power-user-parser.ts
@@ -1,5 +1,6 @@
 import type { RickyMode } from '../cli/mode-selector.js';
 import { isRickyMode } from '../cli/mode-selector.js';
+import { DEFAULT_AUTO_FIX_ATTEMPTS } from '../../../shared/constants.js';
 
 export type PowerUserCommand = 'run' | 'help' | 'version' | 'status' | 'connect';
 export type PowerUserSurface = 'legacy' | 'local' | 'cloud' | 'status' | 'connect';
@@ -240,12 +241,12 @@ function parseAutoFix(argv: string[]): number | undefined {
       rawValue = next && !next.startsWith('--') ? next : undefined;
     }
 
-    if (rawValue === undefined || rawValue === '') return 3;
+    if (rawValue === undefined || rawValue === '') return DEFAULT_AUTO_FIX_ATTEMPTS;
     const parsed = Number.parseInt(rawValue, 10);
     if (!Number.isFinite(parsed) || parsed <= 0) return undefined;
     return Math.min(10, Math.max(1, parsed));
   }
-  return 3;
+  return DEFAULT_AUTO_FIX_ATTEMPTS;
 }
 
 function readFlagValue(argv: string[], flag: string): string | undefined {


### PR DESCRIPTION
## Summary
- add an ora-backed TTY spinner for foreground local generation, repair, and retry progress
- keep progress disabled for --json, --quiet, background runs, non-TTY output, and ordinary injected test streams
- emit concise runLocal phase updates for workflow writing and execution without changing final summaries

## Tests
- npm test -- --run src/surfaces/cli/commands/cli-main.test.ts src/local/entrypoint.test.ts src/local/auto-fix-loop.test.ts
- npm run typecheck
- npx vitest run src/surfaces/cli/flows/local-run-monitor.test.ts
- npm test

## Notes
- PR #33 is already merged, so this is a follow-up PR.
- The suggested bundled demo command entered the real Workforce persona repair path and was stopped rather than left running; automated coverage proves the spinner lifecycle and concise summaries.
- Left untracked workflows/demo-auto-fix/ untouched.