### PR TITLE
Ensure swarm pattern skill loads for workflow generation

### DIFF
--- a/.agents/skills/choosing-swarm-patterns/SKILL.md
+++ b/.agents/skills/choosing-swarm-patterns/SKILL.md
@@ -1,6 +1,12 @@
 ---
 name: choosing-swarm-patterns
-description: Use when coordinating multiple AI agents with Agent Relay's workflow engine and need to pick the right orchestration pattern - covers the 10 core patterns (fan-out, pipeline, hub-spoke, consensus, mesh, handoff, cascade, dag, debate, hierarchical) plus 14 specialized ones, with decision framework and accurate SDK/YAML examples.
+description: Use when Ricky writes or generates Agent Relay workflows and needs to pick the right orchestration shape for coordinating multiple AI agents - covers the 10 core patterns (fan-out, pipeline, hub-spoke, consensus, mesh, handoff, cascade, dag, debate, hierarchical) plus 14 specialized ones, with decision framework and accurate SDK/YAML examples.
+keywords:
+  - workflow generation
+  - workflow shape
+  - pattern selection
+  - swarm pattern
+  - Agent Relay
 ---
 
 ### Overview

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
   },
   "files": [
     "dist",
+    ".agents/skills",
     "README.md"
   ],
   "scripts": {

--- a/src/product/generation/pattern-selector.ts
+++ b/src/product/generation/pattern-selector.ts
@@ -1,9 +1,14 @@
 import type { NormalizedWorkflowSpec } from '../spec-intake/types.js';
 import type { SwarmPattern } from '../../shared/models/workflow-config.js';
-import type { GenerationRiskLevel, PatternDecision } from './types.js';
+import type { GenerationRiskLevel, PatternDecision, SkillContext } from './types.js';
 
-export function selectPattern(spec: NormalizedWorkflowSpec, patternOverride?: SwarmPattern): PatternDecision {
-  const signals = collectSignals(spec);
+export function selectPattern(
+  spec: NormalizedWorkflowSpec,
+  patternOverride?: SwarmPattern,
+  skillContext?: SkillContext,
+): PatternDecision {
+  const usesSwarmPatternSkill = skillContext?.applicableSkillNames.includes('choosing-swarm-patterns') ?? false;
+  const signals = collectSignals(spec, usesSwarmPatternSkill);
   const riskLevel = assessRisk(spec, signals);
 
   if (patternOverride) {
@@ -16,17 +21,19 @@ export function selectPattern(spec: NormalizedWorkflowSpec, patternOverride?: Sw
     };
   }
 
-  const pattern = choosePattern(spec, riskLevel, signals);
+  const pattern = usesSwarmPatternSkill
+    ? choosePatternWithSwarmSkill(spec, riskLevel, signals)
+    : choosePattern(spec, riskLevel, signals);
   return {
     pattern,
-    reason: explainPattern(pattern, riskLevel, signals),
+    reason: explainPattern(pattern, riskLevel, signals, usesSwarmPatternSkill),
     specSignals: signals,
     riskLevel,
     overrideUsed: false,
   };
 }
 
-function collectSignals(spec: NormalizedWorkflowSpec): string[] {
+function collectSignals(spec: NormalizedWorkflowSpec, usesSwarmPatternSkill = false): string[] {
   const signals: string[] = [];
   const targetCount = spec.targetFiles.length;
   const combinedText = normalizeText([
@@ -51,6 +58,7 @@ function collectSignals(spec: NormalizedWorkflowSpec): string[] {
   if (isDocOnly(spec)) signals.push('doc or spec oriented');
   if (spec.executionPreference === 'cloud') signals.push('cloud execution requested');
   if (spec.providerContext.surface === 'mcp') signals.push('mcp handoff surface');
+  if (usesSwarmPatternSkill) signals.push('choosing-swarm-patterns skill loaded');
 
   return signals.length > 0 ? signals : ['simple generation request'];
 }
@@ -80,14 +88,42 @@ function choosePattern(spec: NormalizedWorkflowSpec, riskLevel: GenerationRiskLe
   return 'pipeline';
 }
 
-function explainPattern(pattern: SwarmPattern, riskLevel: GenerationRiskLevel, signals: string[]): string {
+function choosePatternWithSwarmSkill(
+  spec: NormalizedWorkflowSpec,
+  riskLevel: GenerationRiskLevel,
+  signals: string[],
+): SwarmPattern {
+  const text = normalizeText([
+    spec.description,
+    spec.targetContext,
+    ...spec.constraints.map((constraint) => constraint.constraint),
+    ...spec.evidenceRequirements.map((requirement) => requirement.requirement),
+    ...spec.acceptanceGates.map((gate) => gate.gate),
+  ]);
+
+  if (/\b(strictly linear|linear|sequential|pipeline|one step after another)\b/.test(text)) return 'pipeline';
+  if (signals.some((signal) => signal === 'parallel work suggested' || signal === 'many target files')) return 'dag';
+  if (/\b(coordinator|supervisor|lead|review|approval|approve|signoff|gate|handoff|triage|specialist)\b/.test(text)) return 'supervisor';
+  if (riskLevel === 'high') return 'dag';
+  if (riskLevel === 'medium') return 'supervisor';
+  if (isDocOnly(spec) && spec.acceptanceGates.length > 0) return 'supervisor';
+  return 'pipeline';
+}
+
+function explainPattern(
+  pattern: SwarmPattern,
+  riskLevel: GenerationRiskLevel,
+  signals: string[],
+  usesSwarmPatternSkill = false,
+): string {
+  const skillPrefix = usesSwarmPatternSkill ? ' using choosing-swarm-patterns' : '';
   if (pattern === 'dag') {
-    return `Selected dag because the request is ${riskLevel} risk and benefits from parallel implementation, review, and validation gates.`;
+    return `Selected dag${skillPrefix} because the request is ${riskLevel} risk and benefits from parallel implementation, review, and validation gates.`;
   }
   if (pattern === 'supervisor') {
-    return `Selected supervisor because the request is ${riskLevel} risk and needs coordinated planning, implementation, and review.`;
+    return `Selected supervisor${skillPrefix} because the request is ${riskLevel} risk and needs coordinated planning, implementation, and review.`;
   }
-  return `Selected pipeline because the request is ${riskLevel} risk and can proceed through a linear reliability ladder.`;
+  return `Selected pipeline${skillPrefix} because the request is ${riskLevel} risk and can proceed through a linear reliability ladder.`;
 }
 
 function isDocOnly(spec: NormalizedWorkflowSpec): boolean {

--- a/src/product/generation/pipeline.test.ts
+++ b/src/product/generation/pipeline.test.ts
@@ -126,10 +126,23 @@ describe('workflow generation pipeline', () => {
     const artifact = result.artifact!;
 
     expect(result.skillContext.applicableSkillNames).toEqual(
-      expect.arrayContaining(['writing-agent-relay-workflows', 'relay-80-100-workflow']),
+      expect.arrayContaining(['choosing-swarm-patterns', 'writing-agent-relay-workflows', 'relay-80-100-workflow']),
     );
     expect(result.skillContext.applicationEvidence).toEqual(
       expect.arrayContaining([
+        expect.objectContaining({
+          skillName: 'choosing-swarm-patterns',
+          stage: 'generation_selection',
+          behavior: 'generation_time_only',
+          runtimeEmbodiment: false,
+        }),
+        expect.objectContaining({
+          skillName: 'choosing-swarm-patterns',
+          stage: 'generation_loading',
+          effect: 'metadata',
+          behavior: 'generation_time_only',
+          runtimeEmbodiment: false,
+        }),
         expect.objectContaining({
           skillName: 'writing-agent-relay-workflows',
           stage: 'generation_selection',
@@ -161,6 +174,14 @@ describe('workflow generation pipeline', () => {
     expect(artifact.skillApplicationEvidence).toEqual(
       expect.arrayContaining([
         expect.objectContaining({
+          skillName: 'choosing-swarm-patterns',
+          stage: 'generation_rendering',
+          effect: 'pattern_selection',
+          behavior: 'generation_time_only',
+          runtimeEmbodiment: false,
+          evidence: expect.stringContaining('coordination shape'),
+        }),
+        expect.objectContaining({
           skillName: 'writing-agent-relay-workflows',
           stage: 'generation_rendering',
           effect: 'workflow_contract',
@@ -180,6 +201,7 @@ describe('workflow generation pipeline', () => {
     );
     expect(artifact.content).toContain('loaded-skills.txt');
     expect(artifact.content).toContain('skill-application-boundary.json');
+    expect(artifact.content).toContain('choosing-swarm-patterns');
     expect(artifact.content).toContain('writing-agent-relay-workflows');
     expect(artifact.content).toContain('relay-80-100-workflow');
     expect(artifact.content).toContain('generation_time_only');
@@ -187,11 +209,13 @@ describe('workflow generation pipeline', () => {
     expect(artifact.content).toContain('Skills are applied by Ricky during selection, loading, and template rendering.');
     expect(artifact.content).toContain('Do not claim generated agents load, retain, or embody skill files at runtime');
     const skillBoundaryGate = artifact.gates.find((gate) => gate.name === 'skill-boundary-metadata-gate')!;
+    expect(skillBoundaryGate.command).toContain('choosing-swarm-patterns');
     expect(skillBoundaryGate.command).toContain('writing-agent-relay-workflows');
     expect(skillBoundaryGate.command).toContain('relay-80-100-workflow');
     expect(skillBoundaryGate.command).toContain('"stage":"generation_selection"');
     expect(skillBoundaryGate.command).toContain('"stage":"generation_loading"');
     expect(skillBoundaryGate.command).toContain('"stage":"generation_rendering"');
+    expect(skillBoundaryGate.command).toContain('"effect":"pattern_selection"');
     expect(skillBoundaryGate.command).toContain('"effect":"workflow_contract"');
     expect(skillBoundaryGate.command).toContain('"effect":"validation_gates"');
     expect(artifact.gates).toEqual(

--- a/src/product/generation/pipeline.test.ts
+++ b/src/product/generation/pipeline.test.ts
@@ -41,7 +41,9 @@ describe('workflow generation pipeline', () => {
       riskLevel: 'high',
       overrideUsed: false,
     });
+    expect(result.patternDecision.specSignals).toContain('choosing-swarm-patterns skill loaded');
     expect(result.patternDecision.reason).toMatch(/parallel implementation, review, and validation gates/i);
+    expect(result.patternDecision.reason).toMatch(/choosing-swarm-patterns/i);
     expect(result.executionRoute).toMatchObject({
       artifactDelivery: 'write_local_file',
       resolvedTarget: 'local',
@@ -278,6 +280,8 @@ describe('workflow generation pipeline', () => {
       pattern: 'supervisor',
       riskLevel: 'medium',
     });
+    expect(result.patternDecision.specSignals).toContain('choosing-swarm-patterns skill loaded');
+    expect(result.patternDecision.reason).toMatch(/choosing-swarm-patterns/i);
     expect(artifact.tasks).toEqual(
       expect.arrayContaining([
         expect.objectContaining({ id: 'lead-plan', agentRole: 'lead-claude' }),
@@ -877,6 +881,8 @@ describe('workflow generation pipeline', () => {
       riskLevel: 'low',
       overrideUsed: false,
     });
+    expect(result.patternDecision.specSignals).toContain('choosing-swarm-patterns skill loaded');
+    expect(result.patternDecision.reason).toMatch(/choosing-swarm-patterns/i);
   });
 
   it('respects pattern override', () => {

--- a/src/product/generation/pipeline.ts
+++ b/src/product/generation/pipeline.ts
@@ -247,7 +247,7 @@ export function validateGeneratedArtifact(
     }
   }
 
-  for (const requiredRenderingSkill of ['writing-agent-relay-workflows', 'relay-80-100-workflow']) {
+  for (const requiredRenderingSkill of ['choosing-swarm-patterns', 'writing-agent-relay-workflows', 'relay-80-100-workflow']) {
     if (
       skillContext.applicableSkillNames.includes(requiredRenderingSkill) &&
       !artifact.skillApplicationEvidence.some(

--- a/src/product/generation/pipeline.ts
+++ b/src/product/generation/pipeline.ts
@@ -22,8 +22,8 @@ import {
 } from './workforce-persona-writer.js';
 
 export function generate(input: GenerationInput): GenerationResult {
-  const patternDecision = selectPattern(input.spec, input.patternOverride);
   const skillContext = loadSkills(input.spec, input.skillOverrides, input.templateOverride);
+  const patternDecision = selectPattern(input.spec, input.patternOverride, skillContext);
   const artifact = renderWorkflow({
     spec: input.spec,
     pattern: patternDecision,
@@ -89,6 +89,7 @@ export async function generateWithWorkforcePersona(input: GenerationInput): Prom
       tier: input.workforcePersonaWriter?.tier,
       personaIntentCandidates: input.workforcePersonaWriter?.personaIntentCandidates,
       resolver: input.workforcePersonaWriter?.resolver,
+      skillContext: baseResult.skillContext,
     });
     const finalArtifact = applyPersonaArtifactToRenderedArtifact(artifact, personaResult);
     const validation = validateGeneratedArtifact(finalArtifact, baseResult.patternDecision, baseResult.skillContext, input.spec);

--- a/src/product/generation/skill-matcher.test.ts
+++ b/src/product/generation/skill-matcher.test.ts
@@ -26,19 +26,31 @@ describe('skill matcher', () => {
     expect(matches[0].confidence).toBeGreaterThanOrEqual(0.4);
   });
 
-  it('falls back to the project default when no skill-relevant content matches', () => {
+  it('falls back to the project workflow-generation defaults when no skill-relevant content matches', () => {
     const matches = matchSkills(spec('Update a small README sentence.'), {
       registry: registry([
+        { id: 'choosing-swarm-patterns', description: 'Use for Agent Relay workflow pattern selection.' },
         { id: 'writing-agent-relay-workflows', description: 'Use for agent relay workflow authoring.' },
+        { id: 'relay-80-100-workflow', description: 'Use for end-to-end workflow validation.' },
       ]),
     });
 
-    expect(matches).toEqual([
-      expect.objectContaining({
-        id: 'writing-agent-relay-workflows',
-        reason: expect.stringContaining('Project default'),
-      }),
-    ]);
+    expect(matches).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          id: 'choosing-swarm-patterns',
+          reason: expect.stringContaining('Project default'),
+        }),
+        expect.objectContaining({
+          id: 'writing-agent-relay-workflows',
+          reason: expect.stringContaining('Project default'),
+        }),
+        expect.objectContaining({
+          id: 'relay-80-100-workflow',
+          reason: expect.stringContaining('Project default'),
+        }),
+      ]),
+    );
   });
 
   it('returns no skills for an empty registry', () => {
@@ -88,6 +100,10 @@ describe('skill matcher', () => {
 
     expect(skills).toEqual(
       expect.arrayContaining([
+        expect.objectContaining({
+          id: 'choosing-swarm-patterns',
+          path: expect.stringMatching(new RegExp(`^${escapeRegExp(repoRoot)}/.*skills/choosing-swarm-patterns/SKILL\\.md$`)),
+        }),
         expect.objectContaining({
           id: 'writing-agent-relay-workflows',
           path: expect.stringMatching(new RegExp(`^${escapeRegExp(repoRoot)}/.*skills/writing-agent-relay-workflows/SKILL\\.md$`)),

--- a/src/product/generation/skill-matcher.test.ts
+++ b/src/product/generation/skill-matcher.test.ts
@@ -59,6 +59,22 @@ describe('skill matcher', () => {
     expect(matchSkills(spec('Generate a workflow.'), { registry: [] })).toEqual([]);
   });
 
+  it('preserves top-ranked matches when the caller explicitly caps maxMatches', () => {
+    const matches = matchSkills(spec('Generate a github primitive webhook handler.'), {
+      registry: registry([
+        { id: 'github-primitive', description: 'Use for github primitive webhook handlers and GitHub APIs.' },
+        { id: 'choosing-swarm-patterns', description: 'Use for Agent Relay workflow pattern selection.' },
+        { id: 'writing-agent-relay-workflows', description: 'Use for agent relay workflow authoring.' },
+        { id: 'relay-80-100-workflow', description: 'Use for end-to-end workflow validation.' },
+      ]),
+      maxMatches: 1,
+    });
+
+    expect(matches).toEqual([
+      expect.objectContaining({ id: 'github-primitive' }),
+    ]);
+  });
+
   it('does not select below-threshold matches when fallback is disabled', () => {
     const matches = matchSkills(spec('Tiny unrelated request.'), {
       registry: registry([{ id: 'github-primitive', description: 'GitHub webhook APIs.' }]),

--- a/src/product/generation/skill-matcher.test.ts
+++ b/src/product/generation/skill-matcher.test.ts
@@ -1,4 +1,6 @@
-import { resolve } from 'node:path';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, resolve } from 'node:path';
 
 import { afterEach, describe, expect, it } from 'vitest';
 
@@ -110,6 +112,28 @@ describe('skill matcher', () => {
         }),
       ]),
     );
+  });
+
+  it('discovers bundled package skills when invoked outside a project tree', () => {
+    const emptyProject = mkdtempSync(join(tmpdir(), 'ricky-empty-project-'));
+    try {
+      process.chdir(emptyProject);
+      resetSkillRegistryCache();
+
+      const skills = loadSkillRegistry();
+
+      expect(skills).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({ id: 'choosing-swarm-patterns' }),
+          expect.objectContaining({ id: 'writing-agent-relay-workflows' }),
+          expect.objectContaining({ id: 'relay-80-100-workflow' }),
+        ]),
+      );
+    } finally {
+      process.chdir(originalCwd);
+      rmSync(emptyProject, { recursive: true, force: true });
+      resetSkillRegistryCache();
+    }
   });
 });
 

--- a/src/product/generation/skill-matcher.ts
+++ b/src/product/generation/skill-matcher.ts
@@ -24,9 +24,13 @@ export interface SkillMatcherOptions {
   defaultSkillId?: string | null;
 }
 
-const DEFAULT_MAX_MATCHES = 3;
+const DEFAULT_MAX_MATCHES = 5;
 const DEFAULT_THRESHOLD = 0.4;
-const DEFAULT_SKILL_ID = 'writing-agent-relay-workflows';
+const DEFAULT_WORKFLOW_SKILL_IDS = [
+  'choosing-swarm-patterns',
+  'writing-agent-relay-workflows',
+  'relay-80-100-workflow',
+];
 const PROJECT_SKILL_DIRS = ['.agents/skills', 'skills', '.claude/skills'];
 const USER_SKILL_DIRS = ['.claude/skills'];
 
@@ -44,23 +48,14 @@ export function matchSkills(spec: NormalizedWorkflowSpec, options: SkillMatcherO
     .filter((match) => match.confidence >= threshold)
     .sort(compareMatches);
 
-  if (
-    scored.length > 0 &&
-    options.defaultSkillId === undefined &&
-    scored.length < maxMatches &&
-    !scored.some((match) => match.id === DEFAULT_SKILL_ID)
-  ) {
-    const defaultDescriptor = registry.find((descriptor) => descriptor.id === DEFAULT_SKILL_ID);
-    if (defaultDescriptor) scored.push(fallbackMatch(defaultDescriptor));
+  if (options.defaultSkillId === undefined) {
+    const withWorkflowDefaults = appendWorkflowDefaultMatches(scored, registry);
+    return trimMatchesPreservingWorkflowDefaults(dedupeMatches(withWorkflowDefaults), maxMatches);
   }
 
   if (scored.length === 0 && typeof options.defaultSkillId === 'string') {
     const fallback = registry.find((descriptor) => descriptor.id === options.defaultSkillId);
     return fallback ? [fallbackMatch(fallback)] : [];
-  }
-
-  if (scored.length === 0 && options.defaultSkillId === undefined && registry.some((descriptor) => descriptor.id === DEFAULT_SKILL_ID)) {
-    return [fallbackMatch(registry.find((descriptor) => descriptor.id === DEFAULT_SKILL_ID)!)];
   }
 
   return dedupeMatches(scored).slice(0, maxMatches);
@@ -224,6 +219,28 @@ function fallbackMatch(descriptor: SkillRegistryDescriptor): SkillMatch {
     preferredRunner: descriptor.preferredRunner,
     preferredModel: descriptor.preferredModel,
   };
+}
+
+function appendWorkflowDefaultMatches(
+  matches: SkillMatch[],
+  registry: SkillRegistryDescriptor[],
+): SkillMatch[] {
+  const present = new Set(matches.map((match) => match.id));
+  const defaults = DEFAULT_WORKFLOW_SKILL_IDS
+    .filter((id) => !present.has(id))
+    .map((id) => registry.find((descriptor) => descriptor.id === id))
+    .filter((descriptor): descriptor is SkillRegistryDescriptor => Boolean(descriptor))
+    .map(fallbackMatch);
+
+  return [...matches, ...defaults];
+}
+
+function trimMatchesPreservingWorkflowDefaults(matches: SkillMatch[], maxMatches: number): SkillMatch[] {
+  if (matches.length <= maxMatches) return matches;
+
+  const defaultMatches = matches.filter((match) => DEFAULT_WORKFLOW_SKILL_IDS.includes(match.id));
+  const nonDefaultMatches = matches.filter((match) => !DEFAULT_WORKFLOW_SKILL_IDS.includes(match.id));
+  return [...defaultMatches, ...nonDefaultMatches].slice(0, maxMatches).sort(compareMatches);
 }
 
 function compareMatches(a: SkillMatch, b: SkillMatch): number {

--- a/src/product/generation/skill-matcher.ts
+++ b/src/product/generation/skill-matcher.ts
@@ -1,6 +1,7 @@
 import { existsSync, readdirSync, statSync, readFileSync } from 'node:fs';
 import { homedir } from 'node:os';
 import { basename, dirname, join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
 
 import type { NormalizedWorkflowSpec } from '../spec-intake/types.js';
 import type { SkillMatch, SkillMatchEvidence, ToolRunner } from './types.js';
@@ -33,6 +34,7 @@ const DEFAULT_WORKFLOW_SKILL_IDS = [
 ];
 const PROJECT_SKILL_DIRS = ['.agents/skills', 'skills', '.claude/skills'];
 const USER_SKILL_DIRS = ['.claude/skills'];
+const MODULE_DIR = dirname(fileURLToPath(import.meta.url));
 
 let cachedRegistry: SkillRegistryDescriptor[] | null = null;
 
@@ -74,6 +76,7 @@ export function resetSkillRegistryCache(): void {
 function discoverSkillRegistry(): SkillRegistryDescriptor[] {
   const roots = [
     ...projectSkillRoots(process.cwd()),
+    ...packageSkillRoots(),
     ...USER_SKILL_DIRS.map((dir) => join(homedir(), dir)),
   ];
   const seen = new Set<string>();
@@ -90,6 +93,17 @@ function discoverSkillRegistry(): SkillRegistryDescriptor[] {
   }
 
   return dedupeDescriptors(descriptors);
+}
+
+function packageSkillRoots(): string[] {
+  return [
+    // Source execution: src/product/generation/skill-matcher.ts -> repo root.
+    resolve(MODULE_DIR, '../../../.agents/skills'),
+    // Bundled npm execution: dist/ricky.js -> package root.
+    resolve(MODULE_DIR, '../.agents/skills'),
+    // Future direct package layout: module file colocated with bundled skills.
+    resolve(MODULE_DIR, '.agents/skills'),
+  ];
 }
 
 function projectSkillRoots(startDir: string): string[] {

--- a/src/product/generation/skill-matcher.ts
+++ b/src/product/generation/skill-matcher.ts
@@ -52,7 +52,10 @@ export function matchSkills(spec: NormalizedWorkflowSpec, options: SkillMatcherO
 
   if (options.defaultSkillId === undefined) {
     const withWorkflowDefaults = appendWorkflowDefaultMatches(scored, registry);
-    return trimMatchesPreservingWorkflowDefaults(dedupeMatches(withWorkflowDefaults), maxMatches);
+    const deduped = dedupeMatches(withWorkflowDefaults);
+    return options.maxMatches === undefined
+      ? trimMatchesPreservingWorkflowDefaults(deduped, maxMatches)
+      : deduped.slice(0, maxMatches);
   }
 
   if (scored.length === 0 && typeof options.defaultSkillId === 'string') {

--- a/src/product/generation/template-renderer.ts
+++ b/src/product/generation/template-renderer.ts
@@ -311,6 +311,13 @@ function buildSkillBoundaryGateCommand(skillBoundaryPath: string, skills: SkillC
     );
   }
 
+  if (skills.applicableSkillNames.includes('choosing-swarm-patterns')) {
+    commands.push(
+      `grep -F ${shellQuote('"stage":"generation_rendering"')} ${quotedPath}`,
+      `grep -F ${shellQuote('"effect":"pattern_selection"')} ${quotedPath}`,
+    );
+  }
+
   if (skills.applicableSkillNames.includes('writing-agent-relay-workflows')) {
     commands.push(
       `grep -F ${shellQuote('"stage":"generation_rendering"')} ${quotedPath}`,
@@ -617,6 +624,17 @@ function buildRenderingSkillEvidence(
 ): SkillApplicationEvidence[] {
   const loaded = new Set(skills.applicableSkillNames);
   const evidence: SkillApplicationEvidence[] = [...skills.applicationEvidence];
+
+  if (loaded.has('choosing-swarm-patterns')) {
+    evidence.push({
+      skillName: 'choosing-swarm-patterns',
+      stage: 'generation_rendering',
+      effect: 'pattern_selection',
+      behavior: 'generation_time_only',
+      runtimeEmbodiment: false,
+      evidence: 'Rendered the selected swarm pattern into the workflow builder so Ricky chooses the coordination shape before authoring tasks.',
+    });
+  }
 
   if (loaded.has('writing-agent-relay-workflows')) {
     evidence.push({

--- a/src/product/generation/types.ts
+++ b/src/product/generation/types.ts
@@ -22,7 +22,7 @@ export type WorkflowExecutionTarget = 'local' | 'cloud';
 
 export type SkillApplicationStage = 'generation_selection' | 'generation_loading' | 'generation_rendering';
 
-export type SkillApplicationEffect = 'workflow_contract' | 'validation_gates' | 'metadata';
+export type SkillApplicationEffect = 'workflow_contract' | 'validation_gates' | 'metadata' | 'pattern_selection';
 
 export interface GenerationIssue {
   severity: GenerationIssueSeverity;

--- a/src/product/generation/workforce-persona-writer.test.ts
+++ b/src/product/generation/workforce-persona-writer.test.ts
@@ -29,6 +29,7 @@ describe('workforce persona workflow writer', () => {
     expect(task).toContain('"targetMode": "local"');
     expect(task).toContain('"repoRoot": "/repo"');
     expect(task).toContain('Agent Relay workflow standards');
+    expect(task).toContain('Matched Ricky generation skills');
     expect(task).toContain('80-to-100 fix loop');
     expect(task).toContain('Structured response contract');
     expect(task).toContain('fenced ```ts artifact block plus a fenced ```json metadata block');
@@ -325,6 +326,9 @@ describe('workforce persona workflow writer', () => {
     expect(calls[0].intents).toEqual(WORKFORCE_PERSONA_INTENT_CANDIDATES);
     expect(calls[0].task).toContain('"repoRoot": "/repo"');
     expect(calls[0].task).toContain('"outputPath": "workflows/generated/workforce-writer.ts"');
+    expect(calls[0].task).toContain('"loadedSkills"');
+    expect(calls[0].task).toContain('choosing-swarm-patterns');
+    expect(calls[0].task).toContain('Quick Decision Framework');
     expect(result.workforcePersona).toMatchObject({
       personaId: 'agent-relay-workflow',
       tier: 'best',

--- a/src/product/generation/workforce-persona-writer.ts
+++ b/src/product/generation/workforce-persona-writer.ts
@@ -1,9 +1,10 @@
 import { createHash } from 'node:crypto';
+import { readFileSync } from 'node:fs';
 import { readFile } from 'node:fs/promises';
 import { isAbsolute, resolve } from 'node:path';
 
 import type { NormalizedWorkflowSpec } from '../spec-intake/types.js';
-import type { RenderedArtifact, WorkflowExecutionTarget } from './types.js';
+import type { RenderedArtifact, SkillContext, WorkflowExecutionTarget } from './types.js';
 
 export const WORKFORCE_PERSONA_INTENT_CANDIDATES = [
   'agent-relay-workflow',
@@ -109,6 +110,7 @@ export interface WorkforcePersonaWriterOptions {
   onProgress?: (chunk: { stream: 'stdout' | 'stderr'; text: string }) => void;
   personaIntentCandidates?: readonly string[];
   resolver?: WorkforcePersonaResolver;
+  skillContext?: SkillContext;
 }
 
 export interface WorkforcePersonaWriterMetadata {
@@ -186,6 +188,7 @@ export async function writeWorkflowWithWorkforcePersona(
     repoRoot: options.repoRoot,
     outputPath: options.outputPath,
     relevantFiles,
+    skillContext: options.skillContext,
   });
   const promptDigest = digest(task);
   const selection = resolved.context.selection;
@@ -435,6 +438,7 @@ export function buildWorkflowPersonaTask(
     repoRoot: string;
     outputPath: string;
     relevantFiles: Array<{ path: string; content?: string }>;
+    skillContext?: SkillContext;
   },
 ): string {
   const contract = {
@@ -485,9 +489,12 @@ export function buildWorkflowPersonaTask(
       content: file.content ?? null,
     }))),
     '',
+    'Matched Ricky generation skills:',
+    renderSkillContextForPersona(input.skillContext),
+    '',
     'Agent Relay workflow standards:',
     '- Prefer TypeScript workflows using @agent-relay/sdk/workflows.',
-    '- Choose `.pattern(...)` from the normalized spec: pipeline (linear stages), supervisor (coordinated review/hand-off), or dag (parallel branches, gated fan-out). Prefer dag when multiple independent workstreams, critical evidence, or high risk; pipeline for simple linear work; supervisor when a lead must gate subordinate steps.',
+    '- Choose `.pattern(...)` from the normalized spec and matched skill context: pipeline for linear stages, supervisor for coordinated review/hand-off, or dag for parallel branches and gated fan-out. When `choosing-swarm-patterns` is matched, use its decision framework before authoring tasks.',
     '- Use a dedicated workflow channel, not general.',
     '- Include explicit agents, step dependencies, deterministic gates, review stages, and final signoff.',
     '- Include an 80-to-100 fix loop: implement, validate, review, fix, final review, hard validation.',
@@ -519,6 +526,34 @@ export function buildWorkflowPersonaTask(
     'Structured response contract:',
     JSON.stringify(contract, null, 2),
   ].join('\n');
+}
+
+function renderSkillContextForPersona(skillContext: SkillContext | undefined): string {
+  if (!skillContext || skillContext.matches.length === 0) return 'No Ricky generation skills were matched.';
+
+  const summaries = skillContext.matches.map((match) => ({
+    id: match.id,
+    confidence: match.confidence,
+    reason: match.reason,
+    evidence: match.evidence.map((item) => `${item.source}:${item.trigger}`),
+  }));
+  const choosingSwarm = skillContext.matches.find((match) => match.id === 'choosing-swarm-patterns');
+  const choosingSwarmContent = choosingSwarm?.path ? safeReadSkillText(choosingSwarm.path) : null;
+
+  return [
+    safeJson({
+      loadedSkills: skillContext.applicableSkillNames,
+      matches: summaries,
+    }),
+    choosingSwarmContent
+      ? [
+          '',
+          '# choosing-swarm-patterns',
+          'Use this generation-time skill context to choose the workflow shape before writing steps:',
+          choosingSwarmContent,
+        ].join('\n')
+      : '',
+  ].filter(Boolean).join('\n');
 }
 
 export function parsePersonaWorkflowResponse(output: string, expectedPath: string): ParsedPersonaResponse {
@@ -798,6 +833,14 @@ function safeJson(value: unknown): string {
     return JSON.stringify(value, null, 2);
   } catch (error) {
     return JSON.stringify({ error: errorMessage(error) }, null, 2);
+  }
+}
+
+function safeReadSkillText(path: string): string {
+  try {
+    return readFileSync(path, 'utf8');
+  } catch {
+    return 'UNAVAILABLE_SKILL_CONTENT';
   }
 }
 

--- a/test/flat-layout-proof/flat-layout-proof.test.ts
+++ b/test/flat-layout-proof/flat-layout-proof.test.ts
@@ -51,7 +51,7 @@ describe('Ricky flat src layout proof', () => {
     ],
     [
       'cli-bin-still-wired',
-      ['package.json bin.ricky: ./dist/ricky.js', 'src/surfaces/cli/bin/ricky.ts exists: true', 'prepack builds the bundle: true'],
+      ['package.json bin.ricky: ./dist/ricky.js', 'src/surfaces/cli/bin/ricky.ts exists: true', 'prepack builds the bundle: true', 'published files include .agents/skills: true'],
     ],
     ['legacy-packages-removed', ['packages/ exists: false', 'packages/ file count: 0']],
     ['surface-folder-shape', ['src/surfaces exists: true', 'src/surfaces/cli exists: true', 'future surfaces documented: slack/, web/, mac/']],

--- a/test/flat-layout-proof/flat-layout-proof.ts
+++ b/test/flat-layout-proof/flat-layout-proof.ts
@@ -384,10 +384,11 @@ export function getFlatLayoutProofCases(): FlatLayoutProofCase[] {
         const prepackBuildsBundle = typeof rootPkg.scripts?.prepack === 'string'
           && (rootPkg.scripts.prepack.includes('bundle') || rootPkg.scripts.prepack.includes('build'));
         const filesIncludesDist = Array.isArray(rootPkg.files) && rootPkg.files.includes('dist');
+        const filesIncludesSkills = Array.isArray(rootPkg.files) && rootPkg.files.includes('.agents/skills');
 
         return result(
           'cli-bin-still-wired',
-          [targetIsBundle, bundlerScriptExists, cliBinSourceExists, cliMainExists, prepackBuildsBundle, filesIncludesDist],
+          [targetIsBundle, bundlerScriptExists, cliBinSourceExists, cliMainExists, prepackBuildsBundle, filesIncludesDist, filesIncludesSkills],
           [
             `package.json bin.ricky: ${binTarget || '(missing)'}`,
             `bundler script exists: ${bundlerScriptExists}`,
@@ -395,6 +396,7 @@ export function getFlatLayoutProofCases(): FlatLayoutProofCase[] {
             `src/surfaces/cli/commands/cli-main.ts exists: ${cliMainExists}`,
             `prepack builds the bundle: ${prepackBuildsBundle}`,
             `published files include dist: ${filesIncludesDist}`,
+            `published files include .agents/skills: ${filesIncludesSkills}`,
           ],
           [],
           [
@@ -404,6 +406,7 @@ export function getFlatLayoutProofCases(): FlatLayoutProofCase[] {
             ...(cliMainExists ? [] : ['Missing src/surfaces/cli/commands/cli-main.ts']),
             ...(prepackBuildsBundle ? [] : ['prepack script does not run the bundle/build']),
             ...(filesIncludesDist ? [] : ['Root package.json files does not include dist']),
+            ...(filesIncludesSkills ? [] : ['Root package.json files does not include .agents/skills']),
           ],
         );
       },


### PR DESCRIPTION
## Summary
- make choosing-swarm-patterns part of Ricky's default workflow-generation skill set alongside workflow authoring and 80-to-100 validation
- feed loaded skill context into pattern selection before Ricky chooses `.pattern(...)`, and include the swarm skill context in Workforce persona writer prompts
- publish `.agents/skills` with the npm package and add package-relative skill discovery for global installs
- add pattern-selection rendering evidence and validation for generated workflow skill boundaries

## Verification
- npm run typecheck
- npx vitest run src/product/generation/skill-matcher.test.ts src/product/generation/pipeline.test.ts src/product/generation/workforce-persona-writer.test.ts test/flat-layout-proof/flat-layout-proof.test.ts
- npm pack --dry-run
- npm test
