### PR TITLE
Fix Ricky workflow generation output and validation

### DIFF
--- a/src/local/entrypoint.test.ts
+++ b/src/local/entrypoint.test.ts
@@ -1177,7 +1177,7 @@ describe('runLocal', () => {
 
     expect(result.ok).toBe(true);
     expect(progress).toEqual([
-      'Writing workflow...',
+      'ricky is writing the workflow...',
       'Running workflow...',
     ]);
   });

--- a/src/local/entrypoint.ts
+++ b/src/local/entrypoint.ts
@@ -898,9 +898,7 @@ export function createLocalExecutor(options: LocalExecutorOptions = {}): LocalEx
           refine: request.refine,
           ...(workforcePersonaWriter ? { workforcePersonaWriter } : {}),
         };
-        onProgress?.(generationInput.workforcePersonaWriter
-          ? 'Writing workflow with Workforce persona...'
-          : 'Writing workflow...');
+        onProgress?.('ricky is writing the workflow...');
         generationResult = generationInput.workforcePersonaWriter
           ? await generateWithWorkforcePersona(generationInput)
           : generate(generationInput);

--- a/src/product/generation/pipeline.ts
+++ b/src/product/generation/pipeline.ts
@@ -77,7 +77,7 @@ export async function generateWithWorkforcePersona(input: GenerationInput): Prom
     (input.spec.executionPreference === 'cloud' ? 'cloud' : 'local');
 
   try {
-    const personaResult = await writeWorkflowWithWorkforcePersona(input.spec, {
+    const writerOptions = {
       repoRoot: input.workforcePersonaWriter?.repoRoot ?? process.cwd(),
       workflowName: input.workforcePersonaWriter?.workflowName ?? artifact.workflowId,
       targetMode,
@@ -90,9 +90,48 @@ export async function generateWithWorkforcePersona(input: GenerationInput): Prom
       personaIntentCandidates: input.workforcePersonaWriter?.personaIntentCandidates,
       resolver: input.workforcePersonaWriter?.resolver,
       skillContext: baseResult.skillContext,
-    });
-    const finalArtifact = applyPersonaArtifactToRenderedArtifact(artifact, personaResult);
-    const validation = validateGeneratedArtifact(finalArtifact, baseResult.patternDecision, baseResult.skillContext, input.spec);
+    };
+    const personaResult = await writeWorkflowWithWorkforcePersona(input.spec, writerOptions);
+    let finalArtifact = applyPersonaArtifactToRenderedArtifact(artifact, personaResult);
+    let validation = validateGeneratedArtifact(finalArtifact, baseResult.patternDecision, baseResult.skillContext, input.spec);
+    let finalPersonaMetadata = personaResult.metadata;
+
+    if (!validation.valid) {
+      const repairResult = await writeWorkflowWithWorkforcePersona(input.spec, {
+        ...writerOptions,
+        validationFeedback: {
+          errors: validation.errors,
+          previousContent: finalArtifact.content,
+        },
+      });
+      const repairedArtifact = applyPersonaArtifactToRenderedArtifact(artifact, repairResult);
+      const repairValidation = validateGeneratedArtifact(repairedArtifact, baseResult.patternDecision, baseResult.skillContext, input.spec);
+
+      if (repairValidation.valid) {
+        finalArtifact = repairedArtifact;
+        validation = repairValidation;
+        finalPersonaMetadata = {
+          ...repairResult.metadata,
+          warnings: [
+            ...repairResult.metadata.warnings,
+            'Ricky pre-write validation repaired the Workforce persona artifact before writing.',
+          ],
+        };
+      } else {
+        const fallbackMessage = `Ricky pre-write validation rejected the Workforce persona artifact after repair (${repairValidation.errors[0] ?? 'unknown validation error'}); used Ricky deterministic renderer instead.`;
+        const fallbackIssue = warningIssue('validation', 'WORKFORCE_PERSONA_PREWRITE_REPAIR_FALLBACK', fallbackMessage);
+        return {
+          ...baseResult,
+          success: true,
+          validation: addValidationWarning(baseResult.validation, fallbackIssue),
+          workforcePersona: {
+            ...repairResult.metadata,
+            warnings: [...repairResult.metadata.warnings, fallbackMessage],
+          },
+        };
+      }
+    }
+
     const plannedChecks = buildPlannedChecks(finalArtifact, input.dryRunEnabled !== false);
 
     return {
@@ -105,7 +144,7 @@ export async function generateWithWorkforcePersona(input: GenerationInput): Prom
         .filter((check) => check.stage !== 'dry_run')
         .map((check) => check.command),
       executionRoute: resolveExecutionRoute(input.spec, finalArtifact),
-      workforcePersona: personaResult.metadata,
+      workforcePersona: finalPersonaMetadata,
     };
   } catch (error) {
     const writerError = error instanceof WorkforcePersonaWriterError ? error : null;
@@ -503,5 +542,26 @@ function blockingIssue(stage: GenerationIssue['stage'], code: string, message: s
     code,
     message,
     blocking: true,
+  };
+}
+
+function warningIssue(stage: GenerationIssue['stage'], code: string, message: string): GenerationIssue {
+  return {
+    severity: 'warning',
+    stage,
+    code,
+    message,
+    blocking: false,
+  };
+}
+
+function addValidationWarning(
+  validation: GenerationValidationResult,
+  issue: GenerationIssue,
+): GenerationValidationResult {
+  return {
+    ...validation,
+    warnings: [...validation.warnings, issue.message],
+    issues: [...validation.issues, issue],
   };
 }

