### PR TITLE
fix: accept formatted persona workflow run cwd

### DIFF
--- a/src/product/generation/workforce-persona-writer.test.ts
+++ b/src/product/generation/workforce-persona-writer.test.ts
@@ -105,6 +105,36 @@ describe('workforce persona workflow writer', () => {
     expect(parsed.metadata).toMatchObject({ workflowName: 'persona' });
   });
 
+  it('accepts multiline run options when cwd is explicit', () => {
+    const parsed = parsePersonaWorkflowResponse(JSON.stringify({
+      artifact: {
+        path: 'workflows/generated/persona.ts',
+        content: multilineRunSource(),
+      },
+      metadata: {
+        workflowName: 'persona',
+        agents: ['lead'],
+      },
+    }), 'workflows/generated/persona.ts');
+
+    expect(parsed.responseFormat).toBe('structured-json');
+    expect(parsed.content).toContain('cwd: process.cwd()');
+    expect(parsed.metadata).toMatchObject({ workflowName: 'persona' });
+  });
+
+  it('still rejects persona artifacts that run without an explicit cwd', () => {
+    expect(() => parsePersonaWorkflowResponse(JSON.stringify({
+      artifact: {
+        path: 'workflows/generated/persona.ts',
+        content: workflowSource().replace('.run({ cwd: process.cwd() });', '.run();'),
+      },
+      metadata: {
+        workflowName: 'persona',
+        agents: ['lead'],
+      },
+    }), 'workflows/generated/persona.ts')).toThrow(/explicit cwd/);
+  });
+
   it('recovers expected artifact content from disk when structured output omits inline content', () => {
     const repoRoot = mkdtempSync(join(tmpdir(), 'ricky-persona-response-'));
     const artifactPath = 'workflows/generated/persona.ts';
@@ -642,6 +672,18 @@ function workflowSource(): string {
     '});',
     '',
   ].join('\n');
+}
+
+function multilineRunSource(): string {
+  return workflowSource().replace(
+    '    .run({ cwd: process.cwd() });',
+    [
+      '    .run({',
+      '      cwd: process.cwd(),',
+      '      timeoutMs: 120000,',
+      '    });',
+    ].join('\n'),
+  );
 }
 
 function spec(overrides: { description?: string; targetFiles?: string[] } = {}): NormalizedWorkflowSpec {

--- a/src/product/generation/workforce-persona-writer.ts
+++ b/src/product/generation/workforce-persona-writer.ts
@@ -723,9 +723,13 @@ function validateArtifactContent(content: string): void {
   if (!/\bworkflow\(/.test(content)) {
     throw new WorkforcePersonaWriterError('Workforce persona artifact does not call workflow().');
   }
-  if (!/\.run\(\{ cwd: process\.cwd\(\) \}\)/.test(content)) {
+  if (!hasExplicitRunCwd(content)) {
     throw new WorkforcePersonaWriterError('Workforce persona artifact must run with explicit cwd.');
   }
+}
+
+function hasExplicitRunCwd(content: string): boolean {
+  return /\.run\s*\(\s*\{[\s\S]*?\bcwd\s*:\s*process\.cwd\s*\(\s*\)[\s\S]*?\}\s*\)/.test(content);
 }
 
 function validateMetadata(metadata: Record<string, unknown>): void {


### PR DESCRIPTION
## Summary

- Loosens Workforce persona artifact validation so valid multiline `.run({ cwd: process.cwd(), ... })` options pass pre-write validation.
- Keeps rejecting generated workflows that omit an explicit cwd.
- Adds regression coverage for the multiline run options form that can be emitted by the persona writer.

## Why

A local generation failed before writing the artifact with `Workforce persona artifact must run with explicit cwd`, then `ricky run workflows/generated/...` failed because the artifact was never created. The validator was checking for one exact single-line string instead of the semantic requirement.

## Verification

- npm test -- src/product/generation/workforce-persona-writer.test.ts
- npm run typecheck