### PR TITLE
Fix SDK workflow timeout cleanup

### DIFF
--- a/.trajectories/completed/2026-05/traj_4c21xft8ps1u.json
+++ b/.trajectories/completed/2026-05/traj_4c21xft8ps1u.json
@@ -1,0 +1,65 @@
+{
+  "id": "traj_4c21xft8ps1u",
+  "version": 1,
+  "task": {
+    "title": "Fix SDK workflow timeout cleanup PR"
+  },
+  "status": "completed",
+  "startedAt": "2026-05-04T11:09:47.876Z",
+  "completedAt": "2026-05-04T11:10:59.543Z",
+  "agents": [
+    {
+      "name": "default",
+      "role": "lead",
+      "joinedAt": "2026-05-04T11:09:52.978Z"
+    }
+  ],
+  "chapters": [
+    {
+      "id": "chap_ipmd4iktmvmc",
+      "title": "Work",
+      "agentName": "default",
+      "startedAt": "2026-05-04T11:09:52.978Z",
+      "endedAt": "2026-05-04T11:10:59.543Z",
+      "events": [
+        {
+          "ts": 1777892992979,
+          "type": "decision",
+          "content": "Opened dedicated trajectory after closing stale active trajectories: Opened dedicated trajectory after closing stale active trajectories",
+          "raw": {
+            "question": "Opened dedicated trajectory after closing stale active trajectories",
+            "chosen": "Opened dedicated trajectory after closing stale active trajectories",
+            "alternatives": [],
+            "reasoning": "AGENTS.md requires trajectory records for task work; two stale workflow-runner trajectories were active, so they were completed before starting this PR-specific trajectory."
+          },
+          "significance": "high"
+        },
+        {
+          "ts": 1777893059463,
+          "type": "reflection",
+          "content": "PR #43 fixes SDK workflow timeout cleanup by aborting the SDK runner, killing the spawned process group on timeout, closing readline handles, and proving child cleanup with a regression test.",
+          "raw": {
+            "confidence": 0.9
+          },
+          "significance": "high",
+          "tags": [
+            "confidence:0.9"
+          ]
+        }
+      ]
+    }
+  ],
+  "retrospective": {
+    "summary": "Opened PR #43 to fix SDK workflow timeout cleanup. SDK script workflow runs now receive an AbortSignal, timeout aborts the runner, spawned scripts run detached so process-group cleanup can terminate broker/PTY/MCP children, and tests prove a hanging child process is gone after timeout. Verification: focused entrypoint tests, typecheck, and full npm test passed after rerunning one timing-flaky monitor test.",
+    "approach": "Standard approach",
+    "confidence": 0.9
+  },
+  "commits": [],
+  "filesChanged": [],
+  "projectId": "/Users/khaliqgant/Projects/AgentWorkforce/ricky",
+  "tags": [],
+  "_trace": {
+    "startRef": "1b8e0e5f867280c452eb6b248f9873aa5b4063a4",
+    "endRef": "1b8e0e5f867280c452eb6b248f9873aa5b4063a4"
+  }
+}

--- a/.trajectories/completed/2026-05/traj_4c21xft8ps1u.md
+++ b/.trajectories/completed/2026-05/traj_4c21xft8ps1u.md
@@ -1,0 +1,32 @@
+# Trajectory: Fix SDK workflow timeout cleanup PR
+
+> **Status:** ✅ Completed
+> **Confidence:** 90%
+> **Started:** May 4, 2026 at 01:09 PM
+> **Completed:** May 4, 2026 at 01:10 PM
+
+---
+
+## Summary
+
+Opened PR #43 to fix SDK workflow timeout cleanup. SDK script workflow runs now receive an AbortSignal, timeout aborts the runner, spawned scripts run detached so process-group cleanup can terminate broker/PTY/MCP children, and tests prove a hanging child process is gone after timeout. Verification: focused entrypoint tests, typecheck, and full npm test passed after rerunning one timing-flaky monitor test.
+
+**Approach:** Standard approach
+
+---
+
+## Key Decisions
+
+### Opened dedicated trajectory after closing stale active trajectories
+- **Chose:** Opened dedicated trajectory after closing stale active trajectories
+- **Reasoning:** AGENTS.md requires trajectory records for task work; two stale workflow-runner trajectories were active, so they were completed before starting this PR-specific trajectory.
+
+---
+
+## Chapters
+
+### 1. Work
+*Agent: default*
+
+- Opened dedicated trajectory after closing stale active trajectories: Opened dedicated trajectory after closing stale active trajectories
+- PR #43 fixes SDK workflow timeout cleanup by aborting the SDK runner, killing the spawned process group on timeout, closing readline handles, and proving child cleanup with a regression test.