--- a/src/product/generation/workforce-persona-writer.test.ts
+++ b/src/product/generation/workforce-persona-writer.test.ts
@@ -198,6 +198,109 @@ describe('workforce persona workflow writer', () => {
     expect(errorText).toMatch(/workflow|persona|fenced|structured/i);
   });
 
+  it('runs pre-write validation and asks the persona to repair invalid workflow syntax before succeeding', async () => {
+    const base = generate({
+      spec: spec({
+        description: 'Implement a strict Agent Relay workflow with tests and review.',
+        targetFiles: ['src/product/generation/pipeline.ts'],
+      }),
+      artifactPath: 'workflows/generated/prewrite-repair.ts',
+    });
+    expect(base.success).toBe(true);
+    const tasks: string[] = [];
+    const resolver: WorkforcePersonaResolver = async () => ({
+      source: 'package',
+      intent: 'agent-relay-workflow',
+      warnings: [],
+      context: {
+        selection: {
+          personaId: 'agent-relay-workflow',
+          tier: 'best',
+          runtime: { harness: 'codex', model: 'codex/test' },
+        },
+        sendMessage(task) {
+          tasks.push(task);
+          const content = tasks.length === 1
+            ? `${base.artifact!.content}\n}`
+            : base.artifact!.content;
+          return execution(personaResponse('workflows/generated/prewrite-repair.ts', content));
+        },
+      },
+    });
+
+    const result = await generateWithWorkforcePersona({
+      spec: spec({
+        description: 'Implement a strict Agent Relay workflow with tests and review.',
+        targetFiles: ['src/product/generation/pipeline.ts'],
+      }),
+      artifactPath: 'workflows/generated/prewrite-repair.ts',
+      workforcePersonaWriter: {
+        repoRoot: '/repo',
+        workflowName: 'prewrite-repair',
+        targetMode: 'local',
+        resolver,
+      },
+    });
+
+    expect(result.success).toBe(true);
+    expect(result.artifact?.content).toBe(base.artifact!.content);
+    expect(tasks).toHaveLength(2);
+    expect(tasks[1]).toContain('Ricky pre-write validation failed');
+    expect(tasks[1]).toContain('Rendered artifact has unbalanced braces');
+    expect(tasks[1]).toContain('Previous rejected artifact');
+    expect(result.workforcePersona?.warnings).toContain(
+      'Ricky pre-write validation repaired the Workforce persona artifact before writing.',
+    );
+  });
+
+  it('falls back to Ricky deterministic rendering when persona pre-write repair is still invalid', async () => {
+    const base = generate({
+      spec: spec({
+        description: 'Implement a strict Agent Relay workflow with tests and review.',
+        targetFiles: ['src/product/generation/pipeline.ts'],
+      }),
+      artifactPath: 'workflows/generated/prewrite-fallback.ts',
+    });
+    expect(base.success).toBe(true);
+    const resolver: WorkforcePersonaResolver = async () => ({
+      source: 'package',
+      intent: 'agent-relay-workflow',
+      warnings: [],
+      context: {
+        selection: {
+          personaId: 'agent-relay-workflow',
+          tier: 'best',
+          runtime: { harness: 'codex', model: 'codex/test' },
+        },
+        sendMessage() {
+          return execution(personaResponse(
+            'workflows/generated/prewrite-fallback.ts',
+            `${base.artifact!.content}\n}`,
+          ));
+        },
+      },
+    });
+
+    const result = await generateWithWorkforcePersona({
+      spec: spec({
+        description: 'Implement a strict Agent Relay workflow with tests and review.',
+        targetFiles: ['src/product/generation/pipeline.ts'],
+      }),
+      artifactPath: 'workflows/generated/prewrite-fallback.ts',
+      workforcePersonaWriter: {
+        repoRoot: '/repo',
+        workflowName: 'prewrite-fallback',
+        targetMode: 'local',
+        resolver,
+      },
+    });
+
+    expect(result.success).toBe(true);
+    expect(result.artifact?.content).toBe(base.artifact!.content);
+    expect(result.validation.warnings.join('\n')).toContain('used Ricky deterministic renderer instead');
+    expect(result.workforcePersona?.warnings.join('\n')).toContain('used Ricky deterministic renderer instead');
+  });
+
   it('adapts harness-kit useRunnablePersona into the sendMessage context Ricky expects', async () => {
     const calls: Array<{ intent: string; options: Record<string, unknown> | undefined }> = [];
     const resolved = await resolveWorkforcePersonaContextWithModules(
@@ -475,6 +578,16 @@ function execution(output: string): WorkforcePersonaExecution {
   Object.defineProperty(promise, 'runId', { value: Promise.resolve('persona-run-001') });
   promise.cancel = () => {};
   return promise;
+}
+
+function personaResponse(path: string, content: string): string {
+  return JSON.stringify({
+    artifact: {
+      path,
+      content,
+    },
+    metadata: { workflowName: path.split('/').pop()?.replace(/\.ts$/, '') },
+  });
 }
 
 function workflowSource(): string {

--- a/src/product/generation/workforce-persona-writer.ts
+++ b/src/product/generation/workforce-persona-writer.ts
@@ -111,6 +111,10 @@ export interface WorkforcePersonaWriterOptions {
   personaIntentCandidates?: readonly string[];
   resolver?: WorkforcePersonaResolver;
   skillContext?: SkillContext;
+  validationFeedback?: {
+    errors: string[];
+    previousContent: string;
+  };
 }
 
 export interface WorkforcePersonaWriterMetadata {
@@ -189,6 +193,7 @@ export async function writeWorkflowWithWorkforcePersona(
     outputPath: options.outputPath,
     relevantFiles,
     skillContext: options.skillContext,
+    validationFeedback: options.validationFeedback,
   });
   const promptDigest = digest(task);
   const selection = resolved.context.selection;
@@ -439,6 +444,10 @@ export function buildWorkflowPersonaTask(
     outputPath: string;
     relevantFiles: Array<{ path: string; content?: string }>;
     skillContext?: SkillContext;
+    validationFeedback?: {
+      errors: string[];
+      previousContent: string;
+    };
   },
 ): string {
   const contract = {
@@ -492,6 +501,7 @@ export function buildWorkflowPersonaTask(
     'Matched Ricky generation skills:',
     renderSkillContextForPersona(input.skillContext),
     '',
+    ...renderValidationFeedbackForPersona(input.validationFeedback),
     'Agent Relay workflow standards:',
     '- Prefer TypeScript workflows using @agent-relay/sdk/workflows.',
     '- Choose `.pattern(...)` from the normalized spec and matched skill context: pipeline for linear stages, supervisor for coordinated review/hand-off, or dag for parallel branches and gated fan-out. When `choosing-swarm-patterns` is matched, use its decision framework before authoring tasks.',
@@ -528,6 +538,25 @@ export function buildWorkflowPersonaTask(
     'Structured response contract:',
     JSON.stringify(contract, null, 2),
   ].join('\n');
+}
+
+function renderValidationFeedbackForPersona(
+  feedback: { errors: string[]; previousContent: string } | undefined,
+): string[] {
+  if (!feedback) return [];
+  return [
+    'Ricky pre-write validation failed on your previous artifact.',
+    'Fix every validation issue before returning the complete replacement artifact.',
+    '',
+    'Validation errors:',
+    safeJson(feedback.errors),
+    '',
+    'Previous rejected artifact:',
+    '```ts',
+    feedback.previousContent.trimEnd(),
+    '```',
+    '',
+  ];
 }
 
 function renderSkillContextForPersona(skillContext: SkillContext | undefined): string {

--- a/src/surfaces/cli/commands/cli-main.test.ts
+++ b/src/surfaces/cli/commands/cli-main.test.ts
@@ -1202,6 +1202,7 @@ describe('cliMain', () => {
 
       expect(result.exitCode).toBe(0);
       expect(output).toContain('Generation: ok — workflows/generated/issue-3.ts');
+      expect(output).toContain('Workflow name: wf-issue-3');
       expect(output).toContain('Execution: success');
       expect(output).toContain('Stdout: /repo/.workflow-artifacts/ricky-local-runs/run-1/stdout.log');
       expect(output).toContain('Stderr: /repo/.workflow-artifacts/ricky-local-runs/run-1/stderr.log');
@@ -1236,6 +1237,7 @@ describe('cliMain', () => {
 
       const output = result.output.join('\n');
       expect(output).toContain('Generation: ok — workflows/generated/issue-3.ts');
+      expect(output).toContain('Workflow name: wf-issue-3');
       expect(output).toContain('Run: ricky run workflows/generated/issue-3.ts');
       expect(output).not.toContain('Author:');
     });
@@ -1263,6 +1265,7 @@ describe('cliMain', () => {
       const output = result.output.join('\n');
       expect(result.exitCode).toBe(0);
       expect(output).toContain('Generation: ok — workflows/generated/issue-3.ts');
+      expect(output).toContain('Workflow name: wf-issue-3');
       expect(output).toContain('Run: ricky run workflows/generated/issue-3.ts');
       expect(output).toContain('Background: ricky run workflows/generated/issue-3.ts --background');
       expect(output).not.toContain('--- execution ---');
@@ -1666,7 +1669,7 @@ describe('cliMain', () => {
       return spinner;
     });
     const runner = vi.fn(async (deps) => {
-      deps.localProgress?.('Writing workflow with Workforce persona...');
+      deps.localProgress?.('ricky is writing the workflow...');
       deps.localProgress?.('Ricky is fixing the workflow...');
       deps.localProgress?.('Retrying workflow from install-deps...');
       return fakeInteractiveResult({
@@ -1695,8 +1698,8 @@ describe('cliMain', () => {
 
     expect(createProgressSpinner).toHaveBeenCalledTimes(1);
     expect(events).toEqual([
-      'create:Writing workflow with Workforce persona...',
-      'start:Writing workflow with Workforce persona...',
+      'create:ricky is writing the workflow...',
+      'start:ricky is writing the workflow...',
       'text:Ricky is fixing the workflow...',
       'text:Retrying workflow from install-deps...',
       'stop:Retrying workflow from install-deps...',

--- a/src/surfaces/cli/commands/cli-main.ts
+++ b/src/surfaces/cli/commands/cli-main.ts
@@ -1809,12 +1809,15 @@ function renderLocalJson(localResult: NonNullable<InteractiveCliResult['localRes
 function renderLocalHuman(localResult: NonNullable<InteractiveCliResult['localResult']>): string[] {
   const lines: string[] = [];
   const artifactPath = localResult.generation?.artifact?.path ?? localResult.artifacts[0]?.path;
+  const workflowName = localResult.generation?.artifact?.workflow_id;
   if (localResult.ok) {
     if (localResult.execution?.status === 'success') {
       lines.push(`Generation: ok${artifactPath ? ` — ${artifactPath}` : ''}`);
+      if (workflowName) lines.push(`Workflow name: ${workflowName}`);
       lines.push(`Execution: success${localResult.execution.execution.run_id ? ` — run ${localResult.execution.execution.run_id}` : ''}`);
     } else if (localResult.generation) {
       lines.push(`Generation: ok${artifactPath ? ` — ${artifactPath}` : ''}`);
+      if (workflowName) lines.push(`Workflow name: ${workflowName}`);
       if (localResult.generation.next) {
         lines.push(`Run: ${localResult.generation.next.run_command}`);
         lines.push(`Background: ${localResult.generation.next.run_command} --background`);
@@ -1828,6 +1831,7 @@ function renderLocalHuman(localResult: NonNullable<InteractiveCliResult['localRe
   } else {
     if (localResult.execution) {
       lines.push(`Generation: ok${artifactPath ? ` — ${artifactPath}` : ''}`);
+      if (workflowName) lines.push(`Workflow name: ${workflowName}`);
       lines.push(executionFailureSummary(localResult));
       const resume = resumeCommandFor(localResult);
       if (resume) lines.push(`Resume: ${resume}`);


### PR DESCRIPTION
## Summary
- update the local generation spinner to say `ricky is writing the workflow...`
- validate persona-authored workflows before writing, retry with validation feedback, and fall back to Ricky's deterministic renderer if repair still fails
- print the generated workflow name in successful local CLI output

## Verification
- `npx vitest run src/surfaces/cli/commands/cli-main.test.ts src/product/generation/workforce-persona-writer.test.ts src/product/generation/pipeline.test.ts src/local/entrypoint.test.ts`
- `npm run typecheck`