### PR TITLE
fix(cli): opt cloud workflow runs into Ricky

### DIFF
--- a/src/cloud/api/request-types.ts
+++ b/src/cloud/api/request-types.ts
@@ -33,6 +33,13 @@ export interface CloudWorkspaceContext {
 
 export type CloudGenerateMode = 'cloud' | 'both';
 
+export type CloudAutoFixApprovalBoundary =
+  | 'code_push'
+  | 'pr_create'
+  | 'secrets'
+  | 'billing'
+  | 'external_write';
+
 export interface CloudNaturalLanguageSpecPayload {
   kind: 'natural-language';
   text: string;
@@ -49,6 +56,19 @@ export type CloudWorkflowSpecPayload =
   | CloudNaturalLanguageSpecPayload
   | CloudStructuredSpecPayload;
 
+export interface CloudRickyAutoFixPolicy {
+  /** Whether Ricky should diagnose and repair failed Cloud workflow runs. */
+  enabled: boolean;
+  /** Maximum bounded repair attempts when auto-fix is enabled. */
+  maxAttempts?: number;
+  /** Prefer AgentWorkforce's workflow-writer persona during repair. */
+  preferWorkforcePersona?: boolean;
+  /** Allow Cloud to fall back to OpenRouter when configured primary agents fail. */
+  allowOpenRouterFallback?: boolean;
+  /** Destructive or externally-visible actions that still require a human. */
+  requireHumanApprovalFor?: CloudAutoFixApprovalBoundary[];
+}
+
 export interface CloudGenerateRequestBody {
   /** The natural-language prompt or structured workflow spec to generate from. */
   spec: CloudWorkflowSpecPayload;
@@ -56,6 +76,8 @@ export interface CloudGenerateRequestBody {
   specPath?: string;
   /** Execution mode — Cloud-only or both (local + Cloud). */
   mode?: CloudGenerateMode;
+  /** Ricky supervision policy for executing existing workflow artifacts in Cloud. */
+  autoFix?: CloudRickyAutoFixPolicy;
   /** Opaque metadata from the originating surface. */
   metadata?: Record<string, unknown>;
 }

--- a/src/surfaces/cli/commands/cli-main.test.ts
+++ b/src/surfaces/cli/commands/cli-main.test.ts
@@ -88,6 +88,13 @@ describe('parseArgs', () => {
       json: true,
       ...RUN_DEFAULTS,
     });
+    expect(parseArgs(['run', 'workflows/generated/example.ts', '--mode', 'cloud'])).toEqual({
+      command: 'run',
+      mode: 'cloud',
+      artifact: 'workflows/generated/example.ts',
+      runRequested: true,
+      ...RUN_DEFAULTS,
+    });
   });
 
   it('parses --auto-fix attempts and treats zero as disabled', () => {
@@ -1816,6 +1823,92 @@ describe('cliMain', () => {
     });
   });
 
+  it('routes ricky run artifacts in cloud mode through Ricky-supervised Cloud execution', async () => {
+    await withCloudEnvCleared(async () => {
+      const runner = vi.fn().mockResolvedValue(fakeInteractiveResult({ mode: 'cloud' }));
+
+      const result = await cliMain({
+        argv: ['run', 'workflows/generated/cloud-release.ts', '--mode', 'cloud', '--json'],
+        runInteractive: runner,
+        readCloudAuth: vi.fn().mockResolvedValue({
+          accessToken: 'stored-token',
+          refreshToken: 'stored-refresh',
+          accessTokenExpiresAt: new Date(Date.now() + 60_000).toISOString(),
+          apiUrl: 'https://cloud.example.test',
+        }),
+        resolveCloudWorkspace: vi.fn().mockResolvedValue('workspace-from-cloud-profile'),
+      });
+
+      expect(result.exitCode).toBe(0);
+      expect(runner).toHaveBeenCalledWith(
+        expect.objectContaining({
+          mode: 'cloud',
+          cloudRequest: {
+            auth: { token: 'stored-token' },
+            workspace: { workspaceId: 'workspace-from-cloud-profile' },
+            body: {
+              spec: {
+                kind: 'structured',
+                document: {
+                  intent: 'execute',
+                  workflowPath: 'workflows/generated/cloud-release.ts',
+                },
+                format: 'ricky-workflow',
+              },
+              specPath: 'workflows/generated/cloud-release.ts',
+              mode: 'cloud',
+              autoFix: {
+                enabled: true,
+                maxAttempts: 7,
+                preferWorkforcePersona: true,
+                allowOpenRouterFallback: true,
+                requireHumanApprovalFor: ['code_push', 'pr_create', 'secrets', 'billing', 'external_write'],
+              },
+              metadata: {
+                ricky: {
+                  optIn: true,
+                  runEndpoint: '/api/v1/ricky/runs',
+                },
+                cli: {
+                  handoff: 'artifact',
+                },
+              },
+            },
+          },
+        }),
+      );
+      expect(runner.mock.calls[0][0]).not.toHaveProperty('handoff');
+    });
+  });
+
+  it('keeps Ricky cloud execution opt-in while disabling repairs when requested', async () => {
+    await withCloudEnvCleared(async () => {
+      const runner = vi.fn().mockResolvedValue(fakeInteractiveResult({ mode: 'cloud' }));
+
+      const result = await cliMain({
+        argv: ['run', 'workflows/generated/cloud-release.ts', '--mode', 'cloud', '--no-auto-fix', '--json'],
+        runInteractive: runner,
+        readCloudAuth: vi.fn().mockResolvedValue({
+          accessToken: 'stored-token',
+          refreshToken: 'stored-refresh',
+          accessTokenExpiresAt: new Date(Date.now() + 60_000).toISOString(),
+          apiUrl: 'https://cloud.example.test',
+        }),
+        resolveCloudWorkspace: vi.fn().mockResolvedValue('workspace-from-cloud-profile'),
+      });
+
+      expect(result.exitCode).toBe(0);
+      const request = runner.mock.calls[0][0].cloudRequest;
+      expect(request.body.metadata.ricky).toMatchObject({ optIn: true });
+      expect(request.body.autoFix).toMatchObject({
+        enabled: false,
+        preferWorkforcePersona: true,
+        allowOpenRouterFallback: true,
+      });
+      expect(request.body.autoFix).not.toHaveProperty('maxAttempts');
+    });
+  });
+
   it('renders a Cloud run command when power-user Cloud generation does not run immediately', async () => {
     const runner = vi.fn().mockResolvedValue(fakeInteractiveResult({
       mode: 'cloud',
@@ -2479,13 +2572,14 @@ describe('cliMain', () => {
       );
     });
 
-    it('rejects cloud mode with spec handoff', async () => {
+    it('routes cloud mode spec handoff to Cloud setup instead of local handoff', async () => {
       const result = await cliMain({
         argv: ['--mode', 'cloud', '--spec', 'a workflow'],
+        readCloudAuth: async () => null,
       });
 
       expect(result.exitCode).toBe(1);
-      expect(result.output.join('\n')).toContain('Cloud mode does not accept CLI spec handoff');
+      expect(result.output.join('\n')).toContain('Cloud mode requires a connected AgentWorkforce Cloud account.');
     });
 
     it('handles --file alias for --spec-file', async () => {

--- a/src/surfaces/cli/commands/cli-main.ts
+++ b/src/surfaces/cli/commands/cli-main.ts
@@ -15,7 +15,7 @@ import type { InteractiveCliDeps, InteractiveCliResult } from '../entrypoint/int
 import type { CloudIntegrationConnector } from '../entrypoint/interactive-cli.js';
 import type { ProviderStatus, RickyMode } from '../cli/mode-selector.js';
 import type { RawHandoff, SpecInput } from '../../../local/request-normalizer.js';
-import type { CloudGenerateRequest, CloudWorkflowSpecPayload } from '../../../cloud/api/request-types.js';
+import type { CloudGenerateRequest, CloudGenerateRequestBody, CloudWorkflowSpecPayload } from '../../../cloud/api/request-types.js';
 import type { ConnectProviderOptions, ConnectProviderResult, StoredAuth, WhoAmIResponse } from '@agent-relay/cloud';
 import type { LocalRunMonitorState } from '../flows/local-run-monitor.js';
 import { legacyLocalRunStatePath, localRunStatePath } from '../flows/local-run-monitor.js';
@@ -394,12 +394,7 @@ async function buildCliHandoff(parsed: ParsedArgs, deps: CliMainDeps): Promise<R
     return undefined;
   }
 
-  if (parsed.mode === 'cloud') {
-    if (parsed.surface === 'cloud') {
-      return undefined;
-    }
-    throw new Error('Cloud mode does not accept CLI spec handoff in this local slice. Use `ricky cloud --spec ...` for Cloud generation or --mode local for local generation.');
-  }
+  if (parsed.mode === 'cloud') return undefined;
 
   const handoffMode = parsed.mode ?? 'local';
   const invocationRoot = resolveInvocationRoot(deps.cwd);
@@ -551,6 +546,7 @@ async function buildCloudRequest(parsed: ParsedArgs, deps: CliMainDeps): Promise
   const cloudSpec = await readCloudSpec(parsed, deps);
 
   if (deps.cloudRequest) {
+    const rickyExecution = cloudRickyExecutionBodyFor(parsed, cloudSpec.handoff, deps.cloudRequest.body);
     return {
       ...deps.cloudRequest,
       body: {
@@ -558,9 +554,11 @@ async function buildCloudRequest(parsed: ParsedArgs, deps: CliMainDeps): Promise
         spec: cloudSpec.spec,
         ...(cloudSpec.specPath ? { specPath: cloudSpec.specPath } : {}),
         mode: 'cloud',
+        ...rickyExecution,
         metadata: {
           ...deps.cloudRequest.body.metadata,
           ...(parsed.workflowName ? { workflowName: parsed.workflowName } : {}),
+          ...cloudRickyExecutionMetadataFor(cloudSpec.handoff),
           cli: cliMetadataFor(parsed, cloudSpec.handoff),
         },
       },
@@ -601,10 +599,44 @@ async function buildStoredCredentialCloudRequest(
       spec: cloudSpec.spec,
       ...(cloudSpec.specPath ? { specPath: cloudSpec.specPath } : {}),
       mode: 'cloud',
+      ...cloudRickyExecutionBodyFor(parsed, cloudSpec.handoff),
       metadata: {
         ...(parsed.workflowName ? { workflowName: parsed.workflowName } : {}),
+        ...cloudRickyExecutionMetadataFor(cloudSpec.handoff),
         cli: cliMetadataFor(parsed, cloudSpec.handoff),
       },
+    },
+  };
+}
+
+function cloudRickyExecutionBodyFor(
+  parsed: ParsedArgs,
+  handoff: string,
+  existingBody?: CloudGenerateRequestBody,
+): Partial<CloudGenerateRequestBody> {
+  if (handoff !== 'artifact') return {};
+  return {
+    autoFix: existingBody?.autoFix ?? cloudRickyAutoFixPolicyFor(parsed),
+  };
+}
+
+function cloudRickyAutoFixPolicyFor(parsed: ParsedArgs): NonNullable<CloudGenerateRequestBody['autoFix']> {
+  const enabled = parsed.autoFix !== undefined;
+  return {
+    enabled,
+    ...(enabled ? { maxAttempts: parsed.autoFix } : {}),
+    preferWorkforcePersona: parsed.workforcePersonaWriterCli !== false,
+    allowOpenRouterFallback: true,
+    requireHumanApprovalFor: ['code_push', 'pr_create', 'secrets', 'billing', 'external_write'],
+  };
+}
+
+function cloudRickyExecutionMetadataFor(handoff: string): Record<string, unknown> {
+  if (handoff !== 'artifact') return {};
+  return {
+    ricky: {
+      optIn: true,
+      runEndpoint: '/api/v1/ricky/runs',
     },
   };
 }

--- a/src/surfaces/cli/entrypoint/interactive-cli.ts
+++ b/src/surfaces/cli/entrypoint/interactive-cli.ts
@@ -14,7 +14,7 @@
 import type { OnboardingResult, RickyConfigStore } from '../cli/onboarding.js';
 import type { RickyMode } from '../cli/mode-selector.js';
 import type { CloudExecutor, CloudGenerateResult } from '../../../cloud/api/generate-endpoint.js';
-import type { CloudGenerateRequest } from '../../../cloud/api/request-types.js';
+import type { CloudGenerateRequest, CloudGenerateRequestBody } from '../../../cloud/api/request-types.js';
 import type {
   CloudWorkflowFlowDeps,
   CloudImplementationAgent,
@@ -57,6 +57,7 @@ import {
 } from '../prompts/index.js';
 import { resolve } from 'node:path';
 import { spawn } from 'node:child_process';
+import { DEFAULT_AUTO_FIX_ATTEMPTS } from '../../../shared/constants.js';
 
 // ---------------------------------------------------------------------------
 // Interactive CLI result contract
@@ -1541,14 +1542,39 @@ function cloudRequestFromCapture(
       spec,
       ...(capture.specPath ? { specPath: capture.specPath } : {}),
       mode: 'cloud',
+      ...cloudRickyCaptureExecutionBodyFor(capture),
       metadata: {
         workflowName: capture.workflowName,
+        ...cloudRickyCaptureExecutionMetadataFor(capture),
         cli: {
           handoff: capture.source,
           workflowName: capture.workflowName,
           ...(capture.generatedFromGoal ? { generatedFromGoal: capture.generatedFromGoal } : {}),
         },
       },
+    },
+  };
+}
+
+function cloudRickyCaptureExecutionBodyFor(capture: CapturedWorkflowSpec): Partial<CloudGenerateRequestBody> {
+  if (capture.source !== 'workflow-artifact') return {};
+  return {
+    autoFix: {
+      enabled: true,
+      maxAttempts: DEFAULT_AUTO_FIX_ATTEMPTS,
+      preferWorkforcePersona: true,
+      allowOpenRouterFallback: true,
+      requireHumanApprovalFor: ['code_push', 'pr_create', 'secrets', 'billing', 'external_write'],
+    },
+  };
+}
+
+function cloudRickyCaptureExecutionMetadataFor(capture: CapturedWorkflowSpec): Record<string, unknown> {
+  if (capture.source !== 'workflow-artifact') return {};
+  return {
+    ricky: {
+      optIn: true,
+      runEndpoint: '/api/v1/ricky/runs',
     },
   };
 }


### PR DESCRIPTION
## Summary\n- Route `ricky run <workflow> --mode cloud` through Cloud request construction instead of rejecting it as a local handoff.\n- Attach an explicit Ricky Cloud execution marker and auto-fix policy for workflow artifact runs so Cloud can route them through `/api/v1/ricky/runs`.\n- Preserve `--no-auto-fix` as Ricky supervision with repairs disabled.\n\n## Validation\n- `npx vitest run src/surfaces/cli/commands/cli-main.test.ts`\n- `npm run typecheck`\n- `git diff --check`\n- `npm test`