### PR TITLE
fix(auto-fix): harden sentinel-guarded artifact rehydration

### DIFF
--- a/src/local/auto-fix-loop.test.ts
+++ b/src/local/auto-fix-loop.test.ts
@@ -285,6 +285,40 @@ describe('runWithAutoFix', () => {
     expect(repair?.content).not.toContain('NON_TRANSIENT=$(git diff --name-only | rg -v');
   });
 
+  it('deterministically hardens sentinel-guarded rehydration so corrupt artifacts get regenerated on retry', () => {
+    const repair = repairWorkflowDeterministically({
+      artifactPath: 'workflows/generated/sentinel-rehydration.ts',
+      artifactContent: sentinelGuardedRehydrationWorkflowContent(),
+      evidence: sentinelGuardedRehydrationFailureEvidence(),
+    });
+
+    expect(repair).toMatchObject({
+      applied: true,
+      mode: 'deterministic',
+      summary: expect.stringContaining("hardened sentinel-guarded rehydration for '${artifactDir}/final-review-claude.md'"),
+    });
+    expect(repair?.summary).toContain('marker: final_review_claude_pass');
+    expect(repair?.content).toContain(
+      `if [ ! -f '\${artifactDir}/final-review-claude.md' ] || ! tail -n 1 '\${artifactDir}/final-review-claude.md' | tr -d '[:space:]' | grep -qE '^final_review_claude_pass$'; then`,
+    );
+    expect(repair?.content).toContain(
+      `if [ ! -f '\${artifactDir}/final-review-codex.md' ] || ! tail -n 1 '\${artifactDir}/final-review-codex.md' | tr -d '[:space:]' | grep -qE '^final_review_codex_pass$'; then`,
+    );
+    expect(repair?.content).not.toMatch(
+      /if \[ ! -f '\$\{artifactDir\}\/final-review-claude\.md' \]; then/,
+    );
+  });
+
+  it('skips sentinel-guard hardening when no later tail-grep check references the same path and marker', () => {
+    const repair = repairWorkflowDeterministically({
+      artifactPath: 'workflows/generated/sentinel-no-check.ts',
+      artifactContent: sentinelGuardedRehydrationWithoutTailCheckContent(),
+      evidence: sentinelGuardedRehydrationFailureEvidence(),
+    });
+
+    expect(repair).toBeNull();
+  });
+
   it('persona repair failure escalates without retrying', async () => {
     const runSingleAttempt = vi.fn().mockResolvedValue(blockerResponse('MISSING_BINARY', 'run-1', 'install-deps'));
 
@@ -994,6 +1028,109 @@ function gitDiffManifestFailureEvidence(): WorkflowRunEvidence {
     logs: [{
       stream: 'stderr',
       excerpt: '[workflow] FAILED: Step "verify-non-empty-implementation-diff" failed: Command failed with exit code 1',
+    }],
+    narrative: [],
+    routing: [],
+  };
+}
+
+function sentinelGuardedRehydrationWorkflowContent(): string {
+  return [
+    "import { workflow } from '@agent-relay/sdk/workflows';",
+    '',
+    "const artifactDir = '.workflow-artifacts/generated/example';",
+    '',
+    "workflow('sentinel-rehydration')",
+    "  .step('final-review-pass-gate', {",
+    "    type: 'deterministic',",
+    '    command: `set -euo pipefail',
+    "mkdir -p '${artifactDir}'",
+    "if [ ! -f '${artifactDir}/final-review-claude.md' ]; then",
+    "  cat > '${artifactDir}/final-review-claude.md' <<'EOF'",
+    'Final review summary (claude)',
+    '- some content',
+    'final_review_claude_pass',
+    'EOF',
+    'fi',
+    "if [ ! -f '${artifactDir}/final-review-codex.md' ]; then",
+    "  cat > '${artifactDir}/final-review-codex.md' <<'EOF'",
+    'Final review summary (codex)',
+    '- some content',
+    'final_review_codex_pass',
+    'EOF',
+    'fi',
+    "tail -n 1 '${artifactDir}/final-review-claude.md' | tr -d '[:space:]' | grep -E '^final_review_claude_pass$'",
+    "tail -n 1 '${artifactDir}/final-review-codex.md' | tr -d '[:space:]' | grep -E '^final_review_codex_pass$'`,",
+    '    captureOutput: true,',
+    '    failOnError: true,',
+    '  })',
+    '  .run({ cwd: process.cwd() });',
+    '',
+  ].join('\n');
+}
+
+function sentinelGuardedRehydrationWithoutTailCheckContent(): string {
+  return [
+    "import { workflow } from '@agent-relay/sdk/workflows';",
+    '',
+    "const artifactDir = '.workflow-artifacts/generated/example';",
+    '',
+    "workflow('sentinel-no-check')",
+    "  .step('seed-readme', {",
+    "    type: 'deterministic',",
+    '    command: `set -euo pipefail',
+    "mkdir -p '${artifactDir}'",
+    "if [ ! -f '${artifactDir}/readme.md' ]; then",
+    "  cat > '${artifactDir}/readme.md' <<'EOF'",
+    'Seeded readme content',
+    'readme_seeded',
+    'EOF',
+    'fi',
+    "test -f '${artifactDir}/readme.md'`,",
+    '    captureOutput: true,',
+    '    failOnError: true,',
+    '  })',
+    '  .run({ cwd: process.cwd() });',
+    '',
+  ].join('\n');
+}
+
+function sentinelGuardedRehydrationFailureEvidence(): WorkflowRunEvidence {
+  return {
+    runId: 'sentinel-run-1',
+    workflowId: 'wf-sentinel-rehydration',
+    workflowName: 'sentinel-rehydration',
+    status: 'failed',
+    startedAt: '2026-05-04T00:00:00.000Z',
+    completedAt: '2026-05-04T00:00:08.000Z',
+    steps: [{
+      stepId: 'final-review-pass-gate',
+      stepName: 'final-review-pass-gate',
+      status: 'failed',
+      startedAt: '2026-05-04T00:00:07.000Z',
+      completedAt: '2026-05-04T00:00:08.000Z',
+      error: 'Command failed with exit code 1',
+      verifications: [{
+        type: 'exit_code',
+        passed: false,
+        expected: '0',
+        actual: '1',
+        message: 'Command failed with exit code 1',
+        command: "tail -n 1 '.workflow-artifacts/generated/example/final-review-claude.md' | tr -d '[:space:]' | grep -E '^final_review_claude_pass$'",
+        exitCode: 1,
+      }],
+      deterministicGates: [],
+      logs: [],
+      artifacts: [],
+      history: [],
+      retries: [],
+      narrative: [],
+    }],
+    deterministicGates: [],
+    artifacts: [{ path: 'workflows/generated/sentinel-rehydration.ts', kind: 'file' }],
+    logs: [{
+      stream: 'stderr',
+      excerpt: '[workflow] FAILED: Step "final-review-pass-gate" failed: Command failed with exit code 1',
     }],
     narrative: [],
     routing: [],

--- a/src/local/auto-fix-loop.ts
+++ b/src/local/auto-fix-loop.ts
@@ -533,7 +533,7 @@ function repairSentinelGuardedRehydration(content: string): { content: string; c
 
   const next = content.replace(guardPattern, (match, path: string, indent: string, body: string, marker: string) => {
     const sentinelCheckPattern = new RegExp(
-      `tail -n 1 '${escapeRegex(path)}'[^\\n]*\\| grep[^\\n]*'\\^${escapeRegex(marker)}\\$'`,
+      `tail -n 1 '${escapeRegExp(path)}'[^\\n]*\\| grep[^\\n]*'\\^${escapeRegExp(marker)}\\$'`,
     );
     if (!sentinelCheckPattern.test(content)) return match;
 
@@ -542,10 +542,6 @@ function repairSentinelGuardedRehydration(content: string): { content: string; c
   });
 
   return { content: next, changes: [...new Set(changes)] };
-}
-
-function escapeRegex(value: string): string {
-  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
 }
 
 function repairAgentStepTimeouts(content: string, evidence: WorkflowRunEvidence): { content: string; changes: string[] } {

--- a/src/local/auto-fix-loop.ts
+++ b/src/local/auto-fix-loop.ts
@@ -381,6 +381,12 @@ export function repairWorkflowDeterministically(
     changes.push(...gitDiffRepair.changes);
   }
 
+  const sentinelGuardRepair = repairSentinelGuardedRehydration(content);
+  if (sentinelGuardRepair.content !== content) {
+    content = sentinelGuardRepair.content;
+    changes.push(...sentinelGuardRepair.changes);
+  }
+
   if (content === input.artifactContent || changes.length === 0) return null;
 
   return {
@@ -516,6 +522,30 @@ function repairBareGitDiffManifestGates(content: string): { content: string; cha
   );
 
   return { content: next, changes: [...new Set(changes)] };
+}
+
+function repairSentinelGuardedRehydration(content: string): { content: string; changes: string[] } {
+  if (!content.includes("<<'EOF'") || !content.includes("tail -n 1")) return { content, changes: [] };
+
+  const changes: string[] = [];
+  const guardPattern =
+    /if \[ ! -f '([^']+)' \];\s*then\n([ \t]*)cat > '\1' <<'EOF'\n([\s\S]*?)\n([A-Za-z0-9_]+)\nEOF\n[ \t]*fi/g;
+
+  const next = content.replace(guardPattern, (match, path: string, indent: string, body: string, marker: string) => {
+    const sentinelCheckPattern = new RegExp(
+      `tail -n 1 '${escapeRegex(path)}'[^\\n]*\\| grep[^\\n]*'\\^${escapeRegex(marker)}\\$'`,
+    );
+    if (!sentinelCheckPattern.test(content)) return match;
+
+    changes.push(`hardened sentinel-guarded rehydration for '${path}' (marker: ${marker})`);
+    return `if [ ! -f '${path}' ] || ! tail -n 1 '${path}' | tr -d '[:space:]' | grep -qE '^${marker}$'; then\n${indent}cat > '${path}' <<'EOF'\n${body}\n${marker}\nEOF\n${indent}fi`;
+  });
+
+  return { content: next, changes: [...new Set(changes)] };
+}
+
+function escapeRegex(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
 }
 
 function repairAgentStepTimeouts(content: string, evidence: WorkflowRunEvidence): { content: string; changes: string[] } {


### PR DESCRIPTION
## Summary
Closes the auto-fix gap that left a sage workflow stuck on `INVALID_ARTIFACT at final-review-pass-gate` for all 7 retries (the recovery on https://github.com/AgentWorkforce/sage/pull/199 had to be done by hand).

Deterministic gates that lazily seed an artifact via `if [ ! -f '<path>' ]; then cat > '<path>' <<'EOF' ... <marker> EOF fi` followed later by `tail -n 1 '<path>' | tr -d '[:space:]' | grep -E '^<marker>$'` were unrecoverable when a *leftover* artifact from a prior run had trailing junk on its last line: the existence guard short-circuited, the heredoc never re-ran, and the auto-fix loop replayed the same guaranteed-to-fail command up to `maxAttempts`. None of the existing deterministic repairs (`repairAgentStepTimeouts`, `missingFileRepair*`, `repairOutputContainsEchoMismatches`, `repairUnknownStepTemplateRefs`, `repairBareGitDiffManifestGates`) inspect artifact content, and `workforce-persona-repairer` rewrites *workflow definitions*, not artifact bodies — so the loop made no progress.

## Fix
`repairWorkflowDeterministically` now detects this gate shape and rewrites the existence-only guard into a content-aware guard: `if [ ! -f '<path>' ] || ! tail -n 1 '<path>' | tr -d '[:space:]' | grep -qE '^<marker>$'; then` — which lets the next attempt regenerate the corrupt artifact and clear the gate.

The repair only fires when a matching `tail -n 1 '<path>' | ... grep '^<marker>$'` check exists elsewhere in the same workflow source. Unrelated `if [ ! -f ]` seed blocks (e.g. one-shot README seeders) are left alone; a skip-test in the suite asserts this.

## End-to-end smoke
With a corrupted leftover artifact whose last line is the heredoc-bleed garbage seen in the original sage failure:
- Old guard: exit 1 (the original bug).
- Hardened guard: regenerates the file, gate passes.

## Test plan
- [x] `npx tsc --noEmit` clean
- [x] `npx vitest run src/local/auto-fix-loop.test.ts` — 15/15 (13 existing + 2 new)
- [x] `npx vitest run` — 826/826 across 43 files
- [x] Manual bash smoke comparing old vs hardened guard against a corrupted artifact

## Out of scope (follow-up)
The corruption *itself* — a newline between `EOF` and the trailing tail-check getting joined to ` && ` somewhere in the pipeline — is a separate bug, almost certainly in command-string assembly when a heredoc-containing multi-line shell command is flattened. This PR only closes the recovery gap; happy to file a follow-up once the joiner is identified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
