### PR TITLE
fix(generation): accept equivalent sanity gates

### DIFF
--- a/src/product/generation/pipeline.test.ts
+++ b/src/product/generation/pipeline.test.ts
@@ -68,6 +68,8 @@ describe('workflow generation pipeline', () => {
     expect(artifact.content).toContain('.agent("impl-tests-codex"');
     expect(artifact.content).toContain('.agent("validator-claude"');
     expect(artifact.content).toContain('80-to-100 fix loop');
+    expect(artifact.content).toContain('deterministic sanity gate using grep, rg, or an equivalent assertion');
+    expect(artifact.content).toContain('Generated workflow quality');
     expect(result.toolSelection.selections).toEqual(
       expect.arrayContaining([
         expect.objectContaining({
@@ -576,6 +578,171 @@ describe('workflow generation pipeline', () => {
     expect(validation.issues).not.toEqual(
       expect.arrayContaining([
         expect.objectContaining({ code: 'RESULT_PR_REPORTING_MISSING' }),
+      ]),
+    );
+  });
+
+  it('accepts ripgrep as an equivalent deterministic sanity gate', () => {
+    const implementationSpec = spec({
+      description: 'Implement local workflow generation checks with resilient sanity validation.',
+      targetFiles: ['src/product/generation/pipeline.ts'],
+    });
+    const result = generate({
+      spec: implementationSpec,
+      artifactPath: 'workflows/generated/resilient-sanity.ts',
+    });
+    const base = artifact(result);
+    const gatesWithoutGrep = base.gates.map((gate) => ({
+      ...gate,
+      command: gate.command
+        .replace(/\bgit\s+grep\b/g, 'printf')
+        .replace(/\bgrep\b/g, 'printf'),
+    }));
+    const rgArtifact = {
+      ...base,
+      gates: gatesWithoutGrep.map((gate) => gate.name === 'post-implementation-file-gate'
+        ? {
+            ...gate,
+            command: "test -f src/product/generation/pipeline.ts && rg -e 'export|function|class' src/product/generation/pipeline.ts",
+          }
+        : gate),
+    };
+
+    const validation = validateGeneratedArtifact(
+      rgArtifact,
+      result.patternDecision,
+      result.skillContext,
+      implementationSpec,
+    );
+
+    expect(validation.issues).not.toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ code: 'GREP_GATE_MISSING' }),
+      ]),
+    );
+  });
+
+  it('requires inline runtime sanity gates to read evidence and fail on mismatch', () => {
+    const implementationSpec = spec({
+      description: 'Implement local workflow generation checks with inline sanity validation.',
+      targetFiles: ['src/product/generation/pipeline.ts'],
+    });
+    const result = generate({
+      spec: implementationSpec,
+      artifactPath: 'workflows/generated/inline-sanity.ts',
+    });
+    const base = artifact(result);
+    const gatesWithoutGrep = base.gates.map((gate) => ({
+      ...gate,
+      command: gate.command
+        .replace(/\bgit\s+grep\b/g, 'printf')
+        .replace(/\bgrep\b/g, 'printf'),
+    }));
+    const withPostImplementationCommand = (command: string) => ({
+      ...base,
+      gates: gatesWithoutGrep.map((gate) => gate.name === 'post-implementation-file-gate'
+        ? { ...gate, command }
+        : gate),
+    });
+
+    const noOpNodeValidation = validateGeneratedArtifact(
+      withPostImplementationCommand('node -e "console.log(\'ok\')"'),
+      result.patternDecision,
+      result.skillContext,
+      implementationSpec,
+    );
+    expect(noOpNodeValidation.issues).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ code: 'GREP_GATE_MISSING' }),
+      ]),
+    );
+
+    const assertingNodeValidation = validateGeneratedArtifact(
+      withPostImplementationCommand(
+        'node -e "const { readFileSync } = require(\'fs\'); if (!readFileSync(\'src/product/generation/pipeline.ts\', \'utf8\').includes(\'validateGeneratedArtifact\')) process.exit(1)"',
+      ),
+      result.patternDecision,
+      result.skillContext,
+      implementationSpec,
+    );
+    expect(assertingNodeValidation.issues).not.toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ code: 'GREP_GATE_MISSING' }),
+      ]),
+    );
+  });
+
+  it('accepts ruby and perl inline assertions invoked with -e', () => {
+    const implementationSpec = spec({
+      description: 'Implement local workflow generation checks with ruby and perl sanity validation.',
+      targetFiles: ['src/product/generation/pipeline.ts'],
+    });
+    const result = generate({
+      spec: implementationSpec,
+      artifactPath: 'workflows/generated/ruby-perl-sanity.ts',
+    });
+    const base = artifact(result);
+    const gatesWithoutGrep = base.gates.map((gate) => ({
+      ...gate,
+      command: gate.command
+        .replace(/\bgit\s+grep\b/g, 'printf')
+        .replace(/\bgrep\b/g, 'printf'),
+    }));
+    const validations = [
+      'ruby -e "raise unless File.read(\'src/product/generation/pipeline.ts\').include?(\'validateGeneratedArtifact\')"',
+      'perl -e "open my $fh, \'<\', \'src/product/generation/pipeline.ts\' or die $!; local $/; my $s = <$fh>; die unless $s =~ /validateGeneratedArtifact/"',
+    ].map((command) => validateGeneratedArtifact(
+      {
+        ...base,
+        gates: gatesWithoutGrep.map((gate) => gate.name === 'post-implementation-file-gate'
+          ? { ...gate, command }
+          : gate),
+      },
+      result.patternDecision,
+      result.skillContext,
+      implementationSpec,
+    ));
+
+    for (const validation of validations) {
+      expect(validation.issues).not.toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({ code: 'GREP_GATE_MISSING' }),
+        ]),
+      );
+    }
+  });
+
+  it('does not count prose mentioning grep as a rendered sanity gate', () => {
+    const implementationSpec = spec({
+      description: 'Implement local workflow generation checks with strict gate validation.',
+      targetFiles: ['src/product/generation/pipeline.ts'],
+    });
+    const result = generate({
+      spec: implementationSpec,
+      artifactPath: 'workflows/generated/missing-sanity.ts',
+    });
+    const base = artifact(result);
+    const noSanityArtifact = {
+      ...base,
+      gates: base.gates.map((gate) => ({
+        ...gate,
+        command: gate.command
+          .replace(/\bgit\s+grep\b/g, 'printf')
+          .replace(/\bgrep\b/g, 'printf'),
+      })),
+    };
+
+    expect(noSanityArtifact.content).toContain('deterministic sanity gate');
+    const validation = validateGeneratedArtifact(
+      noSanityArtifact,
+      result.patternDecision,
+      result.skillContext,
+      implementationSpec,
+    );
+
+    expect(validation.issues).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ code: 'GREP_GATE_MISSING' }),
       ]),
     );
   });

