### PR TITLE
fix: stop auto-fix retries for setup blockers

### DIFF
--- a/src/local/auto-fix-loop.test.ts
+++ b/src/local/auto-fix-loop.test.ts
@@ -357,7 +357,7 @@ describe('runWithAutoFix', () => {
   it('uses the persona repair path even when the debugger recommends guided repair', async () => {
     const runSingleAttempt = vi
       .fn()
-      .mockResolvedValueOnce(blockerResponse('MISSING_ENV_VAR', 'run-1', 'runtime-launch'))
+      .mockResolvedValueOnce(blockerResponse('INVALID_ARTIFACT', 'run-1', 'runtime-launch'))
       .mockResolvedValueOnce(successResponse('run-2'));
     const workflowRepairer = vi.fn().mockResolvedValue(workflowRepair('guided repair workflow'));
 
@@ -373,6 +373,40 @@ describe('runWithAutoFix', () => {
     expect(runSingleAttempt).toHaveBeenCalledTimes(2);
     expect(workflowRepairer).toHaveBeenCalledTimes(1);
     expect(result.ok).toBe(true);
+  });
+
+  it('does not auto-repair missing environment prerequisites', async () => {
+    const runSingleAttempt = vi
+      .fn()
+      .mockResolvedValue(blockerResponse('MISSING_ENV_VAR', 'run-1', 'runtime-launch'));
+    const workflowRepairer = vi.fn().mockResolvedValue(workflowRepair('should not run'));
+
+    const result = await runWithAutoFix(baseRequest, {
+      maxAttempts: 7,
+      runSingleAttempt,
+      classifyFailure: fakeClassification,
+      debugWorkflowRun: guidedDebugger,
+      workflowRepairer,
+      artifactWriter: vi.fn().mockResolvedValue(undefined),
+    });
+
+    expect(runSingleAttempt).toHaveBeenCalledTimes(1);
+    expect(workflowRepairer).not.toHaveBeenCalled();
+    expect(result.ok).toBe(false);
+    expect(result.auto_fix).toMatchObject({
+      max_attempts: 7,
+      final_status: 'blocker',
+      resumed: false,
+      attempts: [
+        expect.objectContaining({
+          attempt: 1,
+          blocker_code: 'MISSING_ENV_VAR',
+          fix_error: 'external setup blocker; no safe automatic workflow repair',
+        }),
+      ],
+    });
+    expect(result.auto_fix?.escalation?.summary).toContain('environment or credentials prerequisite');
+    expect(result.nextActions.join('\n')).toContain('Set TEST_TOKEN before retrying.');
   });
 
   it('routes semantic workflow failures to persona repair instead of deterministic repair', async () => {

--- a/src/local/auto-fix-loop.ts
+++ b/src/local/auto-fix-loop.ts
@@ -128,6 +128,28 @@ export async function runWithAutoFix(
     };
     attempts.push(attemptSummary);
 
+    if (isExternalSetupBlocker(blockerCode)) {
+      attemptSummary.fix_error = 'external setup blocker; no safe automatic workflow repair';
+      const classification = classifyFailure(evidence);
+      const debuggerResult = debugWorkflowRun({ evidence, classification });
+      const escalated = withAutoFix(response, maxAttempts, attempts, attemptSummary.status, warnings, trackingRunId);
+      escalated.nextActions = [
+        ...escalated.nextActions,
+        debuggerResult.summary,
+        ...debuggerResult.recommendation.steps.map((step) => step.description),
+      ];
+      attachEscalationOptions(escalated, {
+        request: currentRequest,
+        response,
+        debuggerResult,
+        reason: 'The blocker is an environment or credentials prerequisite outside Ricky\'s safe auto-fix scope.',
+        trackingRunId,
+        artifactPath: resolveArtifactPath(currentRequest, response),
+        ...(failedStep ? { failedStep } : {}),
+      });
+      return escalated;
+    }
+
     if (attempt >= maxAttempts) {
       return withAutoFix(response, maxAttempts, attempts, attemptSummary.status, warnings, trackingRunId);
     }
@@ -302,6 +324,10 @@ export async function runWithAutoFix(
 
 function isV1DirectBlocker(code: string | undefined): boolean {
   return code === 'MISSING_BINARY' || code === 'NETWORK_TRANSIENT';
+}
+
+function isExternalSetupBlocker(code: string | undefined): boolean {
+  return code === 'MISSING_ENV_VAR' || code === 'CREDENTIALS_REJECTED' || code === 'WORKDIR_DIRTY';
 }
 
 async function defaultWorkflowRepairer(input: WorkflowRepairInput): Promise<WorkflowRepairResult> {


### PR DESCRIPTION
## Summary

- Stops the auto-fix loop immediately for external setup blockers: `MISSING_ENV_VAR`, `CREDENTIALS_REJECTED`, and `WORKDIR_DIRTY`.
- Preserves escalation details and recovery steps instead of spending every retry on persona workflow repair.
- Keeps persona repair coverage for actual workflow/artifact blockers.

## Why

A Ricky local run exhausted 7/7 auto-fix attempts on `MISSING_ENV_VAR` at `runtime-launch`. Missing env/config is not safely patchable by rewriting the generated workflow, so Ricky should surface the setup blocker directly.

## Verification

- npm test -- src/local/auto-fix-loop.test.ts
- npm run typecheck