### PR TITLE
fix: exclude prpm-managed Claude skills from legacy mirror proof

### DIFF
--- a/test/flat-layout-proof/flat-layout-proof.test.ts
+++ b/test/flat-layout-proof/flat-layout-proof.test.ts
@@ -81,7 +81,7 @@ describe('Ricky flat src layout proof', () => {
     [
       'legacy-claude-skill-mirror-removed',
       [
-        'legacy Claude skill mirrors checked: 3',
+        'legacy Claude skill mirrors checked:',
         'legacy Claude skill mirrors present: 0',
         'prpm.lock references legacy Claude skill mirrors: 0',
         'active references to legacy Claude skill mirrors: 0',

--- a/test/flat-layout-proof/flat-layout-proof.ts
+++ b/test/flat-layout-proof/flat-layout-proof.ts
@@ -267,11 +267,29 @@ function obsoleteRuntimeDebugWorkflows(): string[] {
 }
 
 function legacyClaudeSkillMirrorArtifacts(): string[] {
-  return [
+  const candidates = [
     ['.claude', 'skills', 'choosing-swarm-patterns', 'SKILL.md'].join('/'),
     ['.claude', 'skills', 'writing-agent-relay-workflows', 'SKILL.md'].join('/'),
     ['.claude', 'skills', 'relay-80-100-workflow', 'SKILL.md'].join('/'),
   ];
+  const prpmManagedClaudeSkillPaths = new Set(prpmLockInstalledPaths());
+  return candidates.filter((file) => !prpmManagedClaudeSkillPaths.has(file));
+}
+
+function prpmLockInstalledPaths(): string[] {
+  if (!fileExists('prpm.lock')) {
+    return [];
+  }
+  let lock: { packages?: Record<string, { installedPath?: string }> };
+  try {
+    lock = readJson<{ packages?: Record<string, { installedPath?: string }> }>('prpm.lock');
+  } catch {
+    return [];
+  }
+  const packages = lock.packages ?? {};
+  return Object.values(packages)
+    .map((entry) => entry?.installedPath)
+    .filter((value): value is string => typeof value === 'string' && value.length > 0);
 }
 
 function textFileForReferenceScan(file: string): boolean {


### PR DESCRIPTION
## Summary
- The `legacy-claude-skill-mirror-removed` flat-layout proof case treated every `.claude/skills/.../SKILL.md` path as a legacy mirror, but prpm now installs Claude-format skills (e.g. `@agent-relay/writing-agent-relay-workflows#claude`) into `.claude/skills/...` as a legitimate target.
- After commit `e57486e skill update` re-introduced that prpm-managed file, the proof fired falsely and broke CI.
- Filter the legacy candidate set against `prpm.lock`'s declared `installedPath` values so prpm-managed installs are no longer flagged. Adjust the per-case test expectation so it no longer hard-codes the static count of `3`.

## Test plan
- [x] `npx vitest run test/flat-layout-proof/flat-layout-proof.test.ts` (18/18 pass)
- [x] `npx vitest run` full suite (830/830 pass)

🤖 Generated with [Claude Code](https://claude.com/claude-code)