### PR TITLE
chore: bump default run timeout from 10m to 30m

### DIFF
--- a/src/shared/constants.ts
+++ b/src/shared/constants.ts
@@ -13,7 +13,7 @@ export const WAVE_FOLDER_NAMES = [
 
 export const DEFAULT_MAX_CONCURRENCY = 4;
 
-export const DEFAULT_RUN_TIMEOUT_MS = 600_000;
+export const DEFAULT_RUN_TIMEOUT_MS = 1_800_000;
 
 export const DEFAULT_TIMEOUT_MS = DEFAULT_RUN_TIMEOUT_MS;
 


### PR DESCRIPTION
## Summary
- Bump `DEFAULT_RUN_TIMEOUT_MS` (and the aliased `DEFAULT_TIMEOUT_MS`) from `600_000` to `1_800_000`.
- Newly generated workflows pick this up automatically in their `.timeout()` call (via `template-renderer.ts`).

## Why
The 10-minute ceiling kills real implementation runs before the workflow's own timeout matters. We hit this resuming a code-writing workflow where the implement step (single codex worker + gates) consistently runs longer than 10 minutes. Ricky surfaces the failure as `MISSING_ENV_VAR at runtime-launch` because the outer launcher timeout fires inside the env-blocker classification path — so the user sees a misleading `export API=...` next-step suggestion. Bumping the default avoids that misclassification for the common case.

This is the minimal change. A follow-up could expose `--timeout-ms` / `RICKY_RUN_TIMEOUT_MS` for per-run overrides, but the default alone unblocks the typical path.

## Test plan
- [x] `npx tsc --noEmit` clean
- [x] `npx vitest run src/runtime/local-coordinator.test.ts src/product/generation/ src/product/specialists/validator/validator.test.ts` — 93 tests pass
- [ ] Manual: regenerate a workflow and confirm the rendered `.timeout(1_800_000)`

🤖 Generated with [Claude Code](https://claude.com/claude-code)