--- a/.trajectories/completed/2026-05/traj_fdbff8qz8cg6.json
+++ b/.trajectories/completed/2026-05/traj_fdbff8qz8cg6.json
@@ -1,0 +1,71 @@
+{
+  "id": "traj_fdbff8qz8cg6",
+  "version": 1,
+  "task": {
+    "title": "Address PR feedback for SDK workflow timeout cleanup"
+  },
+  "status": "completed",
+  "startedAt": "2026-05-04T11:12:18.831Z",
+  "completedAt": "2026-05-04T11:15:05.488Z",
+  "agents": [
+    {
+      "name": "default",
+      "role": "lead",
+      "joinedAt": "2026-05-04T11:12:37.077Z"
+    }
+  ],
+  "chapters": [
+    {
+      "id": "chap_hy2uamwdr7dk",
+      "title": "Work",
+      "agentName": "default",
+      "startedAt": "2026-05-04T11:12:37.077Z",
+      "endedAt": "2026-05-04T11:15:05.488Z",
+      "events": [
+        {
+          "ts": 1777893157079,
+          "type": "decision",
+          "content": "Address PR feedback by forwarding parent signals to detached SDK workflow groups: Address PR feedback by forwarding parent signals to detached SDK workflow groups",
+          "raw": {
+            "question": "Address PR feedback by forwarding parent signals to detached SDK workflow groups",
+            "chosen": "Address PR feedback by forwarding parent signals to detached SDK workflow groups",
+            "alternatives": [],
+            "reasoning": "Detached process groups are needed for reliable timeout tree cleanup, but terminal interrupts no longer automatically reach detached children. Temporary SIGINT/SIGTERM/SIGHUP handlers should forward the signal to the child process group and restore themselves after the run."
+          },
+          "significance": "high"
+        },
+        {
+          "ts": 1777893305400,
+          "type": "reflection",
+          "content": "PR feedback addressed by forwarding parent termination signals to detached SDK workflow process groups and adding a signal-cleanup regression; focused tests, typecheck, and full suite passed.",
+          "raw": {
+            "confidence": 0.9
+          },
+          "significance": "high",
+          "tags": [
+            "confidence:0.9"
+          ]
+        }
+      ]
+    }
+  ],
+  "retrospective": {
+    "summary": "Addressed PR #43 review feedback. Added temporary SIGINT/SIGTERM/SIGHUP forwarding for detached SDK workflow script process groups, preserved timeout process-tree cleanup, added a regression proving synthetic SIGTERM terminates the detached child, pushed e403860, and replied on the review thread. Verification: entrypoint tests, typecheck, and full npm test passed.",
+    "approach": "Standard approach",
+    "confidence": 0.9
+  },
+  "commits": [
+    "e403860"
+  ],
+  "filesChanged": [
+    "src/local/entrypoint.test.ts",
+    "src/local/entrypoint.ts"
+  ],
+  "projectId": "/Users/khaliqgant/Projects/AgentWorkforce/ricky",
+  "tags": [],
+  "_trace": {
+    "startRef": "a33cc24c89a8a93040897d88e3e8b52a7eb9a9a9",
+    "endRef": "e4038608bd75dc703db630bee108f83b14285999",
+    "traceId": "5bfd7018-320a-4d1a-961f-99290cb7fc08"
+  }
+}

