### PR TITLE
Auto-repair timed-out agent workflow steps

### DIFF
--- a/src/local/auto-fix-loop.test.ts
+++ b/src/local/auto-fix-loop.test.ts
@@ -203,6 +203,67 @@ describe('runWithAutoFix', () => {
     expect(repair?.content).not.toContain('{{steps.write-message.output}}');
   });
 
+  it('deterministically splits timed-out agent steps and resumes from the failed step', async () => {
+    const firstFailure = agentTimeoutBlockerResponse();
+    const runSingleAttempt = vi
+      .fn()
+      .mockResolvedValueOnce(firstFailure)
+      .mockResolvedValueOnce(successResponse('timeout-run-2'));
+    const artifactWriter = vi.fn().mockResolvedValue(undefined);
+
+    const result = await runWithAutoFix({
+      ...baseRequest,
+      source: 'workflow-artifact',
+      spec: agentTimeoutWorkflowContent(),
+      specPath: 'workflows/generated/webapp-review.ts',
+    }, {
+      maxAttempts: 2,
+      runSingleAttempt,
+      artifactWriter,
+    });
+
+    expect(result.ok).toBe(true);
+    expect(artifactWriter).toHaveBeenCalledTimes(1);
+    const repaired = String(artifactWriter.mock.calls[0][1]);
+    expect(repaired).toContain("RICKY_TIMEOUT_REPAIR");
+    expect(repaired).toContain(".step('implement-tests-timeout-continuation'");
+    expect(repaired).toContain("dependsOn: ['implement-tests']");
+    expect(repaired).toContain("dependsOn: ['implement-tests-timeout-continuation']");
+    expect(repaired).toContain('IMPLEMENT_TESTS_TIMEOUT_CONTINUATION_DONE');
+    expect(result.auto_fix?.attempts[0]).toMatchObject({
+      blocker_code: 'INVALID_ARTIFACT',
+      failed_step: 'implement-tests',
+      applied_fix: {
+        mode: 'deterministic',
+        artifact_path: 'workflows/generated/webapp-review.ts',
+        summary: expect.stringContaining('split timed-out agent step implement-tests'),
+      },
+    });
+    expect(runSingleAttempt.mock.calls[1][0].retry).toMatchObject({
+      attempt: 2,
+      previousRunId: 'timeout-run-1',
+      retryOfRunId: 'timeout-run-1',
+      startFromStep: 'implement-tests',
+    });
+  });
+
+  it('uses step-specific timeout evidence and preserves comma-containing timeout expressions', () => {
+    const repair = repairWorkflowDeterministically({
+      artifactPath: 'workflows/generated/webapp-review.ts',
+      artifactContent: agentTimeoutWorkflowContent('Math.min(MAX_TIMEOUT, 900_000)'),
+      evidence: timeoutRepairEvidenceWithEarlierNonTimeoutFailure(),
+    });
+
+    expect(repair).toMatchObject({
+      applied: true,
+      summary: expect.stringContaining('split timed-out agent step implement-tests'),
+    });
+    expect(repair?.content).toContain(".step('implement-tests-timeout-continuation'");
+    expect(repair?.content).not.toContain(".step('run-focused-validation-timeout-continuation'");
+    expect(repair?.content).toContain('timeoutMs: Math.min(MAX_TIMEOUT, 900_000)');
+    expect(repair?.content).toContain("dependsOn: ['implement-tests-timeout-continuation']");
+  });
+
   it('persona repair failure escalates without retrying', async () => {
     const runSingleAttempt = vi.fn().mockResolvedValue(blockerResponse('MISSING_BINARY', 'run-1', 'install-deps'));
 
@@ -568,6 +629,121 @@ function semanticContractBlockerResponse(artifactPath: string, artifactContent: 
   };
 }
 
+function agentTimeoutBlockerResponse(): LocalResponse {
+  const blocker: LocalClassifiedBlocker = {
+    code: 'INVALID_ARTIFACT',
+    category: 'workflow_invalid',
+    message: 'Workflow reported a failed run: Step "implement-tests" failed after 2 retries: The operation was aborted due to timeout.',
+    detected_at: '2026-04-28T00:00:00.000Z',
+    detected_during: 'launch',
+    recovery: {
+      actionable: true,
+      steps: ['Inspect the timed-out agent step and split the work.'],
+    },
+    context: {
+      missing: ['completed agent step'],
+      found: ['step=implement-tests', 'reason=timeout'],
+    },
+  };
+  return {
+    ok: false,
+    artifacts: [{ path: 'workflows/generated/webapp-review.ts', content: agentTimeoutWorkflowContent() }],
+    logs: [],
+    warnings: [blocker.message],
+    nextActions: [...blocker.recovery.steps],
+    generation: {
+      stage: 'generate',
+      status: 'ok',
+      artifact: { path: 'workflows/generated/webapp-review.ts', workflow_id: 'wf-timeout', spec_digest: 'timeout' },
+    },
+    execution: {
+      stage: 'execute',
+      status: 'blocker',
+      execution: {
+        ...execution('timeout-run-1'),
+        artifact_path: 'workflows/generated/webapp-review.ts',
+        workflow_file: 'workflows/generated/webapp-review.ts',
+      },
+      blocker,
+      evidence: {
+        outcome_summary: blocker.message,
+        logs: {
+          tail: [
+            '[workflow 161:26] [implement-tests] Started (owner: test-impl, specialist: test-impl)',
+            '  ↻ implement-tests — retrying (attempt 1)',
+            '[workflow 163:36] [implement-tests] Started (owner: test-impl, specialist: test-impl)',
+            '  ↻ implement-tests — retrying (attempt 2)',
+            '[workflow 165:46] [implement-tests] Started (owner: test-impl, specialist: test-impl)',
+            '  ✗ implement-tests — FAILED: The operation was aborted due to timeout',
+            '[workflow] FAILED: Step "implement-tests" failed: Step "implement-tests" failed after 2 retries: The operation was aborted due to timeout',
+          ],
+          truncated: false,
+        },
+        side_effects: { files_written: [], commands_invoked: [] },
+        assertions: [{ name: 'runtime_exit_code', status: 'fail', detail: blocker.message }],
+      },
+    },
+    exitCode: 2,
+  };
+}
+
+function timeoutRepairEvidenceWithEarlierNonTimeoutFailure(): WorkflowRunEvidence {
+  return {
+    runId: 'timeout-run-1',
+    workflowId: 'wf-timeout',
+    workflowName: 'ricky-webapp-review',
+    status: 'failed',
+    startedAt: '2026-04-28T00:00:00.000Z',
+    completedAt: '2026-04-28T00:10:00.000Z',
+    steps: [
+      {
+        stepId: 'run-focused-validation',
+        stepName: 'run-focused-validation',
+        status: 'failed',
+        startedAt: '2026-04-28T00:00:00.000Z',
+        completedAt: '2026-04-28T00:00:10.000Z',
+        error: 'Command failed with exit code 1',
+        verifications: [{
+          type: 'exit_code',
+          passed: false,
+          expected: '0',
+          actual: '1',
+          message: 'Command failed with exit code 1',
+        }],
+        deterministicGates: [],
+        logs: [{ stream: 'stdout', excerpt: '[workflow] [run-focused-validation] Command failed (exit code 1)' }],
+        artifacts: [],
+        history: [],
+        retries: [],
+        narrative: [],
+      },
+      {
+        stepId: 'implement-tests',
+        stepName: 'implement-tests',
+        status: 'failed',
+        startedAt: '2026-04-28T00:00:00.000Z',
+        completedAt: '2026-04-28T00:10:00.000Z',
+        error: 'The operation was aborted due to timeout',
+        verifications: [],
+        deterministicGates: [],
+        logs: [{ stream: 'stdout', excerpt: '  ✗ implement-tests — FAILED: The operation was aborted due to timeout' }],
+        artifacts: [],
+        history: [],
+        retries: [],
+        narrative: [],
+      },
+    ],
+    deterministicGates: [],
+    artifacts: [{ path: 'workflows/generated/webapp-review.ts', kind: 'file' }],
+    logs: [
+      { stream: 'stderr', excerpt: '  ✗ implement-tests — FAILED: The operation was aborted due to timeout' },
+      { stream: 'stderr', excerpt: '[workflow] FAILED: Step "implement-tests" failed after 2 retries: The operation was aborted due to timeout' },
+    ],
+    narrative: [],
+    routing: [],
+  };
+}
+
 function semanticContractEvidence(response: LocalResponse): WorkflowRunEvidence {
   return {
     runId: response.execution?.execution.run_id ?? 'semantic-run-1',
@@ -663,6 +839,56 @@ workflow('ricky-demo-broken-greeting')
     type: 'deterministic',
     dependsOn: ['emit-done'],
     command: \`printf 'pipeline complete: %s\\n' '{{steps.write-message.output}}' > \${artifactDir}/summary.txt\`,
+    failOnError: true,
+  })
+  .run({ cwd: process.cwd() });
+`;
+}
+
+function agentTimeoutWorkflowContent(timeoutExpression = 'AGENT_STEP_TIMEOUT_MS'): string {
+  return `
+import { workflow } from '@agent-relay/sdk/workflows';
+
+const ARTIFACT_DIR = 'workflows/generated/.ricky-webapp-review';
+const MAX_TIMEOUT = 1_800_000;
+const AGENT_STEP_TIMEOUT_MS = Number.parseInt(process.env.RICKY_AGENT_STEP_TIMEOUT_MS ?? '300000', 10);
+
+workflow('ricky-webapp-review')
+  .agent('test-impl', {
+    cli: 'codex',
+    preset: 'worker',
+    role: 'Test implementer and fixer.',
+    retries: 2,
+    timeoutMs: AGENT_STEP_TIMEOUT_MS,
+  })
+  .step('verify-surfaces-and-webapp', {
+    type: 'deterministic',
+    command: 'echo SURFACES_VERIFIED',
+    failOnError: true,
+  })
+  .step('implement-tests', {
+    agent: 'test-impl',
+    dependsOn: ['verify-surfaces-and-webapp'],
+    timeoutMs: ${timeoutExpression},
+    task: \`Add and update tests for the implemented deep review flow.
+
+Required coverage:
+- readiness gate states,
+- intent idempotency,
+- runtime election,
+- review-workspace routes,
+- Slack and Telegram retrigger handoff,
+- webapp queued/blocked/running/completed states,
+- workflow dispatch/writeback contract.
+
+Run focused tests while editing. Write \${ARTIFACT_DIR}/tests-summary.md ending with TESTS_IMPLEMENTED.\`,
+    verification: { type: 'file_exists', value: \`\${ARTIFACT_DIR}/tests-summary.md\` },
+  })
+  .step('run-focused-validation', {
+    type: 'deterministic',
+    dependsOn: ['implement-tests'],
+    command: 'npm test',
+    captureOutput: true,
     failOnError: true,
   })
   .run({ cwd: process.cwd() });

--- a/src/local/auto-fix-loop.ts
+++ b/src/local/auto-fix-loop.ts
@@ -347,6 +347,12 @@ export function repairWorkflowDeterministically(
   let content = input.artifactContent;
   const changes: string[] = [];
 
+  const timeoutRepair = repairAgentStepTimeouts(content, input.evidence);
+  if (timeoutRepair.content !== content) {
+    content = timeoutRepair.content;
+    changes.push(...timeoutRepair.changes);
+  }
+
   const missingFileRepair = missingFileRepairFromEvidence(input.evidence)
     ?? missingFileRepairFromArtifactContent(content, input.evidence);
   if (missingFileRepair) {
@@ -484,6 +490,237 @@ function repairUnknownStepTemplateRefs(content: string): { content: string; chan
   return { content: next, changes };
 }
 
+function repairAgentStepTimeouts(content: string, evidence: WorkflowRunEvidence): { content: string; changes: string[] } {
+  const timedOutStep = timedOutAgentStepFromEvidence(evidence);
+  if (!timedOutStep) return { content, changes: [] };
+  if (content.includes(`${timedOutStep}-timeout-continuation`)) return { content, changes: [] };
+
+  const range = findStepObjectRange(content, timedOutStep);
+  if (!range) return { content, changes: [] };
+
+  const block = content.slice(range.start, range.end);
+  const agent = block.match(/\bagent:\s*['"`]([^'"`]+)['"`]/)?.[1];
+  if (!agent) return { content, changes: [] };
+  const taskRange = findTemplatePropertyRange(block, 'task');
+  if (!taskRange) return { content, changes: [] };
+
+  const continuationStep = `${timedOutStep}-timeout-continuation`;
+  const handoffPath = timeoutContinuationPath(content, timedOutStep);
+  const marker = markerForStep(continuationStep);
+  const timeoutValue = timeoutValueForContinuation(block);
+  const originalTask = block.slice(taskRange.contentStart, taskRange.contentEnd);
+  const repairedTask = `${originalTask.trimEnd()}
+
+RICKY_TIMEOUT_REPAIR:
+- This step previously exhausted its agent timeout/retries.
+- Complete a bounded first slice only, then write a concise handoff for the continuation step to ${handoffPath}.
+- Preserve any work already completed in the repository.
+- If the original task has multiple coverage areas, do not try to finish all of them in this one agent turn.`;
+  const repairedBlock = `${block.slice(0, taskRange.contentStart)}${repairedTask}${block.slice(taskRange.contentEnd)}`;
+  const before = content.slice(0, range.start);
+  const after = rewriteDependsOnStep(content.slice(range.end), timedOutStep, continuationStep);
+  const continuation = renderTimeoutContinuationStep({
+    stepId: continuationStep,
+    dependsOn: timedOutStep,
+    agent,
+    timeoutValue,
+    handoffPath,
+    marker,
+  });
+  const next = `${before}${repairedBlock}\n\n${continuation}${after}`;
+
+  return {
+    content: next,
+    changes: [`split timed-out agent step ${timedOutStep} with continuation ${continuationStep}`],
+  };
+}
+
+function timedOutAgentStepFromEvidence(evidence: WorkflowRunEvidence): string | null {
+  for (const step of evidence.steps) {
+    if (step.status !== 'failed') continue;
+    const stepText = [
+      step.error,
+      ...step.verifications.map((verification) => verification.message ?? verification.actual ?? ''),
+      ...step.deterministicGates.flatMap((gate) => gate.verifications.map((verification) => verification.message ?? verification.actual ?? '')),
+      ...step.logs.map((entry) => entry.excerpt),
+    ].filter(Boolean).join('\n');
+    if (hasTimeoutSignal(stepText)) {
+      return step.stepId;
+    }
+  }
+
+  const allLogs = evidence.logs.map((entry) => entry.excerpt).join('\n');
+  const failed = allLogs.match(/Step "([^"]+)" failed after \d+ retries: .*?(?:timed?\s*out|timeout|aborted)/i)
+    ?? allLogs.match(/✗\s+(.+?)\s+—\s+FAILED: .*?(?:timed?\s*out|timeout|aborted)/i);
+  return failed?.[1]?.trim() ?? null;
+}
+
+function hasTimeoutSignal(text: string): boolean {
+  return /\b(?:timed?\s*out|timeout|aborted due to timeout)\b/i.test(text);
+}
+
+function findStepObjectRange(content: string, stepId: string): { start: number; end: number } | null {
+  const escaped = escapeRegExp(stepId);
+  const stepMatch = new RegExp(`\\.step\\(\\s*['"\`]${escaped}['"\`]\\s*,\\s*\\{`).exec(content);
+  if (!stepMatch) return null;
+  const start = stepMatch.index;
+  const objectStart = content.indexOf('{', start);
+  if (objectStart === -1) return null;
+  const objectEnd = findMatchingBrace(content, objectStart);
+  if (objectEnd === -1) return null;
+  let end = objectEnd + 1;
+  while (/\s/.test(content[end] ?? '')) end += 1;
+  if (content[end] === ')') end += 1;
+  return { start, end };
+}
+
+function findMatchingBrace(content: string, start: number): number {
+  let depth = 0;
+  let quote: '"' | "'" | '`' | null = null;
+  let escaped = false;
+
+  for (let index = start; index < content.length; index += 1) {
+    const char = content[index];
+    if (quote) {
+      if (escaped) {
+        escaped = false;
+        continue;
+      }
+      if (char === '\\') {
+        escaped = true;
+        continue;
+      }
+      if (char === quote) quote = null;
+      continue;
+    }
+    if (char === '"' || char === "'" || char === '`') {
+      quote = char;
+      continue;
+    }
+    if (char === '{') depth += 1;
+    if (char === '}') {
+      depth -= 1;
+      if (depth === 0) return index;
+    }
+  }
+  return -1;
+}
+
+function findTemplatePropertyRange(block: string, property: string): {
+  contentStart: number;
+  contentEnd: number;
+} | null {
+  const match = new RegExp(`\\b${escapeRegExp(property)}\\s*:`).exec(block);
+  if (!match) return null;
+  const tick = block.indexOf('`', match.index + match[0].length);
+  if (tick === -1) return null;
+  const contentStart = tick + 1;
+  let escaped = false;
+  for (let index = contentStart; index < block.length; index += 1) {
+    const char = block[index];
+    if (escaped) {
+      escaped = false;
+      continue;
+    }
+    if (char === '\\') {
+      escaped = true;
+      continue;
+    }
+    if (char === '`') return { contentStart, contentEnd: index };
+  }
+  return null;
+}
+
+function rewriteDependsOnStep(content: string, oldStep: string, newStep: string): string {
+  return content.replace(/dependsOn:\s*\[([^\]]*)\]/g, (match, values: string) => {
+    if (!new RegExp(`['"\`]${escapeRegExp(oldStep)}['"\`]`).test(values)) return match;
+    return match.replace(new RegExp(`(['"\`])${escapeRegExp(oldStep)}\\1`, 'g'), `$1${newStep}$1`);
+  });
+}
+
+function timeoutContinuationPath(content: string, stepId: string): string {
+  if (/\bARTIFACT_DIR\b/.test(content)) return `\${ARTIFACT_DIR}/${stepId}-timeout-continuation.md`;
+  return `.workflow-artifacts/ricky-auto-fix/${stepId}-timeout-continuation.md`;
+}
+
+function timeoutValueForContinuation(block: string): string {
+  const timeout = propertyExpression(block, 'timeoutMs');
+  return timeout || '900_000';
+}
+
+function propertyExpression(block: string, property: string): string | null {
+  const match = new RegExp(`\\b${escapeRegExp(property)}\\s*:`).exec(block);
+  if (!match) return null;
+
+  let index = match.index + match[0].length;
+  while (/\s/.test(block[index] ?? '')) index += 1;
+  const start = index;
+  let parenDepth = 0;
+  let bracketDepth = 0;
+  let braceDepth = 0;
+  let quote: '"' | "'" | '`' | null = null;
+  let escaped = false;
+
+  for (; index < block.length; index += 1) {
+    const char = block[index];
+    if (quote) {
+      if (escaped) {
+        escaped = false;
+        continue;
+      }
+      if (char === '\\') {
+        escaped = true;
+        continue;
+      }
+      if (char === quote) quote = null;
+      continue;
+    }
+    if (char === '"' || char === "'" || char === '`') {
+      quote = char;
+      continue;
+    }
+    if (char === '(') parenDepth += 1;
+    if (char === ')') parenDepth = Math.max(0, parenDepth - 1);
+    if (char === '[') bracketDepth += 1;
+    if (char === ']') bracketDepth = Math.max(0, bracketDepth - 1);
+    if (char === '{') braceDepth += 1;
+    if (char === '}') {
+      if (braceDepth === 0) break;
+      braceDepth -= 1;
+      continue;
+    }
+    if (char === ',' && parenDepth === 0 && bracketDepth === 0 && braceDepth === 0) break;
+  }
+
+  const value = block.slice(start, index).trim();
+  return value || null;
+}
+
+function markerForStep(stepId: string): string {
+  return `${stepId.toUpperCase().replace(/[^A-Z0-9]+/g, '_')}_DONE`;
+}
+
+function renderTimeoutContinuationStep(input: {
+  stepId: string;
+  dependsOn: string;
+  agent: string;
+  timeoutValue: string;
+  handoffPath: string;
+  marker: string;
+}): string {
+  return `    .step('${input.stepId}', {
+      agent: '${input.agent}',
+      dependsOn: ['${input.dependsOn}'],
+      timeoutMs: ${input.timeoutValue},
+      task: \`Continue the previously timed-out workflow step "${input.dependsOn}".
+
+Read any handoff or summary produced by ${input.dependsOn}, inspect the current git diff, and finish only the remaining work from that original step. Keep the scope bounded and preserve existing edits.
+
+Write ${input.handoffPath} ending with ${input.marker}.\`,
+      verification: { type: 'file_exists', value: \`${input.handoffPath}\` },
+    })`;
+}
+
 function nearestStepId(value: string, candidates: string[]): string | null {
   const prefix = value.split('-')[0];
   const ranked = candidates
@@ -542,6 +779,10 @@ function replacePathReference(content: string, expectedPath: string, materialize
 
 function errorMessage(error: unknown): string {
   return error instanceof Error ? error.message : String(error);
+}
+
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
 }
 
 async function resolveWorkflowRepairTarget(

--- a/src/product/generation/pipeline.test.ts
+++ b/src/product/generation/pipeline.test.ts
@@ -70,6 +70,7 @@ describe('workflow generation pipeline', () => {
     expect(artifact.content).toContain('80-to-100 fix loop');
     expect(artifact.content).toContain('deterministic sanity gate using grep, rg, or an equivalent assertion');
     expect(artifact.content).toContain('Generated workflow quality');
+    expect(artifact.content).toContain('Keep each agent step bounded to one coherent slice');
     expect(result.toolSelection.selections).toEqual(
       expect.arrayContaining([
         expect.objectContaining({

--- a/src/product/generation/template-renderer.ts
+++ b/src/product/generation/template-renderer.ts
@@ -493,7 +493,8 @@ Keep execution routing explicit for local, cloud, and MCP callers. Materialize o
 
 Generated workflow quality:
 - Include a real deterministic sanity gate over produced files, not just prose saying one exists.
-- Prefer grep, rg, git grep, or a small inline assertion command that exits non-zero when expected content/state is missing.`)},
+- Prefer grep, rg, git grep, or a small inline assertion command that exits non-zero when expected content/state is missing.
+- Keep each agent step bounded to one coherent slice. Split broad implementation or test-writing work into sequential/fan-out steps with deterministic gates between them instead of relying on a single long agent timeout.`)},
     })`;
 }
 

--- a/src/product/generation/workforce-persona-writer.test.ts
+++ b/src/product/generation/workforce-persona-writer.test.ts
@@ -33,6 +33,7 @@ describe('workforce persona workflow writer', () => {
     expect(task).toContain('80-to-100 fix loop');
     expect(task).toContain('deterministic sanity gate');
     expect(task).toContain('grep, rg, git grep');
+    expect(task).toContain('Keep agent steps bounded');
     expect(task).toContain('Structured response contract');
     expect(task).toContain('fenced ```ts artifact block plus a fenced ```json metadata block');
     expect(task).toContain('Relevant file context');

--- a/src/product/generation/workforce-persona-writer.ts
+++ b/src/product/generation/workforce-persona-writer.ts
@@ -499,6 +499,7 @@ export function buildWorkflowPersonaTask(
     '- Include explicit agents, step dependencies, deterministic gates, review stages, and final signoff.',
     '- Include an 80-to-100 fix loop: implement, validate, review, fix, final review, hard validation.',
     '- Include a real deterministic sanity gate over produced files using grep, rg, git grep, or an equivalent inline assertion that exits non-zero when expected content/state is missing.',
+    '- Keep agent steps bounded: split broad implementation or test-writing work into multiple sequential/fan-out steps with deterministic gates between them instead of one large step that can exhaust retries by timeout.',
     '- Verification must include typecheck/test commands when relevant plus git-diff evidence.',
     '- Run with an explicit cwd: .run({ cwd: process.cwd() }).',
     '- Preserve Agent Relay workflow authoring rules: deterministic gates are evidence, agents do production work, and every generated workflow must be locally dry-runnable.',

--- a/src/surfaces/cli/commands/cli-main.test.ts
+++ b/src/surfaces/cli/commands/cli-main.test.ts
@@ -329,6 +329,7 @@ describe('renderHelp', () => {
     expect(helpText).toContain('Happy path:');
     expect(helpText).toContain('ricky local --spec <text>');
     expect(helpText).toContain('ricky run <path> --background');
+    expect(helpText).toContain('ricky run <artifact> --start-from <step>');
     expect(helpText).toContain('ricky status --run <run-id>');
     expect(helpText).toContain('Without --run:  artifact path on disk');
     expect(helpText).not.toMatch(/automatic execution/i);
@@ -1334,6 +1335,59 @@ describe('cliMain', () => {
     expect(output).toContain('  ricky status --run ricky-local-options');
     expect(output).not.toContain('Relevant logs:');
     expect(output).not.toContain('Options:');
+  });
+
+  it('renders a concrete --start-from resume command for failed workflow runs', async () => {
+    const localResult = stagedLocalResult({
+      ok: false,
+      warnings: ['workflow failed'],
+      exitCode: 2,
+      execution: {
+        ...stagedLocalResult().execution!,
+        status: 'blocker',
+        execution: {
+          ...stagedLocalResult().execution!.execution,
+          run_id: 'relay-run-123',
+        },
+        blocker: {
+          code: 'INVALID_ARTIFACT',
+          category: 'workflow_invalid',
+          message: 'Workflow reported a failed run.',
+          detected_at: '2026-01-01T00:00:00.000Z',
+          detected_during: 'launch',
+          recovery: {
+            actionable: true,
+            steps: ['Inspect the captured workflow logs.'],
+          },
+          context: {
+            missing: ['passing workflow run'],
+            found: [],
+          },
+        },
+        evidence: {
+          ...stagedLocalResult().execution!.evidence!,
+          failed_step: { id: 'implement-tests', name: 'implement-tests' },
+          logs: {
+            ...stagedLocalResult().execution!.evidence!.logs,
+            tail: [
+              '  ✗ implement-tests — FAILED: The operation was aborted due to timeout',
+              '[workflow] FAILED: Step "implement-tests" failed after 2 retries',
+            ],
+            truncated: false,
+          },
+        },
+      },
+    });
+    const runner = vi.fn().mockResolvedValue(fakeInteractiveResult({ ok: false, localResult }));
+
+    const result = await cliMain({
+      argv: ['run', 'workflows/generated/issue-3.ts'],
+      runInteractive: runner,
+    });
+
+    const output = result.output.join('\n');
+    expect(output).toContain('Execution: blocked — INVALID_ARTIFACT at implement-tests');
+    expect(output).toContain('Resume: ricky run workflows/generated/issue-3.ts --start-from implement-tests --previous-run-id relay-run-123');
   });
 
   it('renders auto-fix repair mode and summary for applied workflow repairs', async () => {

--- a/src/surfaces/cli/commands/cli-main.ts
+++ b/src/surfaces/cli/commands/cli-main.ts
@@ -310,6 +310,7 @@ export function renderHelp(): string[] {
     '  ricky --mode local --spec-file <path>               Generate from file',
     '  ricky --mode local --stdin                          Generate from stdin',
     '  ricky run <artifact>                                Execute existing artifact',
+    '  ricky run <artifact> --start-from <step>             Resume an existing workflow from a failed step',
     '  ricky help                                          This help text',
     '  ricky version                                       Version',
     '',
@@ -1796,6 +1797,8 @@ function renderLocalHuman(localResult: NonNullable<InteractiveCliResult['localRe
     if (localResult.execution) {
       lines.push(`Generation: ok${artifactPath ? ` — ${artifactPath}` : ''}`);
       lines.push(executionFailureSummary(localResult));
+      const resume = resumeCommandFor(localResult);
+      if (resume) lines.push(`Resume: ${resume}`);
     } else if (localResult.generation) {
       lines.push(`Generation: failed (status: ${localResult.generation.status}).`);
       if (localResult.generation.error) lines.push(`Reason: ${localResult.generation.error}`);
@@ -1936,6 +1939,25 @@ function executionFailureSummary(localResult: NonNullable<InteractiveCliResult['
     ?? execution.evidence?.failed_step?.id;
   const status = execution.status === 'blocker' ? 'blocked' : execution.status;
   return `Execution: ${status}${blocker}${failedStep ? ` at ${failedStep}` : ''}`;
+}
+
+function resumeCommandFor(localResult: NonNullable<InteractiveCliResult['localResult']>): string | undefined {
+  const execution = localResult.execution;
+  if (!execution || execution.status !== 'blocker') return undefined;
+  const artifactPath = execution.execution.workflow_file
+    ?? execution.execution.artifact_path
+    ?? localResult.generation?.artifact?.path
+    ?? localResult.artifacts[0]?.path;
+  const failedStep = failedStepFromTail(execution.evidence?.logs.tail ?? [])
+    ?? execution.evidence?.failed_step?.id;
+  if (!artifactPath || !failedStep) return undefined;
+  return [
+    'ricky run',
+    artifactPath,
+    '--start-from',
+    failedStep,
+    ...(execution.execution.run_id ? ['--previous-run-id', execution.execution.run_id] : []),
+  ].join(' ');
 }
 
 function failedStepFromTail(tail: string[]): string | undefined {


### PR DESCRIPTION
## Summary
- Add deterministic Ricky local auto-fix for Agent Relay agent steps that fail after timeout/retry exhaustion.
- Patch timed-out workflow artifacts by annotating the failed step, inserting a bounded continuation step, and rewiring downstream dependsOn edges to the continuation.
- Keep timeout targeting step-specific first, with run-log fallback only when the timeout failure names the failed step explicitly.
- Preserve complex `timeoutMs` expressions such as `Math.min(MAX_TIMEOUT, 900_000)` when inserting continuation steps.
- Add generation and Workforce persona guidance to split broad implementation/test-writing steps before they become timeout-prone.
- Expose manual resume in the CLI: help shows `ricky run <artifact> --start-from <step>`, and failed run output prints a concrete resume command with `--previous-run-id` when available.
- Add regression coverage for the observed `implement-tests` timeout shape, review-comment edge cases, prompt guardrails, and resume command output.

## Verification
- npm test -- --run src/local/auto-fix-loop.test.ts src/surfaces/cli/commands/cli-main.test.ts src/product/generation/pipeline.test.ts src/product/generation/workforce-persona-writer.test.ts
- npm run typecheck