### PR TITLE
chore: bump Workforce packages

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,19 +1,19 @@
 {
   "name": "@agentworkforce/ricky",
-  "version": "0.1.15",
+  "version": "0.1.23",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@agentworkforce/ricky",
-      "version": "0.1.15",
+      "version": "0.1.23",
       "license": "Apache-2.0",
       "dependencies": {
         "@agent-assistant/turn-context": "^0.4.23",
         "@agent-relay/cloud": "^6.0.6",
         "@agent-relay/sdk": "^6.0.6",
-        "@agentworkforce/harness-kit": "^0.5.5",
-        "@agentworkforce/workload-router": "^0.5.4",
+        "@agentworkforce/harness-kit": "^0.6.1",
+        "@agentworkforce/workload-router": "^0.6.1",
         "@inquirer/prompts": "^8.4.2",
         "ora": "^8.2.0",
         "ssh2": "^1.17.0"
@@ -478,17 +478,17 @@
       "integrity": "sha512-Fu2GJWkIiSUxXawhk9SW+btDz5WDzI6RGKyugG12+wm4CDJ4rnDY9Xg8FGDugzOHL8EasWFvtF6pztZTzjJOSQ=="
     },
     "node_modules/@agentworkforce/harness-kit": {
-      "version": "0.5.5",
-      "resolved": "https://registry.npmjs.org/@agentworkforce/harness-kit/-/harness-kit-0.5.5.tgz",
-      "integrity": "sha512-SQdbjWx7Nbod/BSswto9sT62k2HUMiCs/n36W22p1npOvOylo6/Zb2osrsZP+0o+07fXj5SQUANkU+fSw+yrXw==",
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/@agentworkforce/harness-kit/-/harness-kit-0.6.1.tgz",
+      "integrity": "sha512-Lcoj/9ZrmOenJowhAM0gUWWtnfcHgP/cwPnkiiXi1cQN0O69BD7v6EqiHWLerebqlLTwTOG0JWzerOj7Nlwgcw==",
       "dependencies": {
-        "@agentworkforce/workload-router": "^0.5.4"
+        "@agentworkforce/workload-router": "0.6.1"
       }
     },
     "node_modules/@agentworkforce/workload-router": {
-      "version": "0.5.4",
-      "resolved": "https://registry.npmjs.org/@agentworkforce/workload-router/-/workload-router-0.5.4.tgz",
-      "integrity": "sha512-q4wcY3C5+sDhfbbSrY/SkRK7wZl8Gpu/Ylg2hhyA3kvR/O4bcchO1GLHdAqihGpefH9HO2poOywzDQqZKkNwgw=="
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/@agentworkforce/workload-router/-/workload-router-0.6.1.tgz",
+      "integrity": "sha512-9IziwGVleJwDfL2Z2LlvtN61RaxnGaCZhUVfbxSPS/U5xNDY1S2iC/VKnlasmhYBBW5iy8nsO/755pT19+8O0Q=="
     },
     "node_modules/@aws-crypto/crc32": {
       "version": "5.2.0",

--- a/package.json
+++ b/package.json
@@ -35,8 +35,8 @@
     "@agent-assistant/turn-context": "^0.4.23",
     "@agent-relay/cloud": "^6.0.6",
     "@agent-relay/sdk": "^6.0.6",
-    "@agentworkforce/harness-kit": "^0.5.5",
-    "@agentworkforce/workload-router": "^0.5.4",
+    "@agentworkforce/harness-kit": "^0.6.1",
+    "@agentworkforce/workload-router": "^0.6.1",
     "@inquirer/prompts": "^8.4.2",
     "ora": "^8.2.0",
     "ssh2": "^1.17.0"


### PR DESCRIPTION
## Summary
- bump @agentworkforce/harness-kit to ^0.6.1
- bump @agentworkforce/workload-router to ^0.6.1
- refresh package-lock resolved versions and root package version metadata

## Test plan
- npm run typecheck
- npx vitest run src/product/generation/workforce-persona-writer.test.ts src/surfaces/cli/flows/workforce-persona-cli-preference.test.ts
- npm test