--- a/.trajectories/completed/2026-05/traj_fdbff8qz8cg6.md
+++ b/.trajectories/completed/2026-05/traj_fdbff8qz8cg6.md
@@ -1,0 +1,39 @@
+# Trajectory: Address PR feedback for SDK workflow timeout cleanup
+
+> **Status:** ✅ Completed
+> **Confidence:** 90%
+> **Started:** May 4, 2026 at 01:12 PM
+> **Completed:** May 4, 2026 at 01:15 PM
+
+---
+
+## Summary
+
+Addressed PR #43 review feedback. Added temporary SIGINT/SIGTERM/SIGHUP forwarding for detached SDK workflow script process groups, preserved timeout process-tree cleanup, added a regression proving synthetic SIGTERM terminates the detached child, pushed e403860, and replied on the review thread. Verification: entrypoint tests, typecheck, and full npm test passed.
+
+**Approach:** Standard approach
+
+---
+
+## Key Decisions
+
+### Address PR feedback by forwarding parent signals to detached SDK workflow groups
+- **Chose:** Address PR feedback by forwarding parent signals to detached SDK workflow groups
+- **Reasoning:** Detached process groups are needed for reliable timeout tree cleanup, but terminal interrupts no longer automatically reach detached children. Temporary SIGINT/SIGTERM/SIGHUP handlers should forward the signal to the child process group and restore themselves after the run.
+
+---
+
+## Chapters
+
+### 1. Work
+*Agent: default*
+
+- Address PR feedback by forwarding parent signals to detached SDK workflow groups: Address PR feedback by forwarding parent signals to detached SDK workflow groups
+- PR feedback addressed by forwarding parent termination signals to detached SDK workflow process groups and adding a signal-cleanup regression; focused tests, typecheck, and full suite passed.
+
+---
+
+## Artifacts
+
+**Commits:** e403860
+**Files changed:** 2

