### PR TITLE
Teach workflow repairs from failed attempts

### DIFF
--- a/src/local/auto-fix-loop.test.ts
+++ b/src/local/auto-fix-loop.test.ts
@@ -90,6 +90,48 @@ describe('runWithAutoFix', () => {
     });
   });
 
+  it('passes failed repair history into the next workflow repair attempt', async () => {
+    const runSingleAttempt = vi
+      .fn()
+      .mockResolvedValueOnce(blockerResponse('MISSING_ENV_VAR', 'run-1', 'runtime-launch'))
+      .mockResolvedValueOnce(blockerResponse('MISSING_ENV_VAR', 'run-2', 'runtime-launch'))
+      .mockResolvedValueOnce(successResponse('run-3'));
+    const workflowRepairer = vi
+      .fn()
+      .mockResolvedValueOnce(workflowRepair('first repaired workflow'))
+      .mockResolvedValueOnce(workflowRepair('second repaired workflow'));
+
+    const result = await runWithAutoFix(baseRequest, {
+      maxAttempts: 4,
+      runSingleAttempt,
+      classifyFailure: fakeClassification,
+      debugWorkflowRun: guidedDebugger,
+      workflowRepairer,
+      artifactWriter: vi.fn().mockResolvedValue(undefined),
+    });
+
+    expect(result.ok).toBe(true);
+    expect(workflowRepairer).toHaveBeenCalledTimes(2);
+    expect(workflowRepairer.mock.calls[0][0].previousAttempts).toEqual([]);
+    expect(workflowRepairer.mock.calls[1][0].previousAttempts).toEqual([
+      expect.objectContaining({
+        attempt: 1,
+        repairedArtifactPath: 'workflows/generated/foo.ts',
+        repairSummary: 'persona patched the workflow',
+        repairMode: 'workforce-persona',
+        personaRunId: 'persona-run-1',
+        retryAttempt: 2,
+        outcome: expect.objectContaining({
+          status: 'blocker',
+          failedStep: 'runtime-launch',
+          blockerCode: 'MISSING_ENV_VAR',
+          runId: 'run-2',
+          debuggerSummary: 'Set TEST_TOKEN before retrying.',
+        }),
+      }),
+    ]);
+  });
+
   it('emits concise foreground progress during repair and retry', async () => {
     const progress: string[] = [];
     const runSingleAttempt = vi

--- a/src/local/auto-fix-loop.ts
+++ b/src/local/auto-fix-loop.ts
@@ -12,6 +12,7 @@ import { debugWorkflowRun as defaultDebugWorkflowRun } from '../product/speciali
 import type { DebuggerResult } from '../product/specialists/debugger/types.js';
 import type { WorkflowRunEvidence, WorkflowStepEvidence } from '../shared/models/workflow-evidence.js';
 import { repairWorkflowWithWorkforcePersona } from '../product/generation/workforce-persona-repairer.js';
+import type { WorkforcePersonaRepairAttempt } from '../product/generation/workforce-persona-repairer.js';
 import { localRunStateRoot } from '../shared/state-paths.js';
 
 export interface AutoFixAttemptSummary {
@@ -37,6 +38,7 @@ export interface WorkflowRepairInput {
   cwd: string;
   failedStep?: string;
   runId?: string;
+  previousAttempts?: WorkforcePersonaRepairAttempt[];
   attempt: number;
   maxAttempts: number;
   onProgress?: (message: string) => void;
@@ -92,11 +94,13 @@ export async function runWithAutoFix(
   const sleep = options.sleep ?? ((ms: number) => new Promise<void>((resolve) => setTimeout(resolve, ms)));
   const onProgress = options.onProgress;
   const attempts: AutoFixAttemptSummary[] = [];
+  const previousRepairAttempts: WorkforcePersonaRepairAttempt[] = [];
   const warnings: string[] = [];
   const trackingRunId = resolveTrackingRunId(request) ?? `ricky-local-${randomUUID()}`;
   let currentRequest: LocalInvocationRequest = { ...request, autoFix: undefined };
   let lastResponse: LocalResponse | undefined;
   let retryOfRunId: string | undefined;
+  let pendingRepairAttempt: Omit<WorkforcePersonaRepairAttempt, 'outcome'> | undefined;
 
   for (let attempt = 1; attempt <= maxAttempts; attempt += 1) {
     onProgress?.(`Running workflow (attempt ${attempt}/${maxAttempts})...`);
@@ -156,6 +160,20 @@ export async function runWithAutoFix(
 
     const classification = classifyFailure(evidence);
     const debuggerResult = debugWorkflowRun({ evidence, classification });
+    if (pendingRepairAttempt && pendingRepairAttempt.retryAttempt === attempt) {
+      previousRepairAttempts.push({
+        ...pendingRepairAttempt,
+        outcome: {
+          status: attemptSummary.status === 'ok' ? 'failed' : attemptSummary.status,
+          ...(failedStep ? { failedStep } : {}),
+          ...(blockerCode ? { blockerCode } : {}),
+          ...(runId ? { runId } : {}),
+          classification,
+          debuggerSummary: debuggerResult.summary,
+        },
+      });
+      pendingRepairAttempt = undefined;
+    }
     const repairTarget = await resolveWorkflowRepairTarget(currentRequest, response);
 
     if (repairTarget) {
@@ -172,6 +190,7 @@ export async function runWithAutoFix(
           cwd: repairTarget.cwd,
           ...(failedStep ? { failedStep } : {}),
           ...(runId ? { runId } : {}),
+          previousAttempts: [...previousRepairAttempts],
           attempt,
           maxAttempts,
           ...(onProgress ? { onProgress } : {}),
@@ -204,6 +223,14 @@ export async function runWithAutoFix(
           artifact_path: repairedArtifactPath,
           summary: repair.summary,
           ...(repair.runId ? { persona_run_id: repair.runId } : {}),
+        };
+        pendingRepairAttempt = {
+          attempt,
+          repairedArtifactPath,
+          repairSummary: repair.summary,
+          repairMode: repair.mode ?? 'workforce-persona',
+          ...(repair.runId ? { personaRunId: repair.runId } : {}),
+          retryAttempt: attempt + 1,
         };
         warnings.push(...(repair.warnings ?? []));
 
@@ -348,6 +375,7 @@ async function defaultWorkflowRepairer(input: WorkflowRepairInput): Promise<Work
       blocker: input.response.execution?.blocker,
       ...(input.failedStep ? { failedStep: input.failedStep } : {}),
       ...(input.runId ? { previousRunId: input.runId } : {}),
+      previousAttempts: input.previousAttempts ?? [],
       attempt: input.attempt,
       maxAttempts: input.maxAttempts,
       installRoot: join(localRunStateRoot(input.cwd), 'workforce-persona-repair-skills'),

--- a/src/product/generation/pipeline.ts
+++ b/src/product/generation/pipeline.ts
@@ -19,7 +19,11 @@ import {
   applyPersonaArtifactToRenderedArtifact,
   writeWorkflowWithWorkforcePersona,
   WorkforcePersonaWriterError,
+  type WorkforcePersonaPrewriteRepairAttempt,
 } from './workforce-persona-writer.js';
+
+const DEFAULT_WORKFORCE_PERSONA_PREWRITE_REPAIR_ATTEMPTS = 3;
+const MAX_WORKFORCE_PERSONA_PREWRITE_REPAIR_ATTEMPTS = 8;
 
 export function generate(input: GenerationInput): GenerationResult {
   const skillContext = loadSkills(input.spec, input.skillOverrides, input.templateOverride);
@@ -95,13 +99,18 @@ export async function generateWithWorkforcePersona(input: GenerationInput): Prom
     let finalArtifact = applyPersonaArtifactToRenderedArtifact(artifact, personaResult);
     let validation = validateGeneratedArtifact(finalArtifact, baseResult.patternDecision, baseResult.skillContext, input.spec);
     let finalPersonaMetadata = personaResult.metadata;
+    const repairAttempts = resolvePrewriteRepairAttempts(input.workforcePersonaWriter?.repairAttempts);
+    const previousRepairAttempts: WorkforcePersonaPrewriteRepairAttempt[] = [];
 
-    if (!validation.valid) {
+    for (let repairAttempt = 1; !validation.valid && repairAttempt <= repairAttempts; repairAttempt += 1) {
+      const requestedFixes = validation.errors;
       const repairResult = await writeWorkflowWithWorkforcePersona(input.spec, {
         ...writerOptions,
+        tier: workforcePersonaTierForRepairAttempt(writerOptions.tier, repairAttempt),
         validationFeedback: {
-          errors: validation.errors,
+          errors: requestedFixes,
           previousContent: finalArtifact.content,
+          previousAttempts: previousRepairAttempts,
         },
       });
       const repairedArtifact = applyPersonaArtifactToRenderedArtifact(artifact, repairResult);
@@ -117,19 +126,31 @@ export async function generateWithWorkforcePersona(input: GenerationInput): Prom
             'Ricky pre-write validation repaired the Workforce persona artifact before writing.',
           ],
         };
-      } else {
-        const fallbackMessage = `Ricky pre-write validation rejected the Workforce persona artifact after repair (${repairValidation.errors[0] ?? 'unknown validation error'}); used Ricky deterministic renderer instead.`;
-        const fallbackIssue = warningIssue('validation', 'WORKFORCE_PERSONA_PREWRITE_REPAIR_FALLBACK', fallbackMessage);
-        return {
-          ...baseResult,
-          success: true,
-          validation: addValidationWarning(baseResult.validation, fallbackIssue),
-          workforcePersona: {
-            ...repairResult.metadata,
-            warnings: [...repairResult.metadata.warnings, fallbackMessage],
-          },
-        };
+        break;
       }
+
+      previousRepairAttempts.push({
+        attempt: repairAttempt,
+        requestedFixes,
+        returnedErrors: repairValidation.errors,
+      });
+      finalArtifact = repairedArtifact;
+      validation = repairValidation;
+      finalPersonaMetadata = repairResult.metadata;
+    }
+
+    if (!validation.valid) {
+      const fallbackMessage = `Ricky pre-write validation rejected the Workforce persona artifact after ${repairAttempts} repair attempt(s) (${validation.errors[0] ?? 'unknown validation error'}); used Ricky deterministic renderer instead.`;
+      const fallbackIssue = warningIssue('validation', 'WORKFORCE_PERSONA_PREWRITE_REPAIR_FALLBACK', fallbackMessage);
+      return {
+        ...baseResult,
+        success: true,
+        validation: addValidationWarning(baseResult.validation, fallbackIssue),
+        workforcePersona: {
+          ...finalPersonaMetadata,
+          warnings: [...finalPersonaMetadata.warnings, fallbackMessage],
+        },
+      };
     }
 
     const plannedChecks = buildPlannedChecks(finalArtifact, input.dryRunEnabled !== false);
@@ -184,6 +205,16 @@ export async function generateWithWorkforcePersona(input: GenerationInput): Prom
       },
     };
   }
+}
+
+function resolvePrewriteRepairAttempts(value: number | undefined): number {
+  if (value === undefined) return DEFAULT_WORKFORCE_PERSONA_PREWRITE_REPAIR_ATTEMPTS;
+  if (!Number.isFinite(value)) return DEFAULT_WORKFORCE_PERSONA_PREWRITE_REPAIR_ATTEMPTS;
+  return Math.max(0, Math.min(MAX_WORKFORCE_PERSONA_PREWRITE_REPAIR_ATTEMPTS, Math.floor(value)));
+}
+
+function workforcePersonaTierForRepairAttempt(tier: string | undefined, repairAttempt: number): string | undefined {
+  return repairAttempt > 3 ? 'best' : tier;
 }
 
 export function validateGeneratedArtifact(

--- a/src/product/generation/pipeline.ts
+++ b/src/product/generation/pipeline.ts
@@ -22,7 +22,7 @@ import {
   type WorkforcePersonaPrewriteRepairAttempt,
 } from './workforce-persona-writer.js';
 
-const DEFAULT_WORKFORCE_PERSONA_PREWRITE_REPAIR_ATTEMPTS = 3;
+const DEFAULT_WORKFORCE_PERSONA_PREWRITE_REPAIR_ATTEMPTS = 4;
 const MAX_WORKFORCE_PERSONA_PREWRITE_REPAIR_ATTEMPTS = 8;
 
 export function generate(input: GenerationInput): GenerationResult {

--- a/src/product/generation/types.ts
+++ b/src/product/generation/types.ts
@@ -51,6 +51,8 @@ export interface GenerationInput {
     installSkills?: boolean;
     installRoot?: string;
     tier?: string;
+    /** Maximum pre-write validation repair attempts before falling back to deterministic rendering. */
+    repairAttempts?: number;
     personaIntentCandidates?: readonly string[];
     resolver?: import('./workforce-persona-writer.js').WorkforcePersonaResolver;
   };

--- a/src/product/generation/workforce-persona-repairer.test.ts
+++ b/src/product/generation/workforce-persona-repairer.test.ts
@@ -17,6 +17,20 @@ describe('workforce persona workflow repairer', () => {
       previousRunId: 'relay-run-1',
       attempt: 1,
       maxAttempts: 3,
+      previousAttempts: [{
+        attempt: 1,
+        repairedArtifactPath: 'workflows/generated/failing.ts',
+        repairSummary: 'added env loader',
+        repairMode: 'workforce-persona',
+        retryAttempt: 2,
+        outcome: {
+          status: 'blocker',
+          failedStep: 'install-deps',
+          blockerCode: 'MISSING_ENV_VAR',
+          runId: 'relay-run-2',
+          debuggerSummary: 'same env assertion still failed',
+        },
+      }],
     });
 
     expect(task).toContain('Repair an Agent Relay workflow artifact for Ricky');
@@ -27,6 +41,9 @@ describe('workforce persona workflow repairer', () => {
     expect(task).toContain('--start-from');
     expect(task).toContain('Structured response contract');
     expect(task).toContain('Do not echo the schema, do not return a patch');
+    expect(task).toContain('Previous repair attempts that did not resolve the workflow');
+    expect(task).toContain('added env loader');
+    expect(task).toContain('same repair strategy');
   });
 
   it('invokes the workflow persona and returns a full repaired artifact', async () => {
@@ -97,6 +114,49 @@ describe('workforce persona workflow repairer', () => {
       },
     });
     expect(resolverOptions).toEqual([{ tier: 'best', installRoot: '/state/ricky/persona-repair-skills' }]);
+  });
+
+  it('upgrades repair persona resolution to best after the third failed retry', async () => {
+    const resolverOptions: Array<Record<string, unknown>> = [];
+    const resolver: WorkforcePersonaResolver = async (_intents, options) => {
+      resolverOptions.push(options);
+      return {
+        source: 'package',
+        intent: 'agent-relay-workflow',
+        warnings: [],
+        context: {
+          selection: {
+            personaId: 'agent-relay-workflow',
+            tier: options?.tier ?? 'minimum',
+            runtime: { harness: 'codex', model: 'codex/test' },
+          },
+          sendMessage() {
+            return execution(JSON.stringify({
+              artifact: {
+                path: 'workflows/generated/failing.ts',
+                content: workflowSource('after'),
+              },
+              metadata: { summary: 'patched after escalation' },
+            }));
+          },
+        },
+      };
+    };
+
+    await repairWorkflowWithWorkforcePersona({
+      repoRoot: '/repo',
+      artifactPath: 'workflows/generated/failing.ts',
+      artifactContent: workflowSource('before'),
+      evidence: { runId: 'relay-run-4', status: 'failed' },
+      classification: { failureClass: 'retry_exhaustion' },
+      debuggerResult: { repairMode: 'guided', summary: 'still failing after repairs' },
+      attempt: 4,
+      maxAttempts: 5,
+      tier: 'minimum',
+      resolver,
+    });
+
+    expect(resolverOptions).toEqual([{ tier: 'best' }]);
   });
 });
 

--- a/src/product/generation/workforce-persona-repairer.test.ts
+++ b/src/product/generation/workforce-persona-repairer.test.ts
@@ -113,7 +113,7 @@ describe('workforce persona workflow repairer', () => {
         maxAttempts: 3,
       },
     });
-    expect(resolverOptions).toEqual([{ tier: 'best', installRoot: '/state/ricky/persona-repair-skills' }]);
+    expect(resolverOptions).toEqual([{ tier: 'best-value', installRoot: '/state/ricky/persona-repair-skills' }]);
   });
 
   it('upgrades repair persona resolution to best after the third failed retry', async () => {

--- a/src/product/generation/workforce-persona-repairer.ts
+++ b/src/product/generation/workforce-persona-repairer.ts
@@ -22,6 +22,7 @@ export interface WorkforcePersonaRepairOptions {
   blocker?: unknown;
   failedStep?: string;
   previousRunId?: string;
+  previousAttempts?: WorkforcePersonaRepairAttempt[];
   attempt: number;
   maxAttempts: number;
   timeoutSeconds?: number;
@@ -33,6 +34,23 @@ export interface WorkforcePersonaRepairOptions {
   onProgress?: WorkforcePersonaSendOptions['onProgress'];
   personaIntentCandidates?: readonly string[];
   resolver?: WorkforcePersonaResolver;
+}
+
+export interface WorkforcePersonaRepairAttempt {
+  attempt: number;
+  repairedArtifactPath: string;
+  repairSummary: string;
+  repairMode: string;
+  personaRunId?: string;
+  retryAttempt: number;
+  outcome: {
+    status: 'failed' | 'blocker' | 'error';
+    failedStep?: string;
+    blockerCode?: string;
+    runId?: string;
+    classification?: unknown;
+    debuggerSummary?: string;
+  };
 }
 
 export interface WorkforcePersonaRepairMetadata {
@@ -166,11 +184,15 @@ export function buildWorkflowRepairPersonaTask(options: WorkforcePersonaRepairOp
       evidence: options.evidence,
     }),
     '',
+    'Previous repair attempts that did not resolve the workflow:',
+    safeJson(options.previousAttempts ?? []),
+    '',
     'Repair requirements:',
     '- Return only the final response object or fallback fenced artifact blocks. Do not echo the schema, do not return a patch, and do not describe the patch outside metadata.',
     '- Return the full repaired TypeScript workflow artifact, not a diff.',
     '- Preserve the artifact path and keep the workflow runnable from the same file.',
     '- Fix the workflow artifact itself; do not ask the user to run manual recovery unless the workflow cannot safely express the prerequisite.',
+    '- Treat previous repair attempts as negative evidence: account for why they did not resolve the next run, and do not repeat the same repair strategy unless the new evidence proves it was incomplete.',
     '- For MISSING_ENV_VAR failures, first make the workflow load repo-local `.env.local` and `.env` without overwriting shell exports, then add a fast `MISSING_ENV_VAR: NAME` assertion for known required variables before long-running agent steps. Do not fabricate secret values.',
     '- Preserve or improve the 80-to-100 loop: implementation, deterministic validation, review, final hard gate, and signoff evidence.',
     '- Ensure the failed step can be resumed by Ricky using --start-from with the failed step id and the previous run id.',
@@ -194,8 +216,10 @@ function digest(value: string): string {
   return createHash('sha256').update(value).digest('hex');
 }
 
-function personaResolverOptions(options: { tier?: string; installRoot?: string }): { tier?: string; installRoot?: string } {
-  const resolved: { tier?: string; installRoot?: string } = { tier: options.tier ?? DEFAULT_WORKFORCE_PERSONA_TIER };
+function personaResolverOptions(options: { tier?: string; installRoot?: string; attempt?: number }): { tier?: string; installRoot?: string } {
+  const resolved: { tier?: string; installRoot?: string } = {
+    tier: options.attempt !== undefined && options.attempt > 3 ? 'best' : options.tier ?? DEFAULT_WORKFORCE_PERSONA_TIER,
+  };
   if (options.installRoot) resolved.installRoot = options.installRoot;
   return resolved;
 }

--- a/src/product/generation/workforce-persona-repairer.ts
+++ b/src/product/generation/workforce-persona-repairer.ts
@@ -2,7 +2,6 @@ import { createHash } from 'node:crypto';
 
 import {
   defaultWorkforcePersonaResolver,
-  DEFAULT_WORKFORCE_PERSONA_TIER,
   parsePersonaWorkflowResponse,
   WORKFORCE_PERSONA_INTENT_CANDIDATES,
   WorkforcePersonaWriterError,
@@ -216,9 +215,12 @@ function digest(value: string): string {
   return createHash('sha256').update(value).digest('hex');
 }
 
+const DEFAULT_WORKFORCE_PERSONA_REPAIR_TIER = 'best-value';
+
 function personaResolverOptions(options: { tier?: string; installRoot?: string; attempt?: number }): { tier?: string; installRoot?: string } {
+  const baseTier = options.tier ?? DEFAULT_WORKFORCE_PERSONA_REPAIR_TIER;
   const resolved: { tier?: string; installRoot?: string } = {
-    tier: options.attempt !== undefined && options.attempt > 3 ? 'best' : options.tier ?? DEFAULT_WORKFORCE_PERSONA_TIER,
+    tier: options.attempt !== undefined && options.attempt > 3 ? 'best' : baseTier,
   };
   if (options.installRoot) resolved.installRoot = options.installRoot;
   return resolved;

--- a/src/product/generation/workforce-persona-writer.test.ts
+++ b/src/product/generation/workforce-persona-writer.test.ts
@@ -317,6 +317,70 @@ describe('workforce persona workflow writer', () => {
     );
   });
 
+  it('threads failed pre-write repair attempts into later persona repairs and escalates attempt four to best', async () => {
+    const base = generate({
+      spec: spec({
+        description: 'Implement a strict Agent Relay workflow with tests and review.',
+        targetFiles: ['src/product/generation/pipeline.ts'],
+      }),
+      artifactPath: 'workflows/generated/prewrite-learning.ts',
+    });
+    expect(base.success).toBe(true);
+    const tasks: string[] = [];
+    const resolverOptions: Array<Record<string, unknown> | undefined> = [];
+    const resolver: WorkforcePersonaResolver = async (_intents, options) => {
+      resolverOptions.push(options);
+      return {
+        source: 'package',
+        intent: 'agent-relay-workflow',
+        warnings: [],
+        context: {
+          selection: {
+            personaId: 'agent-relay-workflow',
+            tier: options?.tier ?? 'best',
+            runtime: { harness: 'codex', model: 'codex/test' },
+          },
+          sendMessage(task) {
+            tasks.push(task);
+            const content = tasks.length < 5
+              ? `${base.artifact!.content}\n}`
+              : base.artifact!.content;
+            return execution(personaResponse('workflows/generated/prewrite-learning.ts', content));
+          },
+        },
+      };
+    };
+
+    const result = await generateWithWorkforcePersona({
+      spec: spec({
+        description: 'Implement a strict Agent Relay workflow with tests and review.',
+        targetFiles: ['src/product/generation/pipeline.ts'],
+      }),
+      artifactPath: 'workflows/generated/prewrite-learning.ts',
+      workforcePersonaWriter: {
+        repoRoot: '/repo',
+        workflowName: 'prewrite-learning',
+        targetMode: 'local',
+        tier: 'minimum',
+        repairAttempts: 4,
+        resolver,
+      },
+    });
+
+    expect(result.success).toBe(true);
+    expect(tasks).toHaveLength(5);
+    expect(tasks[4]).toContain('Previous pre-write repair attempts that still failed');
+    expect(tasks[4]).toContain('"attempt": 3');
+    expect(tasks[4]).toContain('Use those failed repair attempts as negative evidence');
+    expect(resolverOptions.map((options) => options?.tier)).toEqual([
+      'minimum',
+      'minimum',
+      'minimum',
+      'minimum',
+      'best',
+    ]);
+  });
+
   it('falls back to Ricky deterministic rendering when persona pre-write repair is still invalid', async () => {
     const base = generate({
       spec: spec({

--- a/src/product/generation/workforce-persona-writer.ts
+++ b/src/product/generation/workforce-persona-writer.ts
@@ -111,10 +111,19 @@ export interface WorkforcePersonaWriterOptions {
   personaIntentCandidates?: readonly string[];
   resolver?: WorkforcePersonaResolver;
   skillContext?: SkillContext;
-  validationFeedback?: {
-    errors: string[];
-    previousContent: string;
-  };
+  validationFeedback?: WorkforcePersonaValidationFeedback;
+}
+
+export interface WorkforcePersonaValidationFeedback {
+  errors: string[];
+  previousContent: string;
+  previousAttempts?: WorkforcePersonaPrewriteRepairAttempt[];
+}
+
+export interface WorkforcePersonaPrewriteRepairAttempt {
+  attempt: number;
+  requestedFixes: string[];
+  returnedErrors: string[];
 }
 
 export interface WorkforcePersonaWriterMetadata {
@@ -451,10 +460,7 @@ export function buildWorkflowPersonaTask(
     outputPath: string;
     relevantFiles: Array<{ path: string; content?: string }>;
     skillContext?: SkillContext;
-    validationFeedback?: {
-      errors: string[];
-      previousContent: string;
-    };
+    validationFeedback?: WorkforcePersonaValidationFeedback;
   },
 ): string {
   const contract = {
@@ -551,7 +557,7 @@ export function buildWorkflowPersonaTask(
 }
 
 function renderValidationFeedbackForPersona(
-  feedback: { errors: string[]; previousContent: string } | undefined,
+  feedback: WorkforcePersonaValidationFeedback | undefined,
 ): string[] {
   if (!feedback) return [];
   return [
@@ -561,6 +567,15 @@ function renderValidationFeedbackForPersona(
     'Validation errors:',
     safeJson(feedback.errors),
     '',
+    ...(feedback.previousAttempts && feedback.previousAttempts.length > 0
+      ? [
+          'Previous pre-write repair attempts that still failed:',
+          safeJson(feedback.previousAttempts),
+          '',
+          'Use those failed repair attempts as negative evidence. Do not repeat the same fix unless the current validation errors prove it was incomplete.',
+          '',
+        ]
+      : []),
     'Previous rejected artifact:',
     '```ts',
     feedback.previousContent.trimEnd(),


### PR DESCRIPTION
## Summary
- feed failed runtime workflow repair attempts back into the next Workforce repair persona call
- include pre-write persona repair history when generated workflow validation keeps failing
- escalate repair persona resolution to tier `best` after the third repair attempt

## Tests
- npm run typecheck
- npm test