### PR TITLE
fix(local): repair git diff manifest gates

### DIFF
--- a/src/local/auto-fix-loop.test.ts
+++ b/src/local/auto-fix-loop.test.ts
@@ -264,6 +264,27 @@ describe('runWithAutoFix', () => {
     expect(repair?.content).toContain("dependsOn: ['implement-tests-timeout-continuation']");
   });
 
+  it('deterministically repairs bare git diff manifest gates to include untracked files', () => {
+    const repair = repairWorkflowDeterministically({
+      artifactPath: 'workflows/generated/cloud-autofix.ts',
+      artifactContent: bareGitDiffManifestWorkflowContent(),
+      evidence: gitDiffManifestFailureEvidence(),
+    });
+
+    expect(repair).toMatchObject({
+      applied: true,
+      mode: 'deterministic',
+      summary: expect.stringContaining('expanded git diff pipe gates to include untracked files'),
+    });
+    expect(repair?.content).toContain(
+      'NON_TRANSIENT=$({ git diff --name-only; git ls-files --others --exclude-standard; } | sort -u | rg -v',
+    );
+    expect(repair?.content).toContain(
+      '`GIT_DIFF_TMP=$(mktemp) && { git diff --name-only; git ls-files --others --exclude-standard; } | sort -u > "$GIT_DIFF_TMP" && mv "$GIT_DIFF_TMP" ${FINAL_DIFF_FILES}`',
+    );
+    expect(repair?.content).not.toContain('NON_TRANSIENT=$(git diff --name-only | rg -v');
+  });
+
   it('persona repair failure escalates without retrying', async () => {
     const runSingleAttempt = vi.fn().mockResolvedValue(blockerResponse('MISSING_BINARY', 'run-1', 'install-deps'));
 
@@ -893,6 +914,90 @@ Run focused tests while editing. Write \${ARTIFACT_DIR}/tests-summary.md ending 
   })
   .run({ cwd: process.cwd() });
 `;
+}
+
+function bareGitDiffManifestWorkflowContent(): string {
+  return `
+import { workflow } from '@agent-relay/sdk/workflows';
+
+const OUTPUT_MANIFEST = 'artifacts/ricky/output-manifest.txt';
+const FINAL_DIFF_FILES = 'artifacts/ricky/final-diff-files.txt';
+
+workflow('cloud-autofix')
+  .step('verify-non-empty-implementation-diff', {
+    type: 'deterministic',
+    command: [
+      'set -e',
+      'NON_TRANSIENT=$(git diff --name-only | rg -v "^(patches/|artifacts/|docs/.*plan\\\\.md$|.*output-manifest\\\\.txt$)" || true)',
+      'if [ -z "$NON_TRANSIENT" ]; then echo "EMPTY_IMPLEMENTATION_DIFF"; exit 1; fi',
+      \`printf "%s\\\\n" "$NON_TRANSIENT" > \${OUTPUT_MANIFEST}\`,
+      \`cat \${OUTPUT_MANIFEST}\`,
+      \`rg -n "^(packages/web/app/api/v1/ricky/runs/|packages/web/lib/ricky/)" \${OUTPUT_MANIFEST} >/dev/null\`,
+    ].join(' && '),
+    captureOutput: true,
+    failOnError: true,
+  })
+  .step('final-signoff', {
+    type: 'deterministic',
+    dependsOn: ['verify-non-empty-implementation-diff'],
+    command: [
+      'set -e',
+      \`git diff --name-only > \${FINAL_DIFF_FILES}\`,
+      \`test -s \${FINAL_DIFF_FILES}\`,
+    ].join(' && '),
+    failOnError: true,
+  })
+  .run({ cwd: process.cwd() });
+`;
+}
+
+function gitDiffManifestFailureEvidence(): WorkflowRunEvidence {
+  return {
+    runId: 'diff-run-1',
+    workflowId: 'wf-cloud-autofix',
+    workflowName: 'cloud-autofix',
+    status: 'failed',
+    startedAt: '2026-05-03T00:00:00.000Z',
+    completedAt: '2026-05-03T00:03:23.000Z',
+    steps: [{
+      stepId: 'verify-non-empty-implementation-diff',
+      stepName: 'verify-non-empty-implementation-diff',
+      status: 'failed',
+      startedAt: '2026-05-03T00:03:23.000Z',
+      completedAt: '2026-05-03T00:03:24.000Z',
+      error: 'Command failed with exit code 1',
+      verifications: [{
+        type: 'exit_code',
+        passed: false,
+        expected: '0',
+        actual: '1',
+        message: 'Command failed with exit code 1',
+        command: 'NON_TRANSIENT=$(git diff --name-only | rg -v "^(patches/|artifacts/|docs/.*plan\\.md$|.*output-manifest\\.txt$)" || true)',
+        exitCode: 1,
+      }],
+      deterministicGates: [],
+      logs: [{
+        stream: 'stdout',
+        excerpt: [
+          'packages/core/src/bootstrap/launcher.ts',
+          'packages/web/app/api/v1/workflows/run/route.ts',
+          'tests/workflow-run-route.test.ts',
+        ].join('\n'),
+      }],
+      artifacts: [],
+      history: [],
+      retries: [],
+      narrative: [],
+    }],
+    deterministicGates: [],
+    artifacts: [{ path: 'workflows/generated/cloud-autofix.ts', kind: 'file' }],
+    logs: [{
+      stream: 'stderr',
+      excerpt: '[workflow] FAILED: Step "verify-non-empty-implementation-diff" failed: Command failed with exit code 1',
+    }],
+    narrative: [],
+    routing: [],
+  };
 }
 
 function execution(runId: string | undefined): NonNullable<LocalResponse['execution']>['execution'] {

--- a/src/local/auto-fix-loop.ts
+++ b/src/local/auto-fix-loop.ts
@@ -375,6 +375,12 @@ export function repairWorkflowDeterministically(
     changes.push(...templateRepair.changes);
   }
 
+  const gitDiffRepair = repairBareGitDiffManifestGates(content);
+  if (gitDiffRepair.content !== content) {
+    content = gitDiffRepair.content;
+    changes.push(...gitDiffRepair.changes);
+  }
+
   if (content === input.artifactContent || changes.length === 0) return null;
 
   return {
@@ -488,6 +494,28 @@ function repairUnknownStepTemplateRefs(content: string): { content: string; chan
   });
 
   return { content: next, changes };
+}
+
+function repairBareGitDiffManifestGates(content: string): { content: string; changes: string[] } {
+  if (!content.includes('git diff --name-only')) return { content, changes: [] };
+
+  const changes: string[] = [];
+  let next = content.replace(
+    /git diff --name-only\s*\|\s*/g,
+    () => {
+      changes.push('expanded git diff pipe gates to include untracked files');
+      return '{ git diff --name-only; git ls-files --others --exclude-standard; } | sort -u | ';
+    },
+  );
+  next = next.replace(
+    /git diff --name-only\s*>\s*/g,
+    () => {
+      changes.push('expanded git diff redirect gates to include untracked files');
+      return 'GIT_DIFF_TMP=$(mktemp) && { git diff --name-only; git ls-files --others --exclude-standard; } | sort -u > "$GIT_DIFF_TMP" && mv "$GIT_DIFF_TMP" ';
+    },
+  );
+
+  return { content: next, changes: [...new Set(changes)] };
 }
 
 function repairAgentStepTimeouts(content: string, evidence: WorkflowRunEvidence): { content: string; changes: string[] } {

--- a/src/product/generation/template-renderer.ts
+++ b/src/product/generation/template-renderer.ts
@@ -450,7 +450,7 @@ Non-goals:
 ${formatList(spec.constraints.filter((constraint) => constraint.category === 'scope').map((constraint) => constraint.constraint))}
 
 Verification commands:
-${formatList(['file_exists gate for declared targets', 'deterministic sanity gate using grep, rg, or an equivalent assertion', 'npx tsc --noEmit', deriveTestCommand(spec), 'git diff --name-only gate requiring a non-empty diff', 'PR URL or explicit result summary'])}
+${formatList(['file_exists gate for declared targets', 'deterministic sanity gate using grep, rg, or an equivalent assertion', 'npx tsc --noEmit', deriveTestCommand(spec), 'git diff gate combining git diff --name-only with git ls-files --others --exclude-standard and requiring a non-empty diff', 'PR URL or explicit result summary'])}
 
 Write ${artifactsDir}/lead-plan.md ending with GENERATION_LEAD_PLAN_READY.`)},
       verification: { type: 'file_exists', value: ${literal(`${artifactsDir}/lead-plan.md`)} },

--- a/src/product/generation/workforce-persona-writer.ts
+++ b/src/product/generation/workforce-persona-writer.ts
@@ -500,7 +500,7 @@ export function buildWorkflowPersonaTask(
     '- Include an 80-to-100 fix loop: implement, validate, review, fix, final review, hard validation.',
     '- Include a real deterministic sanity gate over produced files using grep, rg, git grep, or an equivalent inline assertion that exits non-zero when expected content/state is missing.',
     '- Keep agent steps bounded: split broad implementation or test-writing work into multiple sequential/fan-out steps with deterministic gates between them instead of one large step that can exhaust retries by timeout.',
-    '- Verification must include typecheck/test commands when relevant plus git-diff evidence.',
+    '- Verification must include typecheck/test commands when relevant plus git-diff evidence; diff/manifest gates must combine git diff --name-only with git ls-files --others --exclude-standard so newly-created files are visible.',
     '- Run with an explicit cwd: .run({ cwd: process.cwd() }).',
     '- Preserve Agent Relay workflow authoring rules: deterministic gates are evidence, agents do production work, and every generated workflow must be locally dry-runnable.',
     '- Include the literal marker IMPLEMENTATION_WORKFLOW_CONTRACT in implementation workflows.',


### PR DESCRIPTION
## Summary
- repair bare `git diff --name-only` workflow gates to include untracked files before local auto-fix retries
- strengthen generation guidance so diff/manifest gates combine tracked and untracked files
- add regression coverage for the cloud autofix manifest failure shape

## Validation
- npm test -- --run src/local/auto-fix-loop.test.ts src/product/generation/pipeline.test.ts src/product/generation/workforce-persona-writer.test.ts
- npm run typecheck