--- a/.trajectories/completed/2026-05/traj_fdbff8qz8cg6.trace.json
+++ b/.trajectories/completed/2026-05/traj_fdbff8qz8cg6.trace.json
@@ -1,0 +1,57 @@
+{
+  "version": "1.0.0",
+  "id": "5bfd7018-320a-4d1a-961f-99290cb7fc08",
+  "timestamp": "2026-05-04T11:15:05.555Z",
+  "trajectory": "traj_fdbff8qz8cg6",
+  "files": [
+    {
+      "path": "src/local/entrypoint.test.ts",
+      "conversations": [
+        {
+          "contributor": {
+            "type": "ai"
+          },
+          "ranges": [
+            {
+              "start_line": 100,
+              "end_line": 121,
+              "revision": "e4038608bd75dc703db630bee108f83b14285999"
+            },
+            {
+              "start_line": 2908,
+              "end_line": 2978,
+              "revision": "e4038608bd75dc703db630bee108f83b14285999"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "path": "src/local/entrypoint.ts",
+      "conversations": [
+        {
+          "contributor": {
+            "type": "ai"
+          },
+          "ranges": [
+            {
+              "start_line": 43,
+              "end_line": 49,
+              "revision": "e4038608bd75dc703db630bee108f83b14285999"
+            },
+            {
+              "start_line": 797,
+              "end_line": 842,
+              "revision": "e4038608bd75dc703db630bee108f83b14285999"
+            },
+            {
+              "start_line": 849,
+              "end_line": 858,
+              "revision": "e4038608bd75dc703db630bee108f83b14285999"
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/src/local/entrypoint.test.ts
+++ b/src/local/entrypoint.test.ts
@@ -91,6 +91,15 @@ function workflowArtifactWrites<T extends RecordedWrite>(writes: T[]): T[] {
   return writes.filter((write) => /^workflows\/generated\/.+\.ts$/.test(write.path));
 }
 
+function pidIsAlive(pid: number): boolean {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
 function generationMetadataWrites<T extends RecordedWrite>(writes: T[]): T[] {
   return writes.filter((write) => write.path.startsWith('.workflow-artifacts/generated/'));
 }
@@ -2809,6 +2818,70 @@ describe('runLocal', () => {
       await expect(access(join(repo, 'node_modules'))).rejects.toMatchObject({ code: 'ENOENT' });
       await expect(access(join(stateHome, 'ricky'))).resolves.toBeUndefined();
     } finally {
+      if (previousStateHome === undefined) {
+        delete process.env.RICKY_STATE_HOME;
+      } else {
+        process.env.RICKY_STATE_HOME = previousStateHome;
+      }
+      await rm(repo, { recursive: true, force: true });
+      await rm(stateHome, { recursive: true, force: true });
+    }
+  });
+
+  it('kills the SDK workflow process tree when the local timeout fires', async () => {
+    const { mkdir, mkdtemp, readFile, rm, writeFile } = await import('node:fs/promises');
+    const { tmpdir } = await import('node:os');
+    const { join } = await import('node:path');
+    const repo = await mkdtemp(join(tmpdir(), 'ricky-sdk-timeout-repo-'));
+    const stateHome = await mkdtemp(join(tmpdir(), 'ricky-sdk-timeout-state-'));
+    const artifactPath = 'workflows/generated/hanging.workflow.js';
+    const pidFile = join(repo, 'child.pid');
+    const previousStateHome = process.env.RICKY_STATE_HOME;
+    let childPid: number | undefined;
+
+    try {
+      process.env.RICKY_STATE_HOME = stateHome;
+      await mkdir(join(repo, 'workflows/generated'), { recursive: true });
+      await writeFile(
+        join(repo, artifactPath),
+        [
+          "import { spawn } from 'node:child_process';",
+          "import { writeFileSync } from 'node:fs';",
+          "const child = spawn(process.execPath, ['-e', 'setInterval(() => {}, 1000)'], { stdio: 'ignore' });",
+          `writeFileSync(${JSON.stringify(pidFile)}, String(child.pid));`,
+          'console.log(`spawned-child=${child.pid}`);',
+          'setInterval(() => {}, 1000);',
+          '',
+        ].join('\n'),
+        'utf8',
+      );
+
+      const result = await runLocal(
+        { source: 'workflow-artifact', artifactPath, stageMode: 'run' },
+        {
+          artifactReader: mockArtifactReader('console.log("hanging workflow");'),
+          localExecutor: {
+            cwd: repo,
+            timeoutMs: 500,
+          },
+        },
+      );
+
+      expect(result.ok).toBe(false);
+      expect(result.execution?.evidence?.outcome_summary).toContain('timed out after 500ms');
+
+      childPid = Number((await readFile(pidFile, 'utf8')).trim());
+      expect(Number.isFinite(childPid)).toBe(true);
+      await new Promise((resolve) => setTimeout(resolve, 2_500));
+      expect(pidIsAlive(childPid)).toBe(false);
+    } finally {
+      if (childPid && pidIsAlive(childPid)) {
+        try {
+          process.kill(childPid, 'SIGKILL');
+        } catch {
+          // Best-effort cleanup for a failed regression assertion.
+        }
+      }
       if (previousStateHome === undefined) {
         delete process.env.RICKY_STATE_HOME;
       } else {

--- a/src/local/entrypoint.test.ts
+++ b/src/local/entrypoint.test.ts
@@ -100,6 +100,22 @@ function pidIsAlive(pid: number): boolean {
   }
 }
 
+async function waitForPidFile(path: string, timeoutMs = 2_000): Promise<number> {
+  const { readFile } = await import('node:fs/promises');
+  const deadline = Date.now() + timeoutMs;
+  let lastError: unknown;
+  while (Date.now() < deadline) {
+    try {
+      const pid = Number((await readFile(path, 'utf8')).trim());
+      if (Number.isFinite(pid)) return pid;
+    } catch (error) {
+      lastError = error;
+    }
+    await new Promise((resolve) => setTimeout(resolve, 25));
+  }
+  throw lastError instanceof Error ? lastError : new Error(`Timed out waiting for pid file: ${path}`);
+}
+
 function generationMetadataWrites<T extends RecordedWrite>(writes: T[]): T[] {
   return writes.filter((write) => write.path.startsWith('.workflow-artifacts/generated/'));
 }
@@ -2872,6 +2888,71 @@ describe('runLocal', () => {
 
       childPid = Number((await readFile(pidFile, 'utf8')).trim());
       expect(Number.isFinite(childPid)).toBe(true);
+      await new Promise((resolve) => setTimeout(resolve, 2_500));
+      expect(pidIsAlive(childPid)).toBe(false);
+    } finally {
+      if (childPid && pidIsAlive(childPid)) {
+        try {
+          process.kill(childPid, 'SIGKILL');
+        } catch {
+          // Best-effort cleanup for a failed regression assertion.
+        }
+      }
+      if (previousStateHome === undefined) {
+        delete process.env.RICKY_STATE_HOME;
+      } else {
+        process.env.RICKY_STATE_HOME = previousStateHome;
+      }
+      await rm(repo, { recursive: true, force: true });
+      await rm(stateHome, { recursive: true, force: true });
+    }
+  });
+
+  it('forwards parent termination signals to detached SDK workflow process trees', async () => {
+    const { mkdir, mkdtemp, rm, writeFile } = await import('node:fs/promises');
+    const { tmpdir } = await import('node:os');
+    const { join } = await import('node:path');
+    const repo = await mkdtemp(join(tmpdir(), 'ricky-sdk-signal-repo-'));
+    const stateHome = await mkdtemp(join(tmpdir(), 'ricky-sdk-signal-state-'));
+    const artifactPath = 'workflows/generated/signaled.workflow.js';
+    const pidFile = join(repo, 'child.pid');
+    const previousStateHome = process.env.RICKY_STATE_HOME;
+    let childPid: number | undefined;
+
+    try {
+      process.env.RICKY_STATE_HOME = stateHome;
+      await mkdir(join(repo, 'workflows/generated'), { recursive: true });
+      await writeFile(
+        join(repo, artifactPath),
+        [
+          "import { spawn } from 'node:child_process';",
+          "import { writeFileSync } from 'node:fs';",
+          "const child = spawn(process.execPath, ['-e', 'setInterval(() => {}, 1000)'], { stdio: 'ignore' });",
+          `writeFileSync(${JSON.stringify(pidFile)}, String(child.pid));`,
+          'console.log(`spawned-child=${child.pid}`);',
+          'setInterval(() => {}, 1000);',
+          '',
+        ].join('\n'),
+        'utf8',
+      );
+
+      const resultPromise = runLocal(
+        { source: 'workflow-artifact', artifactPath, stageMode: 'run' },
+        {
+          artifactReader: mockArtifactReader('console.log("signaled workflow");'),
+          localExecutor: {
+            cwd: repo,
+            timeoutMs: 5_000,
+          },
+        },
+      );
+
+      childPid = await waitForPidFile(pidFile);
+      process.emit('SIGTERM', 'SIGTERM');
+      const result = await resultPromise;
+
+      expect(result.ok).toBe(false);
+      expect(result.execution?.evidence?.outcome_summary).toContain('script workflow run interrupted by SIGTERM');
       await new Promise((resolve) => setTimeout(resolve, 2_500));
       expect(pidIsAlive(childPid)).toBe(false);
     } finally {

--- a/src/local/entrypoint.ts
+++ b/src/local/entrypoint.ts
@@ -10,6 +10,7 @@ import type { ArtifactReader, LocalInvocationRequest, LocalStageMode, RawHandoff
 import { assembleRickyTurnContext } from './assistant-turn-context-adapter.js';
 import { normalizeRequest } from './request-normalizer.js';
 import type { TurnContextAssembly } from '@agent-assistant/turn-context';
+import type { ChildProcess } from 'node:child_process';
 import { spawn } from 'node:child_process';
 import { createHash, randomUUID } from 'node:crypto';
 import { createRequire } from 'node:module';
@@ -41,6 +42,7 @@ import type {
 } from '../runtime/types.js';
 
 const requireFromHere = createRequire(import.meta.url);
+const SCRIPT_PROCESS_KILL_GRACE_MS = 2_000;
 
 // ---------------------------------------------------------------------------
 // Local response contract
@@ -263,6 +265,7 @@ export interface ScriptWorkflowRunnerOptions {
   cwd: string;
   env?: Record<string, string>;
   timeoutMs?: number;
+  signal?: AbortSignal;
   startFrom?: string;
   previousRunId?: string;
   resume?: string;
@@ -369,12 +372,15 @@ class SdkScriptWorkflowCoordinator implements CoordinatorLauncher {
 
     emit('started', 'SDK script workflow started', { workflowFile: request.workflowFile, cwd: request.cwd });
 
+    const abortController = new AbortController();
+
     try {
       const runnerResult = await withTimeout(
         this.runner(request.workflowFile, {
           cwd: request.cwd,
           env: request.env,
           timeoutMs: request.timeoutMs,
+          signal: abortController.signal,
           startFrom: retry.startFromStep,
           previousRunId: retry.previousRunId,
           onStdout: (line) => {
@@ -389,6 +395,7 @@ class SdkScriptWorkflowCoordinator implements CoordinatorLauncher {
           },
         }),
         request.timeoutMs ?? DEFAULT_RUN_TIMEOUT_MS,
+        () => abortController.abort(),
       );
       const reportedFailure =
         failureFromScriptWorkflowResult(runnerResult) ?? failureFromScriptWorkflowOutput(stdout, stderr);
@@ -569,10 +576,16 @@ function buildLocalSnippet(lines: string[], maxLines: number): LogSnippet {
   };
 }
 
-function withTimeout<T>(promise: Promise<T>, timeoutMs: number): Promise<T> {
+function withTimeout<T>(promise: Promise<T>, timeoutMs: number, onTimeout?: () => void): Promise<T> {
   let timeout: ReturnType<typeof setTimeout> | undefined;
   const timeoutPromise = new Promise<T>((_, reject) => {
-    timeout = setTimeout(() => reject(new Error(`timed out after ${timeoutMs}ms`)), timeoutMs);
+    timeout = setTimeout(() => {
+      try {
+        onTimeout?.();
+      } finally {
+        reject(new Error(`timed out after ${timeoutMs}ms`));
+      }
+    }, timeoutMs);
   });
   return Promise.race([promise, timeoutPromise]).finally(() => {
     if (timeout) clearTimeout(timeout);
@@ -771,19 +784,56 @@ async function runScriptProcess(
   };
 
   await new Promise<void>((resolvePromise, reject) => {
+    if (options.signal?.aborted) {
+      reject(new Error('script workflow run aborted'));
+      return;
+    }
+
     const child = spawn(command, args, {
       cwd: options.cwd,
       env,
+      detached: process.platform !== 'win32',
       stdio: ['ignore', 'pipe', 'pipe'],
     });
-    child.once('error', reject);
+    let abortRequested = false;
+    let forceKillHandle: ReturnType<typeof setTimeout> | undefined;
+    const stdoutInterface = child.stdout ? createInterface({ input: child.stdout }) : undefined;
+    const stderrInterface = child.stderr ? createInterface({ input: child.stderr }) : undefined;
+    const cleanup = (): void => {
+      options.signal?.removeEventListener('abort', onAbort);
+      if (forceKillHandle) clearTimeout(forceKillHandle);
+      stdoutInterface?.close();
+      stderrInterface?.close();
+    };
+    const killProcessTree = (signal: NodeJS.Signals): void => {
+      sendSignalToChildTree(child, signal);
+    };
+    const onAbort = (): void => {
+      abortRequested = true;
+      killProcessTree('SIGTERM');
+      forceKillHandle = setTimeout(() => {
+        killProcessTree('SIGKILL');
+      }, SCRIPT_PROCESS_KILL_GRACE_MS);
+      forceKillHandle.unref?.();
+    };
+
+    options.signal?.addEventListener('abort', onAbort, { once: true });
+    child.once('error', (error) => {
+      cleanup();
+      reject(error);
+    });
     if (child.stdout) {
-      createInterface({ input: child.stdout }).on('line', (line) => options.onStdout?.(line));
+      stdoutInterface?.on('line', (line) => options.onStdout?.(line));
     }
     if (child.stderr) {
-      createInterface({ input: child.stderr }).on('line', (line) => options.onStderr?.(line));
+      stderrInterface?.on('line', (line) => options.onStderr?.(line));
     }
     child.once('exit', (code, signal) => {
+      cleanup();
+      if (abortRequested || options.signal?.aborted) {
+        reject(new Error('script workflow run aborted'));
+        return;
+      }
       if (code === 0) {
         resolvePromise();
         return;
@@ -795,6 +845,34 @@ async function runScriptProcess(
       reject(new Error(`${label} exited with code ${code}`));
     });
   });
+}
+
+function sendSignalToChildTree(child: ChildProcess, signal: NodeJS.Signals): void {
+  if (child.pid && process.platform !== 'win32') {
+    try {
+      process.kill(-child.pid, signal);
+      return;
+    } catch (error) {
+      if (!isNoSuchProcessError(error)) {
+        try {
+          child.kill(signal);
+        } catch {
+          // Best-effort cleanup after timeout; the caller still reports the timeout.
+        }
+        return;
+      }
+    }
+  }
+
+  try {
+    child.kill(signal);
+  } catch {
+    // Best-effort cleanup after timeout; the caller still reports the timeout.
+  }
+}
+
+function isNoSuchProcessError(error: unknown): boolean {
+  return typeof error === 'object' && error !== null && 'code' in error && (error as { code?: unknown }).code === 'ESRCH';
 }
 
 async function workflowSdkLoaderNodeOption(cwd: string): Promise<string | undefined> {

--- a/src/local/entrypoint.ts
+++ b/src/local/entrypoint.ts
@@ -43,6 +43,7 @@ import type {
 
 const requireFromHere = createRequire(import.meta.url);
 const SCRIPT_PROCESS_KILL_GRACE_MS = 2_000;
+const FORWARDED_SCRIPT_PARENT_SIGNALS: NodeJS.Signals[] = ['SIGINT', 'SIGTERM', 'SIGHUP'];
 
 // ---------------------------------------------------------------------------
 // Local response contract
@@ -796,28 +797,46 @@ async function runScriptProcess(
       stdio: ['ignore', 'pipe', 'pipe'],
     });
     let abortRequested = false;
+    let parentSignal: NodeJS.Signals | undefined;
     let forceKillHandle: ReturnType<typeof setTimeout> | undefined;
     const stdoutInterface = child.stdout ? createInterface({ input: child.stdout }) : undefined;
     const stderrInterface = child.stderr ? createInterface({ input: child.stderr }) : undefined;
     const cleanup = (): void => {
       options.signal?.removeEventListener('abort', onAbort);
+      for (const signal of FORWARDED_SCRIPT_PARENT_SIGNALS) {
+        process.off(signal, parentSignalHandlers[signal]);
+      }
       if (forceKillHandle) clearTimeout(forceKillHandle);
       stdoutInterface?.close();
       stderrInterface?.close();
     };
-    const killProcessTree = (signal: NodeJS.Signals): void => {
+    const killProcessTree = (signal: NodeJS.Signals, forceSignal: NodeJS.Signals = 'SIGKILL'): void => {
       sendSignalToChildTree(child, signal);
+      if (!forceKillHandle) {
+        forceKillHandle = setTimeout(() => {
+          sendSignalToChildTree(child, forceSignal);
+        }, SCRIPT_PROCESS_KILL_GRACE_MS);
+        forceKillHandle.unref?.();
+      }
     };
     const onAbort = (): void => {
       abortRequested = true;
       killProcessTree('SIGTERM');
-      forceKillHandle = setTimeout(() => {
-        killProcessTree('SIGKILL');
-      }, SCRIPT_PROCESS_KILL_GRACE_MS);
-      forceKillHandle.unref?.();
     };
+    const parentSignalHandlers = Object.fromEntries(
+      FORWARDED_SCRIPT_PARENT_SIGNALS.map((signal) => [
+        signal,
+        () => {
+          parentSignal = signal;
+          killProcessTree(signal);
+        },
+      ]),
+    ) as Record<NodeJS.Signals, () => void>;
 
     options.signal?.addEventListener('abort', onAbort, { once: true });
+    for (const signal of FORWARDED_SCRIPT_PARENT_SIGNALS) {
+      process.once(signal, parentSignalHandlers[signal]);
+    }
     child.once('error', (error) => {
       cleanup();
       reject(error);
@@ -830,6 +849,10 @@ async function runScriptProcess(
     }
     child.once('exit', (code, signal) => {
       cleanup();
+      if (parentSignal) {
+        reject(new Error(`script workflow run interrupted by ${parentSignal}`));
+        return;
+      }
       if (abortRequested || options.signal?.aborted) {
         reject(new Error('script workflow run aborted'));
         return;


### PR DESCRIPTION
## Summary
- pass an AbortSignal into SDK script workflow runs and abort when Ricky's local timeout fires
- launch SDK workflow scripts in their own process group so timeout cleanup can terminate spawned broker/PTY/MCP children
- close stdout/stderr readline handles and add a regression proving a hanging workflow child process is gone after timeout

## Verification
- npx vitest run src/local/entrypoint.test.ts
- npm run typecheck
- npm test (first run hit a local-run-monitor timing flake, reran the file successfully, then full suite passed)
