### PR TITLE
fix(spec-intake): pin --spec-file handoffs to generate intent

### DIFF
--- a/src/local/entrypoint.test.ts
+++ b/src/local/entrypoint.test.ts
@@ -2206,6 +2206,32 @@ describe('runLocal', () => {
     expect(result.logs.some((l) => l.includes('[local] workflow generation'))).toBe(false);
   });
 
+  it('routes a non-executable CLI specFile to generate even when the spec body mentions a workflow path', async () => {
+    const localExecutor = memoryLocalExecutorOptions();
+    const designDoc = [
+      '# Relay-backed review runtime',
+      '',
+      'The durable deep-review path in `workflows/runtime/deep-review-pr.ts` is the foundation we want to extend.',
+      'Run, launch, and start references are scattered through the runtime narrative below.',
+      'Author a workflow that wires the new runtime end-to-end.',
+    ].join('\n');
+    const result = await runLocal(
+      {
+        source: 'cli',
+        spec: designDoc,
+        specFile: '/specs/relay-backed-review-runtime-spec.md',
+        stageMode: 'generate',
+        cliMetadata: { argv: ['ricky', '--mode', 'local', '--spec-file', '/specs/relay-backed-review-runtime-spec.md'] },
+      },
+      { localExecutor },
+    );
+
+    expect(result.ok).toBe(true);
+    expect(result.logs.some((l) => l.includes('[local] spec intake route: generate'))).toBe(true);
+    expect(result.logs.some((l) => l.includes('[local] spec intake route: clarify'))).toBe(false);
+    expect(result.logs.some((l) => l.includes('[local] workflow generation: passed'))).toBe(true);
+  });
+
   it('returns local artifact and runtime log shape for an injected runtime adapter', async () => {
     const localExecutor = memoryLocalExecutorOptions({
       stdout: ['local workflow completed'],

--- a/src/local/entrypoint.ts
+++ b/src/local/entrypoint.ts
@@ -1375,13 +1375,19 @@ function toRawSpecPayload(
     };
   }
 
-  // Explicit CLI description handoff — the user handed over prose, not a
-  // workflow path. Bypass the keyword-based intent classifier (which
+  // Explicit CLI description handoff — the user handed Ricky prose (or a
+  // spec file) rather than an executable workflow path, so the request is
+  // to author one. Bypass the keyword-based intent classifier, which
   // over-fires on words like "run" / "execute" that appear naturally in
-  // feature specs) and route straight to generate. Only applies when the
-  // spec text contains no workflow file reference; otherwise the spec is
-  // a "run X" request and the natural-language classifier handles it.
-  if (request.source === 'cli' && !mentionsWorkflowFile(request.spec)) {
+  // feature specs.
+  //
+  // When --spec-file points at a non-executable path, force generate
+  // regardless of what the file mentions: a workflow path inside a design
+  // doc is context, not an invocation target (executable specPaths are
+  // already handled above). For inline --spec prose, keep the older guard
+  // so "run workflows/foo.ts" still flows to the natural-language
+  // classifier.
+  if (request.source === 'cli' && (request.specPath || !mentionsWorkflowFile(request.spec))) {
     return {
       ...base,
       kind: 'structured_json',


### PR DESCRIPTION
## Summary
- `ricky --mode local --spec-file <design-doc.md>` was failing with `Generation: failed (status: error). Reason: targetRepo: No target repository was provided. Next: Provide the workflow artifact path...`
- Root cause: spec-intake bypass for CLI prose handoffs (`toRawSpecPayload` in `src/local/entrypoint.ts`) was gated on `!mentionsWorkflowFile(request.spec)`. Long design docs that reference an existing workflow as **context** (e.g. `workflows/runtime/deep-review-pr.ts`) tripped the guard, fell through to the natural-language classifier, and got scored as `execute` because feature specs naturally contain "run"/"launch"/"start" many times. The router then bailed to `clarify`.
- Fix: when `--spec-file` resolves to a non-executable path, force `intent: generate` regardless of what the file body mentions. A workflow path inside a design doc is context, not an invocation target. Inline `--spec` prose keeps the older guard so `"run workflows/foo.ts"` still routes through natural-language detection. Executable specPaths (`workflows/**/*.ts`, `*.workflow.ts`) continue to take the existing execute branch above this one.

## Test plan
- [x] `npx vitest run src/local/entrypoint.test.ts` — 110/110 pass, including the new `routes a non-executable CLI specFile to generate even when the spec body mentions a workflow path` case.
- [x] `npx vitest run src/local src/product/spec-intake src/surfaces/cli` — 451/451 pass.
- [x] `npx tsc --noEmit -p tsconfig.json` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)