--- a/src/product/generation/pipeline.ts
+++ b/src/product/generation/pipeline.ts
@@ -179,8 +179,12 @@ export function validateGeneratedArtifact(
   if (!artifact.gates.some((gate) => gate.verificationType === 'file_exists')) {
     issues.push(blockingIssue('validation', 'FILE_EXISTS_GATE_MISSING', 'Rendered workflow has no file_exists gate.'));
   }
-  if (!/\bgrep\b/.test(content)) {
-    issues.push(blockingIssue('validation', 'GREP_GATE_MISSING', 'Rendered workflow has no grep sanity gate.'));
+  if (!hasDeterministicSanityGate(artifact)) {
+    issues.push(blockingIssue(
+      'validation',
+      'GREP_GATE_MISSING',
+      'Rendered workflow has no deterministic sanity gate such as grep, rg, or an equivalent assertion.',
+    ));
   }
   if (!/npx tsc --noEmit/.test(content)) {
     issues.push(blockingIssue('validation', 'TYPECHECK_GATE_MISSING', 'Rendered workflow has no typecheck gate.'));
@@ -307,6 +311,57 @@ export function validateGeneratedArtifact(
     hasDeterministicGates,
     hasReviewStage,
   };
+}
+
+function hasDeterministicSanityGate(artifact: RenderedArtifact): boolean {
+  return artifact.gates.some((gate) => gate.failOnError && isSanityGateCommand(gate.command));
+}
+
+function isSanityGateCommand(command: string): boolean {
+  const normalized = command.replace(/\\\n/g, ' ').replace(/\s+/g, ' ').trim();
+  if (!normalized) return false;
+
+  return [
+    /\b(?:git\s+grep|grep|rg)\b/,
+    isInlineAssertionCommand(normalized),
+    /\bawk\b.*\bexit\b/,
+    /\btest\s+-s\s+['"]?[^'"\s]*output-manifest\.txt\b/,
+    /\[\[\s+.+(?:==|=~)\s+.+\]\]/,
+    /\bcase\b.+\bin\b.+\besac\b/,
+  ].some((pattern) => typeof pattern === 'boolean' ? pattern : pattern.test(normalized));
+}
+
+function isInlineAssertionCommand(command: string): boolean {
+  const invokesInlineRuntime =
+    /\b(?:node|bun)\s+(?:--input-type=module\s+)?(?:-e|--eval)\b/.test(command) ||
+    /\bpython3?\s+-c\b/.test(command) ||
+    /\b(?:ruby|perl)\s+-e\b/.test(command);
+  if (!invokesInlineRuntime) return false;
+
+  const readsEvidence = [
+    /\breadFileSync\b/,
+    /\b(?:existsSync|statSync|accessSync)\b/,
+    /\b(?:require|import)\s*\(\s*['"](?:node:)?fs/,
+    /\bfrom\s+['"](?:node:)?fs\b/,
+    /\bopen\b/,
+    /\bPath\s*\(/,
+    /\bFile\./,
+    /\bARGV\b|\$ARGV\b|@ARGV\b/,
+  ].some((pattern) => pattern.test(command));
+
+  const canFailOnMismatch = [
+    /\bassert\b/,
+    /\bprocess\.exit\s*\(\s*1\s*\)/,
+    /\bthrow\s+new\s+Error\b/,
+    /\braise\b/,
+    /\bdie\b/,
+    /\bexit\s+1\b/,
+    /\bexit\s*\(\s*1\s*\)/,
+    /\bunless\b/,
+    /\bif\b/,
+  ].some((pattern) => pattern.test(command));
+
+  return readsEvidence && canFailOnMismatch;
 }
 
 function requiresImplementationWorkflow(spec: NormalizedWorkflowSpec): boolean {

--- a/src/product/generation/template-renderer.ts
+++ b/src/product/generation/template-renderer.ts
@@ -450,7 +450,7 @@ Non-goals:
 ${formatList(spec.constraints.filter((constraint) => constraint.category === 'scope').map((constraint) => constraint.constraint))}
 
 Verification commands:
-${formatList(['file_exists gate for declared targets', 'grep sanity gate', 'npx tsc --noEmit', deriveTestCommand(spec), 'git diff --name-only gate requiring a non-empty diff', 'PR URL or explicit result summary'])}
+${formatList(['file_exists gate for declared targets', 'deterministic sanity gate using grep, rg, or an equivalent assertion', 'npx tsc --noEmit', deriveTestCommand(spec), 'git diff --name-only gate requiring a non-empty diff', 'PR URL or explicit result summary'])}
 
 Write ${artifactsDir}/lead-plan.md ending with GENERATION_LEAD_PLAN_READY.`)},
       verification: { type: 'file_exists', value: ${literal(`${artifactsDir}/lead-plan.md`)} },
@@ -489,7 +489,11 @@ ${renderToolSelectionSummary(selection)}
 
 Before editing, read ${artifactsDir}/matched-skills.md when it exists and use it only as generation-time context for this task.
 
-Keep execution routing explicit for local, cloud, and MCP callers. Materialize outputs to disk, then stop for deterministic gates.`)},
+Keep execution routing explicit for local, cloud, and MCP callers. Materialize outputs to disk, then stop for deterministic gates.
+
+Generated workflow quality:
+- Include a real deterministic sanity gate over produced files, not just prose saying one exists.
+- Prefer grep, rg, git grep, or a small inline assertion command that exits non-zero when expected content/state is missing.`)},
     })`;
 }
 

--- a/src/product/generation/workforce-persona-writer.test.ts
+++ b/src/product/generation/workforce-persona-writer.test.ts
@@ -31,6 +31,8 @@ describe('workforce persona workflow writer', () => {
     expect(task).toContain('Agent Relay workflow standards');
     expect(task).toContain('Matched Ricky generation skills');
     expect(task).toContain('80-to-100 fix loop');
+    expect(task).toContain('deterministic sanity gate');
+    expect(task).toContain('grep, rg, git grep');
     expect(task).toContain('Structured response contract');
     expect(task).toContain('fenced ```ts artifact block plus a fenced ```json metadata block');
     expect(task).toContain('Relevant file context');

--- a/src/product/generation/workforce-persona-writer.ts
+++ b/src/product/generation/workforce-persona-writer.ts
@@ -498,6 +498,7 @@ export function buildWorkflowPersonaTask(
     '- Use a dedicated workflow channel, not general.',
     '- Include explicit agents, step dependencies, deterministic gates, review stages, and final signoff.',
     '- Include an 80-to-100 fix loop: implement, validate, review, fix, final review, hard validation.',
+    '- Include a real deterministic sanity gate over produced files using grep, rg, git grep, or an equivalent inline assertion that exits non-zero when expected content/state is missing.',
     '- Verification must include typecheck/test commands when relevant plus git-diff evidence.',
     '- Run with an explicit cwd: .run({ cwd: process.cwd() }).',
     '- Preserve Agent Relay workflow authoring rules: deterministic gates are evidence, agents do production work, and every generated workflow must be locally dry-runnable.',


### PR DESCRIPTION
## Summary
- Validate deterministic sanity gates from rendered gate commands instead of scanning the whole workflow text for the word grep.
- Accept equivalent assertions such as rg, git grep, evidence-reading inline node/python/bun/ruby/perl checks, awk exits, shell pattern assertions, and Ricky's no-target output manifest gate.
- Require inline runtime sanity gates to both inspect evidence and expose a failure path, so no-op eval commands do not satisfy the guard.
- Update generator and Workforce persona-writing guidance so new workflows ask for real deterministic sanity gates using grep, rg, git grep, or equivalent assertions.
- Add regression coverage that rg passes, prose mentioning grep does not satisfy the guard, no-op inline evals fail, ruby/perl -e checks pass, and generation prompts carry the updated guideline.

## Verification
- npm test -- --run src/product/generation/pipeline.test.ts src/product/generation/workforce-persona-writer.test.ts
- npm run typecheck
- npm test -- --run src/product/generation/pipeline.test.ts
- npx vitest run src/surfaces/cli/flows/local-run-monitor.test.ts
- npm test (local full suite currently hits existing timing-sensitive local-run-monitor expectation: status completed before running; targeted rerun passes)