### PR TITLE
Show workflow target on generation failures

### DIFF
--- a/src/local/entrypoint.ts
+++ b/src/local/entrypoint.ts
@@ -921,7 +921,7 @@ export function createLocalExecutor(options: LocalExecutorOptions = {}): LocalEx
 
         if (!generationResult.success || !artifact) {
           warnings.push(...generationResult.validation.errors);
-          nextActions.push('Fix the generated workflow validation errors before local execution.');
+          nextActions.push(nextActionForGenerationFailure(generationResult.validation.errors));
           generationStage = createGenerationStage(
             'error',
             artifact,
@@ -1445,6 +1445,12 @@ function createGenerationStage(
         }
       : decisionsForAssistantTurnContext(assistantTurnContext)),
   };
+}
+
+function nextActionForGenerationFailure(errors: string[]): string {
+  return errors.some((error) => /Workforce persona/i.test(error))
+    ? 'Fix the Workforce persona response contract before local execution.'
+    : 'Fix the generated workflow validation errors before local execution.';
 }
 
 async function writeGenerationMetadataArtifacts(

--- a/src/product/generation/workforce-persona-writer.test.ts
+++ b/src/product/generation/workforce-persona-writer.test.ts
@@ -1,4 +1,7 @@
 import { describe, expect, it } from 'vitest';
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
 
 import type { NormalizedWorkflowSpec, RawSpecPayload } from '../spec-intake/types.js';
 import { generate, generateWithWorkforcePersona } from './pipeline.js';
@@ -41,6 +44,7 @@ describe('workforce persona workflow writer', () => {
     expect(task).toContain('Evidence rules');
     expect(task).toContain('IMPLEMENTATION_WORKFLOW_CONTRACT');
     expect(task).toContain('must edit source files');
+    expect(task).toContain('Do not create, edit, or write outputPath directly');
     expect(task).toContain('Do not satisfy implementation specs by only writing plan.md');
     expect(task).toContain('Do not open an interactive Claude, Codex, or OpenCode terminal UI');
   });
@@ -99,6 +103,35 @@ describe('workforce persona workflow writer', () => {
     expect(parsed.responseFormat).toBe('fenced-artifact');
     expect(parsed.content).toContain('.run({ cwd: process.cwd() })');
     expect(parsed.metadata).toMatchObject({ workflowName: 'persona' });
+  });
+
+  it('recovers expected artifact content from disk when structured output omits inline content', () => {
+    const repoRoot = mkdtempSync(join(tmpdir(), 'ricky-persona-response-'));
+    const artifactPath = 'workflows/generated/persona.ts';
+    const absoluteArtifactPath = join(repoRoot, artifactPath);
+    mkdirSync(join(repoRoot, 'workflows/generated'), { recursive: true });
+    writeFileSync(absoluteArtifactPath, workflowSource(), 'utf8');
+
+    try {
+      const parsed = parsePersonaWorkflowResponse(JSON.stringify({
+        artifact: {
+          path: artifactPath,
+          language: 'typescript',
+          content: 'See artifact block above.',
+        },
+        metadata: {
+          workflowName: 'persona',
+          agents: ['lead'],
+        },
+      }), artifactPath, { repoRoot });
+
+      expect(parsed.responseFormat).toBe('structured-json');
+      expect(parsed.content).toContain('workflow("persona")');
+      expect(parsed.content).toContain('.run({ cwd: process.cwd() })');
+      expect(parsed.metadata).toMatchObject({ workflowName: 'persona' });
+    } finally {
+      rmSync(repoRoot, { recursive: true, force: true });
+    }
   });
 
   it('invokes the spawned harness non-interactively (no TUI flag, structured-response contract)', async () => {

--- a/src/product/generation/workforce-persona-writer.ts
+++ b/src/product/generation/workforce-persona-writer.ts
@@ -145,6 +145,11 @@ export interface WorkforcePersonaWriterResult {
   metadata: WorkforcePersonaWriterMetadata;
 }
 
+export interface PersonaResponseParseOptions {
+  repoRoot?: string;
+  readFileText?: (path: string) => string;
+}
+
 export interface ResolvedWorkforcePersonaContext {
   source: 'package';
   intent: string;
@@ -227,7 +232,9 @@ export async function writeWorkflowWithWorkforcePersona(
     );
   }
 
-  const parsed = parsePersonaWorkflowResponse(result.output, options.outputPath);
+  const parsed = parsePersonaWorkflowResponse(result.output, options.outputPath, {
+    repoRoot: options.repoRoot,
+  });
   return {
     artifact: {
       content: parsed.content,
@@ -519,6 +526,7 @@ export function buildWorkflowPersonaTask(
     '',
     'Constraints:',
     '- Produce only the workflow artifact and metadata contract.',
+    '- Do not create, edit, or write outputPath directly; Ricky writes the returned artifact after parsing artifact.content.',
     '- Do not commit, push, open PRs, or perform destructive file operations.',
     '- Do not open an interactive Claude, Codex, or OpenCode terminal UI.',
     '- Keep generated runtime-agent prompts model-agnostic.',
@@ -587,10 +595,14 @@ function renderSkillContextForPersona(skillContext: SkillContext | undefined): s
   ].filter(Boolean).join('\n');
 }
 
-export function parsePersonaWorkflowResponse(output: string, expectedPath: string): ParsedPersonaResponse {
+export function parsePersonaWorkflowResponse(
+  output: string,
+  expectedPath: string,
+  options: PersonaResponseParseOptions = {},
+): ParsedPersonaResponse {
   const directJson = parseJsonObject(output);
   if (directJson) {
-    return validateStructuredResponse(directJson, expectedPath, 'structured-json');
+    return validateStructuredResponse(directJson, expectedPath, 'structured-json', options);
   }
 
   const jsonFence = fencedBlock(output, 'json');
@@ -601,7 +613,7 @@ export function parsePersonaWorkflowResponse(output: string, expectedPath: strin
       return validateFencedResponse(tsFence, metadataJson, expectedPath);
     }
     if (metadataJson) {
-      return validateStructuredResponse(metadataJson, expectedPath, 'structured-json');
+      return validateStructuredResponse(metadataJson, expectedPath, 'structured-json', options);
     }
   }
 
@@ -631,24 +643,60 @@ function validateStructuredResponse(
   value: Record<string, unknown>,
   expectedPath: string,
   responseFormat: WorkforcePersonaWriterMetadata['responseFormat'],
+  options: PersonaResponseParseOptions,
 ): ParsedPersonaResponse {
   const artifact = isRecord(value.artifact) ? value.artifact : value;
-  const content = artifact.content;
+  const artifactPath = artifact.path;
+  const inlineContent = artifact.content;
+  const recoveredContent = recoverExpectedArtifactContent(artifactPath, expectedPath, options);
+  const content = typeof inlineContent === 'string' && inlineContent.trim().length > 0
+    ? inlineContent
+    : recoveredContent;
   if (typeof content !== 'string' || content.trim().length === 0) {
     throw new WorkforcePersonaWriterError('Workforce persona structured response is missing artifact.content.');
   }
-  validateArtifactContent(content);
 
-  const artifactPath = artifact.path;
   if (typeof artifactPath === 'string' && artifactPath !== expectedPath) {
     throw new WorkforcePersonaWriterError(
       `Workforce persona artifact path ${artifactPath} did not match expected output path ${expectedPath}.`,
     );
   }
+  try {
+    validateArtifactContent(content);
+  } catch (error) {
+    if (!recoveredContent || content === recoveredContent) throw error;
+    validateArtifactContent(recoveredContent);
+    const metadata = isRecord(value.metadata) ? value.metadata : {};
+    validateMetadata(metadata);
+    return { content: recoveredContent, metadata, responseFormat };
+  }
 
   const metadata = isRecord(value.metadata) ? value.metadata : {};
   validateMetadata(metadata);
   return { content, metadata, responseFormat };
+}
+
+function recoverExpectedArtifactContent(
+  artifactPath: unknown,
+  expectedPath: string,
+  options: PersonaResponseParseOptions,
+): string | undefined {
+  if (!options.repoRoot || typeof artifactPath !== 'string' || artifactPath !== expectedPath) {
+    return undefined;
+  }
+  const expectedResolved = isAbsolute(expectedPath)
+    ? expectedPath
+    : resolve(options.repoRoot, expectedPath);
+  const artifactResolved = isAbsolute(artifactPath)
+    ? artifactPath
+    : resolve(options.repoRoot, artifactPath);
+  if (artifactResolved !== expectedResolved) return undefined;
+
+  try {
+    return options.readFileText?.(artifactResolved) ?? readFileSync(artifactResolved, 'utf8');
+  } catch {
+    return undefined;
+  }
 }
 
 function validateFencedResponse(

--- a/src/surfaces/cli/commands/cli-main.test.ts
+++ b/src/surfaces/cli/commands/cli-main.test.ts
@@ -714,7 +714,7 @@ describe('cliMain', () => {
       ok: false,
       logs: ['[local] workflow generation: failed'],
       warnings: ['Workforce persona writer did not complete: failed.'],
-      nextActions: ['Fix the generated workflow validation errors before local execution.'],
+      nextActions: ['Fix the Workforce persona response contract before local execution.'],
       exitCode: 1,
       generation: {
         stage: 'generate',
@@ -768,7 +768,7 @@ describe('cliMain', () => {
     expect(output).toContain('Artifact written: no');
     expect(output).toContain('Workflow name: ricky-docs-audit');
     expect(output).toContain('Reason: WORKFORCE_PERSONA_WRITER_FAILED');
-    expect(output).toContain('Next: Fix the generated workflow validation errors before local execution.');
+    expect(output).toContain('Next: Fix the Workforce persona response contract before local execution.');
     expect(output).not.toContain('Local handoff failed.');
     expect(output).not.toContain('Run commands');
     expect(output).not.toContain('ricky status --run <run-id>');

--- a/src/surfaces/cli/commands/cli-main.test.ts
+++ b/src/surfaces/cli/commands/cli-main.test.ts
@@ -764,6 +764,9 @@ describe('cliMain', () => {
     expect(output).toContain('Status: failed — generation did not complete');
     expect(output).toContain('Author: Workforce persona writer failed before authoring completed');
     expect(output).toContain('Generation: failed (status: error).');
+    expect(output).toContain('Workflow target: workflows/generated/docs-audit.ts');
+    expect(output).toContain('Artifact written: no');
+    expect(output).toContain('Workflow name: ricky-docs-audit');
     expect(output).toContain('Reason: WORKFORCE_PERSONA_WRITER_FAILED');
     expect(output).toContain('Next: Fix the generated workflow validation errors before local execution.');
     expect(output).not.toContain('Local handoff failed.');

--- a/src/surfaces/cli/commands/cli-main.ts
+++ b/src/surfaces/cli/commands/cli-main.ts
@@ -1837,6 +1837,11 @@ function renderLocalHuman(localResult: NonNullable<InteractiveCliResult['localRe
       if (resume) lines.push(`Resume: ${resume}`);
     } else if (localResult.generation) {
       lines.push(`Generation: failed (status: ${localResult.generation.status}).`);
+      if (artifactPath) {
+        lines.push(`Workflow target: ${artifactPath}`);
+        lines.push('Artifact written: no');
+      }
+      if (workflowName) lines.push(`Workflow name: ${workflowName}`);
       if (localResult.generation.error) lines.push(`Reason: ${localResult.generation.error}`);
     } else {
       lines.push('Local handoff failed.');

--- a/src/surfaces/cli/flows/local-workflow-flow.test.ts
+++ b/src/surfaces/cli/flows/local-workflow-flow.test.ts
@@ -189,7 +189,7 @@ describe('local workflow flow', () => {
       }],
       logs: ['[local] workflow generation: failed'],
       warnings: ['Workforce persona writer did not complete: failed.'],
-      nextActions: ['Fix the generated workflow validation errors before local execution.'],
+      nextActions: ['Fix the Workforce persona response contract before local execution.'],
       generation: {
         stage: 'generate',
         status: 'error',


### PR DESCRIPTION
## Summary
- print the workflow target path when local generation fails after artifact selection
- make failed generation output explicit that no artifact was written by Ricky
- recover Workforce persona responses that omit inline artifact.content when the exact expected outputPath was written on disk
- make persona-contract failures suggest fixing the Workforce persona response contract instead of generic workflow validation

## Tests
- npx vitest run src/product/generation/workforce-persona-writer.test.ts src/surfaces/cli/commands/cli-main.test.ts src/surfaces/cli/flows/local-workflow-flow.test.ts
- npm run typecheck