### PR TITLE
fix: harden publish workflow against stale main

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -32,6 +32,10 @@ permissions:
   contents: write
   id-token: write
 
+concurrency:
+  group: publish-ricky-main
+  cancel-in-progress: false
+
 jobs:
   publish-ricky:
     runs-on: ubuntu-latest
@@ -41,6 +45,24 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+
+      - name: Verify publish branch is current
+        run: |
+          if [ "$GITHUB_REF_NAME" != "main" ]; then
+            echo "::error::Publish must be dispatched from main, got $GITHUB_REF_NAME"
+            exit 1
+          fi
+
+          git fetch origin main --tags
+          LOCAL_SHA="$(git rev-parse HEAD)"
+          REMOTE_SHA="$(git rev-parse origin/main)"
+
+          if [ "$LOCAL_SHA" != "$REMOTE_SHA" ]; then
+            echo "::error::origin/main moved before publish. Re-run from the latest main."
+            echo "Local:  $LOCAL_SHA"
+            echo "Remote: $REMOTE_SHA"
+            exit 1
+          fi
 
       - name: Setup Node
         uses: actions/setup-node@v4
@@ -68,28 +90,30 @@ jobs:
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
-          git add package.json
+          git add package.json package-lock.json
           git commit -m "chore(release): @agentworkforce/ricky v${{ steps.bump.outputs.version }}"
+
+      - name: Tag + push release commit
+        if: ${{ github.event.inputs.dry_run != 'true' }}
+        run: |
+          git tag "ricky-v${{ steps.bump.outputs.version }}"
+          git push --atomic origin HEAD:main "refs/tags/ricky-v${{ steps.bump.outputs.version }}"
 
       - name: Install latest npm
         run: npm install -g npm@latest
 
       - name: Publish (dry run)
         if: ${{ github.event.inputs.dry_run == 'true' }}
-        run: npm publish --dry-run --access public --tag ${{ github.event.inputs.tag }}
+        run: npm publish --dry-run --access public --tag "${{ github.event.inputs.tag }}"
 
       - name: Publish to npm
         if: ${{ github.event.inputs.dry_run != 'true' }}
-        run: npm publish --provenance --access public --tag ${{ github.event.inputs.tag }}
-
-      - name: Tag + push
-        if: ${{ github.event.inputs.dry_run != 'true' }}
-        run: |
-          git tag ricky-v${{ steps.bump.outputs.version }}
-          git push origin main --follow-tags
+        run: npm publish --provenance --access public --tag "${{ github.event.inputs.tag }}"
 
       - name: Summary
         run: |
-          echo "Published: @agentworkforce/ricky@${{ steps.bump.outputs.version }}" >> $GITHUB_STEP_SUMMARY
-          echo "Tag: ${{ github.event.inputs.tag }}" >> $GITHUB_STEP_SUMMARY
-          echo "Dry run: ${{ github.event.inputs.dry_run }}" >> $GITHUB_STEP_SUMMARY
+          {
+            echo "Published: @agentworkforce/ricky@${{ steps.bump.outputs.version }}"
+            echo "Tag: ${{ github.event.inputs.tag }}"
+            echo "Dry run: ${{ github.event.inputs.dry_run }}"
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@agentworkforce/ricky",
-  "version": "0.1.23",
+  "version": "0.1.26",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@agentworkforce/ricky",
-      "version": "0.1.23",
+      "version": "0.1.26",
       "license": "Apache-2.0",
       "dependencies": {
         "@agent-assistant/turn-context": "^0.4.23",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agentworkforce/ricky",
-  "version": "0.1.25",
+  "version": "0.1.26",
   "license": "Apache-2.0",
   "description": "Workflow reliability, coordination, and authoring product for AgentWorkforce",
   "repository": {


### PR DESCRIPTION
## Summary
- fail publish dispatches that are not running from current main
- serialize publish workflow runs and atomically push the release commit/tag before npm publish
- include package-lock.json in release commits and reconcile repo metadata to the already-published 0.1.26

## Validation
- npm ci
- actionlint .github/workflows/publish.yml
- npm test

## Note
No npm install was needed; npm version 0.1.26 --no-git-tag-version updated only package metadata, and npm ci verified the lockfile.