### PR TITLE
Improve missing-env workflow recovery

### DIFF
--- a/src/local/auto-fix-loop.test.ts
+++ b/src/local/auto-fix-loop.test.ts
@@ -375,11 +375,12 @@ describe('runWithAutoFix', () => {
     expect(result.ok).toBe(true);
   });
 
-  it('does not auto-repair missing environment prerequisites', async () => {
+  it('repairs missing environment prerequisites in the workflow artifact before retrying', async () => {
     const runSingleAttempt = vi
       .fn()
-      .mockResolvedValue(blockerResponse('MISSING_ENV_VAR', 'run-1', 'runtime-launch'));
-    const workflowRepairer = vi.fn().mockResolvedValue(workflowRepair('should not run'));
+      .mockResolvedValueOnce(blockerResponse('MISSING_ENV_VAR', 'run-1', 'runtime-launch'))
+      .mockResolvedValueOnce(successResponse('run-2'));
+    const workflowRepairer = vi.fn().mockResolvedValue(workflowRepair('repaired env workflow'));
 
     const result = await runWithAutoFix(baseRequest, {
       maxAttempts: 7,
@@ -390,23 +391,58 @@ describe('runWithAutoFix', () => {
       artifactWriter: vi.fn().mockResolvedValue(undefined),
     });
 
-    expect(runSingleAttempt).toHaveBeenCalledTimes(1);
-    expect(workflowRepairer).not.toHaveBeenCalled();
-    expect(result.ok).toBe(false);
+    expect(runSingleAttempt).toHaveBeenCalledTimes(2);
+    expect(workflowRepairer).toHaveBeenCalledWith(expect.objectContaining({
+      failedStep: 'runtime-launch',
+      runId: 'run-1',
+      response: expect.objectContaining({
+        execution: expect.objectContaining({
+          blocker: expect.objectContaining({ code: 'MISSING_ENV_VAR' }),
+        }),
+      }),
+    }));
+    expect(runSingleAttempt.mock.calls[1][0].retry).toMatchObject({
+      previousRunId: 'run-1',
+      retryOfRunId: 'run-1',
+      startFromStep: 'runtime-launch',
+    });
+    expect(result.ok).toBe(true);
     expect(result.auto_fix).toMatchObject({
       max_attempts: 7,
-      final_status: 'blocker',
-      resumed: false,
+      final_status: 'ok',
       attempts: [
         expect.objectContaining({
           attempt: 1,
           blocker_code: 'MISSING_ENV_VAR',
-          fix_error: 'external setup blocker; no safe automatic workflow repair',
+          applied_fix: expect.objectContaining({
+            mode: 'workforce-persona',
+            summary: 'persona patched the workflow',
+          }),
         }),
+        expect.objectContaining({ attempt: 2, status: 'ok', run_id: 'run-2' }),
       ],
     });
-    expect(result.auto_fix?.escalation?.summary).toContain('environment or credentials prerequisite');
-    expect(result.nextActions.join('\n')).toContain('Set TEST_TOKEN before retrying.');
+  });
+
+  it('deterministically adds env loading and fast assertions for missing env failures', () => {
+    const repair = repairWorkflowDeterministically({
+      artifactPath: 'workflows/generated/foo.ts',
+      artifactContent: workflowContent(),
+      evidence: missingEnvEvidence(),
+      response: blockerResponse('MISSING_ENV_VAR', 'run-1', 'runtime-launch'),
+    });
+
+    expect(repair).toMatchObject({
+      applied: true,
+      mode: 'deterministic',
+      summary: expect.stringContaining('repo-local .env loader'),
+    });
+    expect(repair?.content).toContain('RICKY_WORKFLOW_ENV_LOADER');
+    expect(repair?.content).toContain("import * as rickyWorkflowFs from 'node:fs';");
+    expect(repair?.content).toContain("import * as rickyWorkflowPath from 'node:path';");
+    expect(repair?.content).toContain('loadRickyWorkflowEnv();');
+    expect(repair?.content).toContain('assertRickyWorkflowEnv(["TEST_TOKEN"]);');
+    expect(repair?.content).toContain('MISSING_ENV_VAR:');
   });
 
   it('routes semantic workflow failures to persona repair instead of deterministic repair', async () => {
@@ -886,6 +922,39 @@ function workflowRepair(content: string) {
 
 function workflowContent(): string {
   return 'import { workflow } from "@agent-relay/sdk/workflows";\nworkflow("foo").run({ cwd: process.cwd() });\n';
+}
+
+function missingEnvEvidence(): WorkflowRunEvidence {
+  return {
+    runId: 'run-1',
+    workflowId: 'wf-1',
+    workflowName: 'foo',
+    status: 'failed',
+    startedAt: '2026-04-28T00:00:00.000Z',
+    completedAt: '2026-04-28T00:00:01.000Z',
+    steps: [
+      {
+        stepId: 'runtime-launch',
+        stepName: 'runtime-launch',
+        status: 'failed',
+        startedAt: '2026-04-28T00:00:00.000Z',
+        completedAt: '2026-04-28T00:00:01.000Z',
+        error: 'MISSING_ENV_VAR: TEST_TOKEN',
+        verifications: [],
+        deterministicGates: [],
+        logs: [{ stream: 'stderr', excerpt: 'MISSING_ENV_VAR: TEST_TOKEN' }],
+        artifacts: [],
+        history: [],
+        retries: [],
+        narrative: [],
+      },
+    ],
+    deterministicGates: [],
+    artifacts: [{ path: 'workflows/generated/foo.ts', kind: 'file' }],
+    logs: [{ stream: 'stderr', excerpt: 'MISSING_ENV_VAR: TEST_TOKEN' }],
+    narrative: [],
+    routing: [],
+  };
 }
 
 function demoArtifactDir(): string {

--- a/src/local/auto-fix-loop.ts
+++ b/src/local/auto-fix-loop.ts
@@ -327,7 +327,7 @@ function isV1DirectBlocker(code: string | undefined): boolean {
 }
 
 function isExternalSetupBlocker(code: string | undefined): boolean {
-  return code === 'MISSING_ENV_VAR' || code === 'CREDENTIALS_REJECTED' || code === 'WORKDIR_DIRTY';
+  return code === 'CREDENTIALS_REJECTED' || code === 'WORKDIR_DIRTY';
 }
 
 async function defaultWorkflowRepairer(input: WorkflowRepairInput): Promise<WorkflowRepairResult> {
@@ -367,11 +367,17 @@ async function defaultWorkflowRepairer(input: WorkflowRepairInput): Promise<Work
 }
 
 export function repairWorkflowDeterministically(
-  input: Pick<WorkflowRepairInput, 'artifactPath' | 'artifactContent' | 'evidence'>,
+  input: Pick<WorkflowRepairInput, 'artifactPath' | 'artifactContent' | 'evidence'> & Partial<Pick<WorkflowRepairInput, 'response'>>,
   personaError?: unknown,
 ): WorkflowRepairResult | null {
   let content = input.artifactContent;
   const changes: string[] = [];
+
+  const envRepair = repairMissingEnvVarPreflight(content, input.evidence, input.response);
+  if (envRepair.content !== content) {
+    content = envRepair.content;
+    changes.push(...envRepair.changes);
+  }
 
   const timeoutRepair = repairAgentStepTimeouts(content, input.evidence);
   if (timeoutRepair.content !== content) {
@@ -425,6 +431,186 @@ export function repairWorkflowDeterministically(
       ? [`Workforce persona repair unavailable (${errorMessage(personaError)}); used deterministic workflow repair fallback.`]
       : ['Used deterministic workflow repair fallback.'],
   };
+}
+
+function repairMissingEnvVarPreflight(
+  content: string,
+  evidence: WorkflowRunEvidence,
+  response?: LocalResponse,
+): { content: string; changes: string[] } {
+  if (!isMissingEnvVarFailure(evidence, response)) return { content, changes: [] };
+
+  const requiredEnvVars = missingEnvVarsFromFailure(evidence, response);
+  const next = injectWorkflowEnvLoader(content, requiredEnvVars);
+  if (next === content) return { content, changes: [] };
+
+  const assertion = requiredEnvVars.length > 0
+    ? ` and fast assertion for ${requiredEnvVars.join(', ')}`
+    : '';
+  return {
+    content: next,
+    changes: [`added repo-local .env loader${assertion}`],
+  };
+}
+
+function isMissingEnvVarFailure(evidence: WorkflowRunEvidence, response?: LocalResponse): boolean {
+  if (response?.execution?.blocker?.code === 'MISSING_ENV_VAR') return true;
+  const text = workflowFailureText(evidence);
+  return /\bMISSING_ENV_VAR\b|(?:missing|required).*(?:env|environment)|not set/i.test(text);
+}
+
+function missingEnvVarsFromFailure(evidence: WorkflowRunEvidence, response?: LocalResponse): string[] {
+  const names = new Set<string>();
+  for (const name of response?.execution?.blocker?.context.missing ?? []) {
+    if (isConcreteEnvVarName(name)) names.add(name);
+  }
+
+  const text = workflowFailureText(evidence);
+  const patterns = [
+    /\bMISSING_ENV_VAR:\s*([A-Z][A-Z0-9_]*(?:\s*,\s*[A-Z][A-Z0-9_]*)*)/g,
+    /(?:env(?:ironment)?(?:\s+variable)?|variable)\s+['"`]?([A-Z][A-Z0-9_]{2,})['"`]?/gi,
+    /\b([A-Z][A-Z0-9_]{2,})\b\s+(?:is\s+)?(?:missing|required|not\s+set|unset)/gi,
+    /(?:missing|required|not\s+set|unset)[^A-Z\n]{0,80}\b([A-Z][A-Z0-9_]{2,})\b/gi,
+  ];
+  for (const pattern of patterns) {
+    for (const match of text.matchAll(pattern)) {
+      const value = match[1] ?? '';
+      for (const name of value.split(/\s*,\s*/)) {
+        if (isConcreteEnvVarName(name)) names.add(name);
+      }
+    }
+  }
+
+  return [...names].sort();
+}
+
+function workflowFailureText(evidence: WorkflowRunEvidence): string {
+  return [
+    ...evidence.logs.map((log) => log.excerpt),
+    ...evidence.deterministicGates.flatMap((gate) => [
+      gate.outputExcerpt,
+      gate.stdoutExcerpt,
+      gate.stderrExcerpt,
+    ]),
+    ...evidence.steps.flatMap((step) => [
+      step.error,
+      ...step.logs.map((log) => log.excerpt),
+      ...step.deterministicGates.flatMap((gate) => [
+        gate.outputExcerpt,
+        gate.stdoutExcerpt,
+        gate.stderrExcerpt,
+      ]),
+      ...step.verifications.flatMap((verification) => [
+        verification.message,
+        verification.outputExcerpt,
+        verification.stdoutExcerpt,
+        verification.stderrExcerpt,
+      ]),
+    ]),
+  ].filter((value): value is string => typeof value === 'string' && value.trim().length > 0).join('\n');
+}
+
+function isConcreteEnvVarName(name: string): boolean {
+  return /^[A-Z][A-Z0-9_]{2,}$/.test(name)
+    && !['ENOENT', 'PATH'].includes(name)
+    && (name.includes('_') || name.length > 3);
+}
+
+function injectWorkflowEnvLoader(content: string, requiredEnvVars: string[]): string {
+  let next = content;
+  let changed = false;
+
+  if (!next.includes("from 'node:fs'") && !next.includes('from "node:fs"')) {
+    next = insertAfterWorkflowImport(next, "import * as rickyWorkflowFs from 'node:fs';");
+    changed = true;
+  }
+  if (!next.includes("from 'node:path'") && !next.includes('from "node:path"')) {
+    next = insertAfterWorkflowImport(next, "import * as rickyWorkflowPath from 'node:path';");
+    changed = true;
+  }
+  if (!next.includes('RICKY_WORKFLOW_ENV_LOADER')) {
+    next = insertBeforeMain(next, rickyWorkflowEnvLoaderSource());
+    changed = true;
+  } else if (requiredEnvVars.length > 0 && !next.includes('function assertRickyWorkflowEnv')) {
+    next = insertBeforeMain(next, rickyWorkflowEnvAssertSource());
+    changed = true;
+  }
+
+  const calls = [
+    '  loadRickyWorkflowEnv();',
+    ...(requiredEnvVars.length > 0 ? [`  assertRickyWorkflowEnv(${JSON.stringify(requiredEnvVars)});`] : []),
+  ];
+  for (const call of calls) {
+    if (next.includes(call.trim())) continue;
+    const updated = next.includes('async function main()')
+      ? next.replace(/async function main\(\) \{\n/, (match) => `${match}${call}\n`)
+      : next.replace(/\bworkflow\(/, `${call.trim()}\nworkflow(`);
+    if (updated !== next) {
+      next = updated;
+      changed = true;
+    }
+  }
+
+  return changed ? next : content;
+}
+
+function insertAfterWorkflowImport(content: string, importLine: string): string {
+  const workflowImport = /^import\s+\{\s*workflow\s+\}\s+from\s+['"]@agent-relay\/sdk\/workflows['"];?\n/m;
+  if (workflowImport.test(content)) {
+    return content.replace(workflowImport, (match) => `${match}${importLine}\n`);
+  }
+  return `${importLine}\n${content}`;
+}
+
+function insertBeforeMain(content: string, helper: string): string {
+  if (content.includes('async function main()')) {
+    return content.replace(/\nasync function main\(\)/, `\n${helper}\n\nasync function main()`);
+  }
+  return `${helper}\n\n${content}`;
+}
+
+function rickyWorkflowEnvLoaderSource(): string {
+  return `// RICKY_WORKFLOW_ENV_LOADER: load repo-local env files before spawning workflow agents.
+function loadRickyWorkflowEnv(cwd = process.cwd()) {
+  for (const file of ['.env.local', '.env']) {
+    const path = rickyWorkflowPath.join(cwd, file);
+    if (!rickyWorkflowFs.existsSync(path)) continue;
+    const body = rickyWorkflowFs.readFileSync(path, 'utf8');
+    for (const rawLine of body.split(/\\r?\\n/)) {
+      const line = rawLine.trim();
+      if (!line || line.startsWith('#')) continue;
+      const match = /^(?:export\\s+)?([A-Za-z_][A-Za-z0-9_]*)\\s*=\\s*(.*)$/.exec(line);
+      if (!match) continue;
+      const [, key, rawValue] = match;
+      if (!key || rawValue === undefined || process.env[key] !== undefined) continue;
+      process.env[key] = unquoteRickyWorkflowEnvValue(rawValue);
+    }
+  }
+}
+
+function assertRickyWorkflowEnv(names: string[]): void {
+  const missing = names.filter((name) => !process.env[name]);
+  if (missing.length > 0) {
+    throw new Error(\`MISSING_ENV_VAR: \${missing.join(', ')}. Add missing values to .env.local or export them before rerunning.\`);
+  }
+}
+
+function unquoteRickyWorkflowEnvValue(value: string): string {
+  const trimmed = value.trim();
+  if ((trimmed.startsWith('"') && trimmed.endsWith('"')) || (trimmed.startsWith("'") && trimmed.endsWith("'"))) {
+    return trimmed.slice(1, -1);
+  }
+  return trimmed;
+}`;
+}
+
+function rickyWorkflowEnvAssertSource(): string {
+  return `function assertRickyWorkflowEnv(names: string[]): void {
+  const missing = names.filter((name) => !process.env[name]);
+  if (missing.length > 0) {
+    throw new Error(\`MISSING_ENV_VAR: \${missing.join(', ')}. Add missing values to .env.local or export them before rerunning.\`);
+  }
+}`;
 }
 
 function summaryFromRepairMetadata(metadata: Record<string, unknown>): string {

--- a/src/local/entrypoint.test.ts
+++ b/src/local/entrypoint.test.ts
@@ -1547,7 +1547,7 @@ describe('runLocal', () => {
       const localExecutor = memoryLocalExecutorOptions({
         exitCode: 1,
         stdout: ['Spec context mentions API, MSD, and GENERATED_WORKFLOW_READY.'],
-        stderr: ['missing env var GITHUB_TOKEN'],
+        stderr: ['missing env var GITHUB_TOKEN before calling API for MSD workflows'],
       });
       const result = await runLocal(
         {
@@ -1562,6 +1562,8 @@ describe('runLocal', () => {
       expect(result.execution?.blocker?.code).toBe('MISSING_ENV_VAR');
       expect(result.execution?.blocker?.context.missing).toEqual(['GITHUB_TOKEN']);
       expect(result.nextActions).toEqual(['export GITHUB_TOKEN=...']);
+      expect(result.nextActions.join('\n')).not.toContain('export API=');
+      expect(result.nextActions.join('\n')).not.toContain('export MSD=');
     });
 
     it('does not turn prose acronyms near missing-env text into export commands', async () => {

--- a/src/local/entrypoint.test.ts
+++ b/src/local/entrypoint.test.ts
@@ -1564,6 +1564,27 @@ describe('runLocal', () => {
       expect(result.nextActions).toEqual(['export GITHUB_TOKEN=...']);
     });
 
+    it('does not turn prose acronyms near missing-env text into export commands', async () => {
+      const localExecutor = memoryLocalExecutorOptions({
+        exitCode: 1,
+        stderr: ['Required runtime environment is missing: Owner: MSD backend; Relaycast API key resolved.'],
+      });
+      const result = await runLocal(
+        {
+          source: 'cli',
+          spec: 'generate a local workflow for packages/local/src/entrypoint.ts',
+          stageMode: 'run',
+        },
+        { localExecutor },
+      );
+
+      expect(result.ok).toBe(false);
+      expect(result.execution?.blocker?.code).toBe('MISSING_ENV_VAR');
+      expect(result.execution?.blocker?.context.missing).toEqual(['required environment variable']);
+      expect(result.nextActions.join('\n')).not.toContain('export API=');
+      expect(result.nextActions.join('\n')).not.toContain('export MSD=');
+    });
+
     it('keeps stop-after-generation artifact-only output without launching runtime', async () => {
       const localExecutor = memoryLocalExecutorOptions({
         exitCode: 127,

--- a/src/local/entrypoint.test.ts
+++ b/src/local/entrypoint.test.ts
@@ -1543,6 +1543,27 @@ describe('runLocal', () => {
       expect(result.nextActions.join('\n')).not.toMatch(/rerun.*later|vague/i);
     });
 
+    it('extracts env recovery steps only from explicit missing-env messages', async () => {
+      const localExecutor = memoryLocalExecutorOptions({
+        exitCode: 1,
+        stdout: ['Spec context mentions API, MSD, and GENERATED_WORKFLOW_READY.'],
+        stderr: ['missing env var GITHUB_TOKEN'],
+      });
+      const result = await runLocal(
+        {
+          source: 'cli',
+          spec: 'generate a local workflow for packages/local/src/entrypoint.ts',
+          stageMode: 'run',
+        },
+        { localExecutor },
+      );
+
+      expect(result.ok).toBe(false);
+      expect(result.execution?.blocker?.code).toBe('MISSING_ENV_VAR');
+      expect(result.execution?.blocker?.context.missing).toEqual(['GITHUB_TOKEN']);
+      expect(result.nextActions).toEqual(['export GITHUB_TOKEN=...']);
+    });
+
     it('keeps stop-after-generation artifact-only output without launching runtime', async () => {
       const localExecutor = memoryLocalExecutorOptions({
         exitCode: 127,
@@ -2863,6 +2884,7 @@ describe('runLocal', () => {
         [
           "import { spawn } from 'node:child_process';",
           "import { writeFileSync } from 'node:fs';",
+          "console.log('Runtime banner mentions API, MSD, and GENERATED_WORKFLOW_READY but not missing env.');",
           "const child = spawn(process.execPath, ['-e', 'setInterval(() => {}, 1000)'], { stdio: 'ignore' });",
           `writeFileSync(${JSON.stringify(pidFile)}, String(child.pid));`,
           'console.log(`spawned-child=${child.pid}`);',
@@ -2885,6 +2907,9 @@ describe('runLocal', () => {
 
       expect(result.ok).toBe(false);
       expect(result.execution?.evidence?.outcome_summary).toContain('timed out after 500ms');
+      expect(result.execution?.blocker?.code).toBe('NETWORK_UNREACHABLE');
+      expect(result.nextActions.join('\n')).not.toContain('export API=');
+      expect(result.nextActions.join('\n')).not.toContain('export MSD=');
 
       childPid = Number((await readFile(pidFile, 'utf8')).trim());
       expect(Number.isFinite(childPid)).toBe(true);

--- a/src/local/entrypoint.ts
+++ b/src/local/entrypoint.ts
@@ -2000,7 +2000,7 @@ function classifyCoordinatorBlocker(
   }
 
   const missingEnvVars = extractMissingEnvVars(combined);
-  if (missingEnvVars.length > 0 || /(?:missing|required).*(?:env|environment)|not set/i.test(combined)) {
+  if (missingEnvVars.length > 0 || hasMissingEnvironmentMessage(combined)) {
     return blocker({
       code: 'MISSING_ENV_VAR',
       category: 'environment',
@@ -2071,13 +2071,41 @@ function npxNoInstallPackage(args: string[]): string | undefined {
   return args[noInstallIndex + 1];
 }
 
+function hasMissingEnvironmentMessage(text: string): boolean {
+  for (const line of text.split(/\r?\n/)) {
+    if (/\bnot\s+missing\s+env(?:ironment)?\b/i.test(line)) continue;
+    if (/(?:missing|required).{0,80}(?:env(?:ironment)?(?:\s+variable)?)/i.test(line)) return true;
+    if (/(?:env(?:ironment)?(?:\s+variable)?).{0,80}(?:missing|required|not\s+set|unset)/i.test(line)) return true;
+    if (/\b[A-Z][A-Z0-9_]{2,}\b\s+(?:is\s+)?(?:missing|required|not\s+set|unset)/.test(line)) return true;
+  }
+  return false;
+}
+
 function extractMissingEnvVars(text: string): string[] {
   const names = new Set<string>();
-  for (const match of text.matchAll(/\b([A-Z][A-Z0-9_]{2,})\b/g)) {
-    const name = match[1];
-    if (['ENOENT', 'PATH'].includes(name)) continue;
-    names.add(name);
+
+  for (const line of text.split(/\r?\n/)) {
+    if (/\bnot\s+missing\s+env(?:ironment)?\b/i.test(line)) continue;
+    if (!/(?:env(?:ironment)?(?:\s+variable)?|variable|not\s+set|unset|missing|required)/i.test(line)) {
+      continue;
+    }
+
+    for (const match of line.matchAll(/\b[A-Z][A-Z0-9_]{2,}\b/g)) {
+      const name = match[0];
+      if (['ENOENT', 'PATH'].includes(name)) continue;
+
+      const index = match.index ?? 0;
+      const context = line.slice(Math.max(0, index - 100), index + name.length + 100).toLowerCase();
+      const hasEnvContext = /env(?:ironment)?(?:\s+variable)?|variable/.test(context);
+      const hasMissingContext = /missing|required|not\s+set|unset/.test(context);
+      const nameHasState = new RegExp(`\\b${name}\\b\\s+(?:is\\s+)?(?:missing|required|not\\s+set|unset)`).test(line);
+
+      if ((hasEnvContext && hasMissingContext) || nameHasState) {
+        names.add(name);
+      }
+    }
   }
+
   return [...names];
 }
 

--- a/src/local/entrypoint.ts
+++ b/src/local/entrypoint.ts
@@ -2072,11 +2072,11 @@ function npxNoInstallPackage(args: string[]): string | undefined {
 }
 
 function hasMissingEnvironmentMessage(text: string): boolean {
-  for (const line of text.split(/\r?\n/)) {
+  for (const rawLine of text.split(/\r?\n/)) {
+    const line = stripAnsi(rawLine);
     if (/\bnot\s+missing\s+env(?:ironment)?\b/i.test(line)) continue;
     if (/(?:missing|required).{0,80}(?:env(?:ironment)?(?:\s+variable)?)/i.test(line)) return true;
     if (/(?:env(?:ironment)?(?:\s+variable)?).{0,80}(?:missing|required|not\s+set|unset)/i.test(line)) return true;
-    if (/\b[A-Z][A-Z0-9_]{2,}\b\s+(?:is\s+)?(?:missing|required|not\s+set|unset)/.test(line)) return true;
   }
   return false;
 }
@@ -2084,34 +2084,45 @@ function hasMissingEnvironmentMessage(text: string): boolean {
 function extractMissingEnvVars(text: string): string[] {
   const names = new Set<string>();
 
-  for (const line of text.split(/\r?\n/)) {
+  for (const rawLine of text.split(/\r?\n/)) {
+    const line = stripAnsi(rawLine);
     if (/\bnot\s+missing\s+env(?:ironment)?\b/i.test(line)) continue;
-    if (!/(?:env(?:ironment)?(?:\s+variable)?|variable|not\s+set|unset|missing|required)/i.test(line)) {
-      continue;
+    if (!hasMissingEnvironmentMessage(line)) continue;
+
+    for (const match of line.matchAll(/\bMISSING_ENV_VAR:\s*([A-Z][A-Z0-9_]*(?:\s*,\s*[A-Z][A-Z0-9_]*)*)/g)) {
+      addEnvNames(names, match[1]);
     }
 
-    for (const match of line.matchAll(/\b[A-Z][A-Z0-9_]{2,}\b/g)) {
-      const name = match[0];
-      if (['ENOENT', 'PATH'].includes(name)) continue;
+    for (const match of line.matchAll(/\b(?:missing|required|unset|not\s+set)\s+(?:runtime\s+)?(?:env(?:ironment)?(?:\s+var(?:iable)?)?|variable)\s+([A-Z][A-Z0-9_]{2,})\b/gi)) {
+      addEnvNames(names, match[1]);
+    }
 
-      const index = match.index ?? 0;
-      const context = line.slice(Math.max(0, index - 100), index + name.length + 100).toLowerCase();
-      const hasEnvContext = /env(?:ironment)?(?:\s+variable)?|variable/.test(context);
-      const hasMissingContext = /missing|required|not\s+set|unset/.test(context);
-      const nameHasState = new RegExp(`\\b${name}\\b\\s+(?:is\\s+)?(?:missing|required|not\\s+set|unset)`).test(line);
-      const explicitEnvReference = new RegExp(`(?:\\$|process\\.env\\.)${name}\\b|\\b${name}=`).test(line);
+    for (const match of line.matchAll(/\b(?:env(?:ironment)?(?:\s+var(?:iable)?)?|variable)\s+([A-Z][A-Z0-9_]{2,})\b.{0,24}\b(?:missing|required|not\s+set|unset)\b/gi)) {
+      addEnvNames(names, match[1]);
+    }
 
-      if (explicitEnvReference || (((hasEnvContext && hasMissingContext) || nameHasState) && looksLikeConfigEnvName(name))) {
-        names.add(name);
-      }
+    for (const match of line.matchAll(/\b([A-Z][A-Z0-9_]{2,})\b\s+(?:env(?:ironment)?(?:\s+var(?:iable)?)?|variable)\s+(?:is\s+)?(?:missing|required|not\s+set|unset)\b/gi)) {
+      addEnvNames(names, match[1]);
+    }
+
+    for (const match of line.matchAll(/\b(?:missing|required|unset|not\s+set)\s+(?:\$|process\.env\.)([A-Z][A-Z0-9_]{2,})\b/gi)) {
+      addEnvNames(names, match[1]);
+    }
+
+    for (const match of line.matchAll(/(?:\$|process\.env\.)([A-Z][A-Z0-9_]{2,})\b.{0,32}\b(?:missing|required|not\s+set|unset)\b/gi)) {
+      addEnvNames(names, match[1]);
     }
   }
 
   return [...names];
 }
 
-function looksLikeConfigEnvName(name: string): boolean {
-  return name.includes('_') || name.length > 3;
+function addEnvNames(names: Set<string>, value: string | undefined): void {
+  for (const name of (value ?? '').split(/\s*,\s*/)) {
+    if (/^[A-Z][A-Z0-9_]{2,}$/.test(name) && !['ENOENT', 'PATH'].includes(name)) {
+      names.add(name);
+    }
+  }
 }
 
 async function writeRuntimeLogs(result: CoordinatorResult): Promise<LocalExecutionEvidence['logs']> {

--- a/src/local/entrypoint.ts
+++ b/src/local/entrypoint.ts
@@ -2099,14 +2099,19 @@ function extractMissingEnvVars(text: string): string[] {
       const hasEnvContext = /env(?:ironment)?(?:\s+variable)?|variable/.test(context);
       const hasMissingContext = /missing|required|not\s+set|unset/.test(context);
       const nameHasState = new RegExp(`\\b${name}\\b\\s+(?:is\\s+)?(?:missing|required|not\\s+set|unset)`).test(line);
+      const explicitEnvReference = new RegExp(`(?:\\$|process\\.env\\.)${name}\\b|\\b${name}=`).test(line);
 
-      if ((hasEnvContext && hasMissingContext) || nameHasState) {
+      if (explicitEnvReference || (((hasEnvContext && hasMissingContext) || nameHasState) && looksLikeConfigEnvName(name))) {
         names.add(name);
       }
     }
   }
 
   return [...names];
+}
+
+function looksLikeConfigEnvName(name: string): boolean {
+  return name.includes('_') || name.length > 3;
 }
 
 async function writeRuntimeLogs(result: CoordinatorResult): Promise<LocalExecutionEvidence['logs']> {

--- a/src/product/generation/pipeline.test.ts
+++ b/src/product/generation/pipeline.test.ts
@@ -435,6 +435,9 @@ describe('workflow generation pipeline', () => {
     expect(artifact.channel).not.toBe('general');
     expect(artifact.content).toMatch(/\bworkflow\(/);
     expect(artifact.content).toContain(`.channel("${artifact.channel}")`);
+    expect(artifact.content).toContain('RICKY_WORKFLOW_ENV_LOADER');
+    expect(artifact.content).toContain('loadRickyWorkflowEnv();');
+    expect(artifact.content).toContain("['.env.local', '.env']");
     expect(artifact.content).toContain('.run({ cwd: process.cwd() })');
     expect(artifact.content).toContain('.step("lead-plan-gate"');
     expect(artifact.content).toContain('.step("fix-loop-report-gate"');

--- a/src/product/generation/template-renderer.ts
+++ b/src/product/generation/template-renderer.ts
@@ -116,10 +116,16 @@ function renderSource(input: {
   const onError = input.pattern.riskLevel === 'low' ? "'fail-fast'" : `'retry', { maxRetries: ${DEFAULT_RETRY_MAX_ATTEMPTS}, retryDelayMs: ${DEFAULT_RETRY_BACKOFF_MS} }`;
   const lines: string[] = [
     "import { workflow } from '@agent-relay/sdk/workflows';",
+    "import * as rickyWorkflowFs from 'node:fs';",
+    "import * as rickyWorkflowPath from 'node:path';",
     '',
     '// IMPLEMENTATION_WORKFLOW_CONTRACT: implementation specs must produce source changes, tests, non-empty diff evidence, and PR/result reporting.',
+    '// RICKY_WORKFLOW_ENV_LOADER: load repo-local env files before spawning workflow agents.',
+    '',
+    renderWorkflowEnvLoaderHelper(),
     '',
     'async function main() {',
+    '  loadRickyWorkflowEnv();',
     `  const result = await workflow(${literal(input.workflowId)})`,
     `    .description(${literal(input.spec.description)})`,
     `    .pattern(${literal(input.pattern.pattern)})`,
@@ -820,6 +826,40 @@ function renderDeterministicStep(name: string, dependsOn: string[], command: str
       captureOutput: true,
       failOnError: ${failOnError},
     })`;
+}
+
+function renderWorkflowEnvLoaderHelper(): string {
+  return `function loadRickyWorkflowEnv(cwd = process.cwd()) {
+  for (const file of ['.env.local', '.env']) {
+    const path = rickyWorkflowPath.join(cwd, file);
+    if (!rickyWorkflowFs.existsSync(path)) continue;
+    const body = rickyWorkflowFs.readFileSync(path, 'utf8');
+    for (const rawLine of body.split(/\\r?\\n/)) {
+      const line = rawLine.trim();
+      if (!line || line.startsWith('#')) continue;
+      const match = /^(?:export\\s+)?([A-Za-z_][A-Za-z0-9_]*)\\s*=\\s*(.*)$/.exec(line);
+      if (!match) continue;
+      const [, key, rawValue] = match;
+      if (!key || rawValue === undefined || process.env[key] !== undefined) continue;
+      process.env[key] = unquoteRickyWorkflowEnvValue(rawValue);
+    }
+  }
+}
+
+function unquoteRickyWorkflowEnvValue(value: string): string {
+  const trimmed = value.trim();
+  if ((trimmed.startsWith('"') && trimmed.endsWith('"')) || (trimmed.startsWith("'") && trimmed.endsWith("'"))) {
+    return trimmed.slice(1, -1);
+  }
+  return trimmed;
+}
+
+function assertRickyWorkflowEnv(names: string[]): void {
+  const missing = names.filter((name) => !process.env[name]);
+  if (missing.length > 0) {
+    throw new Error(\`MISSING_ENV_VAR: \${missing.join(', ')}. Add missing values to .env.local or export them before rerunning.\`);
+  }
+}`;
 }
 
 function buildFinalArtifactConsistencyGateCommand(artifactsDir: string): string {

--- a/src/product/generation/workforce-persona-repairer.ts
+++ b/src/product/generation/workforce-persona-repairer.ts
@@ -171,6 +171,7 @@ export function buildWorkflowRepairPersonaTask(options: WorkforcePersonaRepairOp
     '- Return the full repaired TypeScript workflow artifact, not a diff.',
     '- Preserve the artifact path and keep the workflow runnable from the same file.',
     '- Fix the workflow artifact itself; do not ask the user to run manual recovery unless the workflow cannot safely express the prerequisite.',
+    '- For MISSING_ENV_VAR failures, first make the workflow load repo-local `.env.local` and `.env` without overwriting shell exports, then add a fast `MISSING_ENV_VAR: NAME` assertion for known required variables before long-running agent steps. Do not fabricate secret values.',
     '- Preserve or improve the 80-to-100 loop: implementation, deterministic validation, review, final hard gate, and signoff evidence.',
     '- Ensure the failed step can be resumed by Ricky using --start-from with the failed step id and the previous run id.',
     '- Keep side effects explicit and bounded. Do not commit, push, open PRs, or perform destructive file operations.',

--- a/src/product/generation/workforce-persona-writer.ts
+++ b/src/product/generation/workforce-persona-writer.ts
@@ -517,6 +517,7 @@ export function buildWorkflowPersonaTask(
     '- Include an 80-to-100 fix loop: implement, validate, review, fix, final review, hard validation.',
     '- Include a real deterministic sanity gate over produced files using grep, rg, git grep, or an equivalent inline assertion that exits non-zero when expected content/state is missing.',
     '- Keep agent steps bounded: split broad implementation or test-writing work into multiple sequential/fan-out steps with deterministic gates between them instead of one large step that can exhaust retries by timeout.',
+    '- Before calling `.run(...)`, load repo-local `.env.local` and `.env` values into `process.env` without overwriting existing shell exports, so local BYOH runs inherit common project configuration. If the workflow requires named env vars, add a fast deterministic preflight/assertion that prints `MISSING_ENV_VAR: NAME` before long-running agent steps.',
     '- Verification must include typecheck/test commands when relevant plus git-diff evidence; diff/manifest gates must combine git diff --name-only with git ls-files --others --exclude-standard so newly-created files are visible.',
     '- Run with an explicit cwd: .run({ cwd: process.cwd() }).',
     '- Preserve Agent Relay workflow authoring rules: deterministic gates are evidence, agents do production work, and every generated workflow must be locally dry-runnable.',

--- a/workflows/shared/WORKFLOW_AUTHORING_RULES.md
+++ b/workflows/shared/WORKFLOW_AUTHORING_RULES.md
@@ -16,6 +16,7 @@ Compact execution rules for agents writing Ricky workflows.
 10. If generating workflows in bulk, run structural sanity checks and `agent-relay run --dry-run` before sign-off.
 11. End serious workflows with `.run({ cwd: process.cwd() })`.
 12. Keep commit/push boundaries explicit and deterministic.
+13. Load repo-local `.env.local`/`.env` before `.run(...)` without overwriting exported values, and fail fast with `MISSING_ENV_VAR: NAME` for required env vars before long-running agent steps.
 
 ## Must-not
 


### PR DESCRIPTION
## Summary

- Load repo-local .env.local/.env in generated workflows before Agent Relay steps run, preserving shell-export precedence.
- Let auto-fix repair MISSING_ENV_VAR workflow failures by adding env loading and fast MISSING_ENV_VAR assertions instead of stopping immediately.
- Tighten missing env extraction so prose acronyms like API/MSD are not suggested as bogus export commands.
- Update Workforce persona prompts and shared workflow authoring rules with the env preflight pattern.

## Test Plan

- npm run typecheck
- npm test