### PR TITLE
feat(spec-intake): clarification questions for ambiguous specs

### DIFF
--- a/src/local/entrypoint.test.ts
+++ b/src/local/entrypoint.test.ts
@@ -1254,6 +1254,41 @@ describe('runLocal', () => {
     expect(localExecutor.runner.invocations).toHaveLength(0);
   });
 
+  it('returns structured clarification questions instead of generating from unresolved specs', async () => {
+    const localExecutor = memoryLocalExecutorOptions({ stdout: ['should not launch'] });
+    const result = await runLocal(
+      {
+        source: 'cli',
+        spec: [
+          'Generate a workflow for package validation.',
+          'Open questions:',
+          '- Should it validate package A or package B?',
+        ].join('\n'),
+      },
+      { localExecutor },
+    );
+
+    expect(result.ok).toBe(false);
+    expect(result.exitCode).toBe(1);
+    expect(result.generation).toMatchObject({
+      stage: 'generate',
+      status: 'needs_clarification',
+      decisions: {
+        clarification_questions: [
+          expect.objectContaining({
+            id: 'open-question-1',
+            question: 'Should it validate package A or package B?',
+            blocking: true,
+          }),
+        ],
+      },
+    });
+    expect(result.clarificationQuestions).toEqual(result.generation?.decisions?.clarification_questions);
+    expect(result.nextActions).toContain('Clarify: Should it validate package A or package B?');
+    expect(workflowArtifactWrites(localExecutor.writes)).toHaveLength(0);
+    expect(localExecutor.runner.invocations).toHaveLength(0);
+  });
+
   it('emits the generation stage contract when generation mode is explicit', async () => {
     const localExecutor = memoryLocalExecutorOptions({ stdout: ['should not launch'] });
     const result = await runLocal(

--- a/src/local/entrypoint.ts
+++ b/src/local/entrypoint.ts
@@ -22,7 +22,7 @@ import { runWithAutoFix } from './auto-fix-loop.js';
 import { generate, generateWithWorkforcePersona } from '../product/generation/index.js';
 import type { GenerationInput, GenerationResult, RenderedArtifact } from '../product/generation/index.js';
 import { intake } from '../product/spec-intake/index.js';
-import type { ExecutionPreference, InputSurface, RawSpecPayload, RouteTarget } from '../product/spec-intake/index.js';
+import type { ClarificationQuestion, ExecutionPreference, InputSurface, RawSpecPayload, RouteTarget } from '../product/spec-intake/index.js';
 import { defaultRepoDetector, type RepoDetector } from '../product/spec-intake/detect-current-repo.js';
 import { LocalCoordinator } from '../runtime/local-coordinator.js';
 import { DEFAULT_RUN_TIMEOUT_MS } from '../shared/constants.js';
@@ -58,7 +58,7 @@ export interface LocalResponseArtifact {
   content?: string;
 }
 
-export type LocalGenerationStatus = 'ok' | 'error';
+export type LocalGenerationStatus = 'ok' | 'error' | 'needs_clarification';
 export type LocalExecutionStatus = 'success' | 'blocker' | 'error';
 
 export interface LocalAssistantTurnContextDecision {
@@ -88,6 +88,7 @@ export interface LocalGenerationStageResult {
     tool_selection?: unknown;
     refinement?: unknown;
     workforce_persona?: unknown;
+    clarification_questions?: ClarificationQuestion[];
     assistant_turn_context?: LocalAssistantTurnContextDecision;
   };
 }
@@ -180,6 +181,8 @@ export interface LocalResponse {
   warnings: string[];
   /** Suggested next actions for the user. */
   nextActions: string[];
+  /** Structured questions Ricky needs answered before it can safely continue. */
+  clarificationQuestions?: ClarificationQuestion[];
   /** Stage 1 result: artifact generation or artifact selection. */
   generation?: LocalGenerationStageResult;
   /** Stage 2 result: populated only when run behavior was requested. */
@@ -971,14 +974,23 @@ export function createLocalExecutor(options: LocalExecutorOptions = {}): LocalEx
 
       if (!intakeResult.routing || intakeResult.routing.target === 'clarify' || !intakeResult.success) {
         if (intakeResult.routing?.suggestedFollowUp) nextActions.push(intakeResult.routing.suggestedFollowUp);
+        nextActions.push(...clarificationNextActions(intakeResult.clarificationQuestions));
         nextActions.push('Clarify the local workflow request and retry.');
         generationStage = {
           stage: 'generate',
-          status: 'error',
+          status: intakeResult.clarificationQuestions.length > 0 ? 'needs_clarification' : 'error',
           error: warnings[0] ?? 'Spec intake could not produce an executable workflow artifact.',
-          ...decisionsForAssistantTurnContext(assistantTurnContext),
+          ...decisionsForClarification(intakeResult.clarificationQuestions, assistantTurnContext),
         };
-        return { ok: false, artifacts, logs, warnings, nextActions, ...stageResponse(includeStageContract, generationStage, undefined, 1) };
+        return {
+          ok: false,
+          artifacts,
+          logs,
+          warnings,
+          nextActions,
+          ...(intakeResult.clarificationQuestions.length > 0 ? { clarificationQuestions: intakeResult.clarificationQuestions } : {}),
+          ...stageResponse(includeStageContract, generationStage, undefined, 1),
+        };
       }
 
       const workflowFile = workflowFileForRoute(
@@ -1029,16 +1041,27 @@ export function createLocalExecutor(options: LocalExecutorOptions = {}): LocalEx
 
         if (!generationResult.success || !artifact) {
           warnings.push(...generationResult.validation.errors);
+          nextActions.push(...clarificationNextActions(generationResult.clarificationQuestions ?? []));
           nextActions.push(nextActionForGenerationFailure(generationResult.validation.errors));
           generationStage = createGenerationStage(
-            'error',
+            (generationResult.clarificationQuestions?.length ?? 0) > 0 ? 'needs_clarification' : 'error',
             artifact,
             specDigest,
             generationResult.validation.errors[0],
             generationResult,
             assistantTurnContext,
           );
-          return { ok: false, artifacts, logs, warnings, nextActions, ...stageResponse(includeStageContract, generationStage, undefined, 1) };
+          return {
+            ok: false,
+            artifacts,
+            logs,
+            warnings,
+            nextActions,
+            ...((generationResult.clarificationQuestions?.length ?? 0) > 0
+              ? { clarificationQuestions: generationResult.clarificationQuestions }
+              : {}),
+            ...stageResponse(includeStageContract, generationStage, undefined, 1),
+          };
         }
 
         onProgress?.(`Writing workflow artifact to ${artifact.artifactPath}...`);
@@ -1555,6 +1578,7 @@ function createGenerationStage(
             tool_selection: generationResult.toolSelection.selections,
             ...(generationResult.refinement ? { refinement: generationResult.refinement } : {}),
             ...(generationResult.workforcePersona ? { workforce_persona: generationResult.workforcePersona } : {}),
+            ...((generationResult.clarificationQuestions?.length ?? 0) > 0 ? { clarification_questions: generationResult.clarificationQuestions } : {}),
             ...(assistantTurnContext ? { assistant_turn_context: assistantTurnContext } : {}),
           },
         }
@@ -1563,9 +1587,31 @@ function createGenerationStage(
 }
 
 function nextActionForGenerationFailure(errors: string[]): string {
+  if (errors.some((error) => /needs clarification|WORKFORCE_PERSONA_NEEDS_CLARIFICATION/i.test(error))) {
+    return 'Answer the clarification questions before local workflow generation continues.';
+  }
   return errors.some((error) => /Workforce persona/i.test(error))
     ? 'Fix the Workforce persona response contract before local execution.'
     : 'Fix the generated workflow validation errors before local execution.';
+}
+
+function clarificationNextActions(questions: ClarificationQuestion[]): string[] {
+  return questions
+    .filter((question) => question.blocking)
+    .map((question) => `Clarify: ${question.question}`);
+}
+
+function decisionsForClarification(
+  questions: ClarificationQuestion[],
+  assistantTurnContext: LocalAssistantTurnContextDecision | undefined,
+): Pick<LocalGenerationStageResult, 'decisions'> {
+  if (questions.length === 0) return decisionsForAssistantTurnContext(assistantTurnContext);
+  return {
+    decisions: {
+      clarification_questions: questions,
+      ...(assistantTurnContext ? { assistant_turn_context: assistantTurnContext } : {}),
+    },
+  };
 }
 
 async function writeGenerationMetadataArtifacts(

--- a/src/product/generation/index.ts
+++ b/src/product/generation/index.ts
@@ -11,6 +11,7 @@ export {
   loadWorkforcePersonaModule,
   parsePersonaWorkflowResponse,
   writeWorkflowWithWorkforcePersona,
+  WorkforcePersonaClarificationError,
 } from './workforce-persona-writer.js';
 export type {
   DeterministicGate,

--- a/src/product/generation/pipeline.ts
+++ b/src/product/generation/pipeline.ts
@@ -18,6 +18,7 @@ import { renderWorkflow } from './template-renderer.js';
 import {
   applyPersonaArtifactToRenderedArtifact,
   writeWorkflowWithWorkforcePersona,
+  WorkforcePersonaClarificationError,
   WorkforcePersonaWriterError,
   type WorkforcePersonaPrewriteRepairAttempt,
 } from './workforce-persona-writer.js';
@@ -168,6 +169,27 @@ export async function generateWithWorkforcePersona(input: GenerationInput): Prom
       workforcePersona: finalPersonaMetadata,
     };
   } catch (error) {
+    if (error instanceof WorkforcePersonaClarificationError) {
+      const issue = blockingIssue(
+        'rendering',
+        'WORKFORCE_PERSONA_NEEDS_CLARIFICATION',
+        error.message,
+      );
+      const validation = {
+        ...baseResult.validation,
+        valid: false,
+        errors: [...baseResult.validation.errors, issue.message],
+        issues: [...baseResult.validation.issues, issue],
+      };
+      return {
+        ...baseResult,
+        success: false,
+        artifact: null,
+        clarificationQuestions: error.questions,
+        validation,
+        workforcePersona: null,
+      };
+    }
     const writerError = error instanceof WorkforcePersonaWriterError ? error : null;
     const issue = blockingIssue(
       'rendering',

--- a/src/product/generation/types.ts
+++ b/src/product/generation/types.ts
@@ -1,4 +1,4 @@
-import type { ExecutionPreference, NormalizedWorkflowSpec } from '../spec-intake/types.js';
+import type { ClarificationQuestion, ExecutionPreference, NormalizedWorkflowSpec } from '../spec-intake/types.js';
 import type { SwarmPattern } from '../../shared/models/workflow-config.js';
 import type { VerificationType } from '../../shared/models/workflow-evidence.js';
 
@@ -235,6 +235,7 @@ export interface WorkflowExecutionRoute {
 export interface GenerationResult {
   success: boolean;
   artifact: RenderedArtifact | null;
+  clarificationQuestions?: ClarificationQuestion[];
   patternDecision: PatternDecision;
   skillContext: SkillContext;
   toolSelection: ToolSelectionContext;

--- a/src/product/generation/workforce-persona-repairer.ts
+++ b/src/product/generation/workforce-persona-repairer.ts
@@ -115,6 +115,10 @@ export async function repairWorkflowWithWorkforcePersona(
   }
 
   const parsed = parsePersonaWorkflowResponse(result.output, options.artifactPath);
+  if (parsed.clarification || !parsed.content) {
+    throw new WorkforcePersonaWriterError('Workforce persona repair response must include a repaired workflow artifact.');
+  }
+  const responseFormat = parsed.responseFormat as 'structured-json' | 'fenced-artifact';
   return {
     artifact: {
       content: parsed.content,
@@ -130,7 +134,7 @@ export async function repairWorkflowWithWorkforcePersona(
       runId: result.workflowRunId ?? runId,
       source: resolved.source,
       selectedIntent: resolved.intent,
-      responseFormat: parsed.responseFormat,
+      responseFormat,
       outputPath: options.artifactPath,
     },
   };

--- a/src/product/generation/workforce-persona-writer.test.ts
+++ b/src/product/generation/workforce-persona-writer.test.ts
@@ -91,6 +91,36 @@ describe('workforce persona workflow writer', () => {
     expect(parsed.metadata).toMatchObject({ workflowName: 'persona' });
   });
 
+  it('parses persona clarification requests without requiring an artifact', () => {
+    const parsed = parsePersonaWorkflowResponse(JSON.stringify({
+      needs_clarification: {
+        status: 'needs_clarification',
+        reason: 'Deployment target is unclear.',
+        questions: [
+          {
+            id: 'deployment-target',
+            question: 'Should the workflow deploy to staging or production?',
+            reason: 'The spec names deployment but not the target environment.',
+            blocking: true,
+            defaultAssumption: 'Pause before deploy.',
+          },
+        ],
+      },
+    }), 'workflows/generated/persona.ts');
+
+    expect(parsed.responseFormat).toBe('needs-clarification');
+    expect(parsed.clarification).toMatchObject({
+      status: 'needs_clarification',
+      questions: [
+        {
+          id: 'deployment-target',
+          question: 'Should the workflow deploy to staging or production?',
+          blocking: true,
+        },
+      ],
+    });
+  });
+
   it('parses fenced TypeScript artifact plus JSON metadata fallback', () => {
     const parsed = parsePersonaWorkflowResponse([
       '```ts',
@@ -260,6 +290,59 @@ describe('workforce persona workflow writer', () => {
     expect(result.success).toBe(false);
     const errorText = result.validation.errors.join(' | ');
     expect(errorText).toMatch(/workflow|persona|fenced|structured/i);
+  });
+
+  it('returns persona clarification questions instead of falling back to deterministic rendering', async () => {
+    const resolver: WorkforcePersonaResolver = async () => ({
+      source: 'package',
+      intent: 'agent-relay-workflow',
+      warnings: [],
+      context: {
+        selection: {
+          personaId: 'agent-relay-workflow',
+          tier: 'best',
+          runtime: { harness: 'codex', model: 'codex/test' },
+        },
+        sendMessage() {
+          return execution(JSON.stringify({
+            needs_clarification: {
+              status: 'needs_clarification',
+              reason: 'Approval boundary is missing.',
+              questions: [
+                {
+                  id: 'side-effects',
+                  question: 'Should commits and pushes require approval?',
+                  reason: 'The workflow could otherwise perform irreversible side effects.',
+                  blocking: true,
+                },
+              ],
+            },
+          }));
+        },
+      },
+    });
+
+    const result = await generateWithWorkforcePersona({
+      spec: spec({ description: 'Generate a workflow for risky implementation work.' }),
+      artifactPath: 'workflows/generated/clarify.ts',
+      workforcePersonaWriter: {
+        repoRoot: '/repo',
+        workflowName: 'clarify',
+        targetMode: 'local',
+        resolver,
+      },
+    });
+
+    expect(result.success).toBe(false);
+    expect(result.artifact).toBeNull();
+    expect(result.clarificationQuestions).toEqual([
+      expect.objectContaining({
+        id: 'side-effects',
+        question: 'Should commits and pushes require approval?',
+        blocking: true,
+      }),
+    ]);
+    expect(result.validation.errors.join('\n')).toContain('needs clarification');
   });
 
   it('runs pre-write validation and asks the persona to repair invalid workflow syntax before succeeding', async () => {

--- a/src/product/generation/workforce-persona-writer.ts
+++ b/src/product/generation/workforce-persona-writer.ts
@@ -3,7 +3,7 @@ import { readFileSync } from 'node:fs';
 import { readFile } from 'node:fs/promises';
 import { isAbsolute, resolve } from 'node:path';
 
-import type { NormalizedWorkflowSpec } from '../spec-intake/types.js';
+import type { ClarificationQuestion, ClarificationRequest, NormalizedWorkflowSpec } from '../spec-intake/types.js';
 import type { RenderedArtifact, SkillContext, WorkflowExecutionTarget } from './types.js';
 
 export const WORKFORCE_PERSONA_INTENT_CANDIDATES = [
@@ -183,10 +183,24 @@ export class WorkforcePersonaWriterError extends Error {
   }
 }
 
+export class WorkforcePersonaClarificationError extends WorkforcePersonaWriterError {
+  readonly questions: ClarificationQuestion[];
+
+  constructor(questions: ClarificationQuestion[], warnings: string[] = []) {
+    super(
+      `Workforce persona needs clarification before workflow generation: ${questions.map((question) => question.question).join(' | ')}`,
+      warnings,
+    );
+    this.name = 'WorkforcePersonaClarificationError';
+    this.questions = questions;
+  }
+}
+
 interface ParsedPersonaResponse {
-  content: string;
+  content?: string;
   metadata: Record<string, unknown>;
-  responseFormat: WorkforcePersonaWriterMetadata['responseFormat'];
+  responseFormat: WorkforcePersonaWriterMetadata['responseFormat'] | 'needs-clarification';
+  clarification?: ClarificationRequest;
 }
 
 export async function writeWorkflowWithWorkforcePersona(
@@ -244,6 +258,13 @@ export async function writeWorkflowWithWorkforcePersona(
   const parsed = parsePersonaWorkflowResponse(result.output, options.outputPath, {
     repoRoot: options.repoRoot,
   });
+  if (parsed.clarification) {
+    throw new WorkforcePersonaClarificationError(parsed.clarification.questions, resolved.warnings);
+  }
+  if (!parsed.content) {
+    throw new WorkforcePersonaWriterError('Workforce persona response did not include workflow artifact content.');
+  }
+  const responseFormat = parsed.responseFormat as WorkforcePersonaWriterMetadata['responseFormat'];
   return {
     artifact: {
       content: parsed.content,
@@ -259,7 +280,7 @@ export async function writeWorkflowWithWorkforcePersona(
       runId: result.workflowRunId ?? runId,
       source: resolved.source,
       selectedIntent: resolved.intent,
-      responseFormat: parsed.responseFormat,
+      responseFormat,
       outputPath: options.outputPath,
       promptInputs: {
         workflowName,
@@ -472,6 +493,11 @@ export function buildWorkflowPersonaTask(
           language: 'typescript',
           content: 'Complete Agent Relay workflow TypeScript source.',
         },
+        needs_clarification: {
+          status: 'needs_clarification',
+          reason: 'Why the workflow cannot be authored safely from the current spec.',
+          questions: 'Array of { id, question, reason, blocking, defaultAssumption? } items for Ricky to ask the user.',
+        },
         metadata: {
           workflowName: input.workflowName,
           targetMode: input.targetMode,
@@ -488,6 +514,7 @@ export function buildWorkflowPersonaTask(
   return [
     'Write an Agent Relay workflow artifact for Ricky.',
     'Run as a non-interactive one-shot persona invocation. Return only the response contract.',
+    'If the normalized spec has blocking ambiguity or open questions, return needs_clarification with targeted user-facing questions instead of guessing.',
     '',
     'Normalized spec JSON:',
     JSON.stringify(spec, null, 2),
@@ -619,6 +646,8 @@ export function parsePersonaWorkflowResponse(
 ): ParsedPersonaResponse {
   const directJson = parseJsonObject(output);
   if (directJson) {
+    const clarification = parseClarificationResponse(directJson);
+    if (clarification) return { metadata: {}, responseFormat: 'needs-clarification', clarification };
     return validateStructuredResponse(directJson, expectedPath, 'structured-json', options);
   }
 
@@ -626,6 +655,8 @@ export function parsePersonaWorkflowResponse(
   if (jsonFence) {
     const metadataJson = parseJsonObject(jsonFence);
     const tsFence = fencedBlock(output, 'ts') ?? fencedBlock(output, 'typescript');
+    const clarification = metadataJson ? parseClarificationResponse(metadataJson) : null;
+    if (clarification) return { metadata: {}, responseFormat: 'needs-clarification', clarification };
     if (metadataJson && tsFence) {
       return validateFencedResponse(tsFence, metadataJson, expectedPath);
     }
@@ -644,6 +675,52 @@ export function parsePersonaWorkflowResponse(
   throw new WorkforcePersonaWriterError(
     'Workforce persona response must be structured JSON or include fenced TypeScript artifact and JSON metadata blocks.',
   );
+}
+
+function parseClarificationResponse(value: Record<string, unknown>): ClarificationRequest | null {
+  const raw = isRecord(value.needs_clarification)
+    ? value.needs_clarification
+    : value.status === 'needs_clarification'
+      ? value
+      : null;
+  if (!raw) return null;
+
+  const rawQuestions = Array.isArray(raw.questions) ? raw.questions : [];
+  const questions = rawQuestions
+    .map(parseClarificationQuestion)
+    .filter((question): question is ClarificationQuestion => question !== null);
+  if (questions.length === 0) {
+    throw new WorkforcePersonaWriterError('Workforce persona needs_clarification response must include at least one question.');
+  }
+
+  return {
+    status: 'needs_clarification',
+    reason: typeof raw.reason === 'string' && raw.reason.trim()
+      ? raw.reason.trim()
+      : 'The workflow spec has blocking ambiguity.',
+    questions,
+  };
+}
+
+function parseClarificationQuestion(value: unknown): ClarificationQuestion | null {
+  if (!isRecord(value)) return null;
+  const question = typeof value.question === 'string' ? value.question.trim() : '';
+  if (!question) return null;
+  const id = typeof value.id === 'string' && value.id.trim()
+    ? value.id.trim()
+    : question.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-+|-+$/g, '').slice(0, 80) || 'clarification';
+
+  return {
+    id,
+    question,
+    reason: typeof value.reason === 'string' && value.reason.trim()
+      ? value.reason.trim()
+      : 'The persona could not safely author the workflow without this answer.',
+    blocking: typeof value.blocking === 'boolean' ? value.blocking : true,
+    ...(typeof value.defaultAssumption === 'string' && value.defaultAssumption.trim()
+      ? { defaultAssumption: value.defaultAssumption.trim() }
+      : {}),
+  };
 }
 
 export function applyPersonaArtifactToRenderedArtifact(

--- a/src/product/spec-intake/clarifications.ts
+++ b/src/product/spec-intake/clarifications.ts
@@ -1,0 +1,109 @@
+import type { ClarificationQuestion, NormalizedWorkflowSpec, ValidationIssue } from './types.js';
+
+export function analyzeClarificationNeeds(
+  spec: NormalizedWorkflowSpec,
+  issues: ValidationIssue[] = [],
+): ClarificationQuestion[] {
+  const questions: ClarificationQuestion[] = [];
+  const text = [
+    spec.description,
+    spec.targetContext,
+    ...spec.constraints.map((constraint) => constraint.constraint),
+    ...spec.evidenceRequirements.map((requirement) => requirement.requirement),
+    ...spec.acceptanceGates.map((gate) => gate.gate),
+  ]
+    .filter(Boolean)
+    .join('\n');
+
+  if (issues.some((issue) => issue.severity === 'error')) return questions;
+
+  if (spec.intent === 'generate') {
+    questions.push(...explicitOpenQuestionQuestions(text));
+    const executionConflict = executionModeConflictQuestion(spec, text);
+    if (executionConflict) questions.push(executionConflict);
+    const riskySideEffect = riskySideEffectQuestion(text);
+    if (riskySideEffect) questions.push(riskySideEffect);
+  }
+
+  return dedupeQuestions(questions);
+}
+
+export function blockingClarificationQuestions(questions: ClarificationQuestion[]): ClarificationQuestion[] {
+  return questions.filter((question) => question.blocking);
+}
+
+function explicitOpenQuestionQuestions(text: string): ClarificationQuestion[] {
+  const lower = text.toLowerCase();
+  const unresolvedMarkers = [
+    /\bopen questions?\b/,
+    /\btbd\b/,
+    /\btodo:\s*(decide|choose|clarify|ask)\b/,
+    /\bunclear\b/,
+    /\bunspecified\b/,
+    /\bnot sure\b/,
+    /\bdecide later\b/,
+    /\?\?\?/,
+  ];
+  if (!unresolvedMarkers.some((pattern) => pattern.test(lower))) return [];
+
+  const questionLines = text
+    .split(/\r?\n/)
+    .map((line) => line.trim().replace(/^[-*]\s*/, ''))
+    .filter((line) => line.endsWith('?'))
+    .slice(0, 3);
+
+  if (questionLines.length > 0) {
+    return questionLines.map((line, index) => ({
+      id: `open-question-${index + 1}`,
+      question: line,
+      reason: 'The spec contains an explicit unresolved question.',
+      blocking: true,
+    }));
+  }
+
+  return [{
+    id: 'resolve-open-questions',
+    question: 'What should Ricky decide for the unresolved or TBD parts of this workflow spec?',
+    reason: 'The spec contains explicit unresolved markers such as open questions, TBD, or unclear requirements.',
+    blocking: true,
+  }];
+}
+
+function executionModeConflictQuestion(
+  spec: NormalizedWorkflowSpec,
+  text: string,
+): ClarificationQuestion | null {
+  const mentionsLocal = /\b(local|byoh|on this machine)\b/i.test(text);
+  const mentionsCloud = /\b(cloud|hosted|remote)\b/i.test(text);
+  if (!mentionsLocal || !mentionsCloud || spec.executionPreference !== 'auto') return null;
+
+  return {
+    id: 'execution-mode-conflict',
+    question: 'Should this workflow run locally/BYOH, in Cloud, or generate artifacts for both paths?',
+    reason: 'The spec mentions both local and Cloud execution without a clear preference.',
+    blocking: true,
+    defaultAssumption: 'Generate for local/BYOH first and keep Cloud promotion as a follow-up.',
+  };
+}
+
+function riskySideEffectQuestion(text: string): ClarificationQuestion | null {
+  const risky = /\b(deletes?|removes?|drops?|destroys?|resets?|migrates?|deploys?|publishes?|commits?|push(?:es)?|merges?|open pr|create pr)\b/i.test(text);
+  const guarded = /\b(pause|ask|confirm|approval|approve|dry[- ]run|no destructive|non[- ]destructive|do not commit|do not push)\b/i.test(text);
+  if (!risky || guarded) return null;
+
+  return {
+    id: 'side-effect-approval',
+    question: 'Which side effects may the generated workflow perform automatically, and which ones require user approval first?',
+    reason: 'The spec asks for potentially risky side effects without an approval boundary.',
+    blocking: true,
+    defaultAssumption: 'Run validation and write artifacts only; pause before destructive actions, commits, pushes, deploys, or PR creation.',
+  };
+}
+
+function dedupeQuestions(questions: ClarificationQuestion[]): ClarificationQuestion[] {
+  const byId = new Map<string, ClarificationQuestion>();
+  for (const question of questions) {
+    if (!byId.has(question.id)) byId.set(question.id, question);
+  }
+  return [...byId.values()];
+}

--- a/src/product/spec-intake/index.ts
+++ b/src/product/spec-intake/index.ts
@@ -2,11 +2,13 @@ import { normalizeSpec } from './normalizer.js';
 import { parseSpec } from './parser.js';
 import { routeSpec } from './router.js';
 import type { IntakeResult, RawSpecPayload, ValidationIssue } from './types.js';
+import { analyzeClarificationNeeds } from './clarifications.js';
 
 export function intake(payload: RawSpecPayload): IntakeResult {
   const parsed = parseSpec(payload);
   const { normalized, issues } = normalizeSpec(parsed);
-  const routing = routeSpec(normalized, issues);
+  const clarificationQuestions = analyzeClarificationNeeds(normalized, issues);
+  const routing = routeSpec(normalized, issues, clarificationQuestions);
 
   const allIssues = [...issues];
   if (
@@ -28,12 +30,14 @@ export function intake(payload: RawSpecPayload): IntakeResult {
     routing,
     validationIssues: allIssues,
     parseWarnings: parsed.parseWarnings,
+    clarificationQuestions,
     requestId: payload.requestId ?? `${payload.surface}-${payload.receivedAt}`,
     receivedAt: payload.receivedAt,
     processedAt: new Date().toISOString(),
   };
 }
 
+export { analyzeClarificationNeeds, blockingClarificationQuestions } from './clarifications.js';
 export { normalizeSpec } from './normalizer.js';
 export {
   detectIntent,
@@ -47,6 +51,8 @@ export { detectCurrentRepo, defaultRepoDetector, parseRepoSlugFromGitUrl } from 
 export type { RepoDetector } from './detect-current-repo.js';
 export type {
   DesiredAction,
+  ClarificationQuestion,
+  ClarificationRequest,
   ExecutionPreference,
   InputSurface,
   IntakeResult,

--- a/src/product/spec-intake/parser.test.ts
+++ b/src/product/spec-intake/parser.test.ts
@@ -307,4 +307,51 @@ describe('spec intake parser, normalizer, and router', () => {
     expect(result.routing?.suggestedFollowUp).toContain('generate, debug, coordinate, or execute');
     expect(result.routing?.suggestedFollowUp).toContain('target context');
   });
+
+  it('returns structured clarification questions for explicit open questions in generation specs', () => {
+    const result = intake(
+      natural(
+        [
+          'Generate a workflow for package validation.',
+          '',
+          'Open questions:',
+          '- Should it validate package A or package B?',
+          '- Who signs off the final review?',
+        ].join('\n'),
+      ),
+    );
+
+    expect(result.success).toBe(false);
+    expect(result.routing?.target).toBe('clarify');
+    expect(result.clarificationQuestions).toEqual([
+      expect.objectContaining({
+        id: 'open-question-1',
+        question: 'Should it validate package A or package B?',
+        blocking: true,
+      }),
+      expect.objectContaining({
+        id: 'open-question-2',
+        question: 'Who signs off the final review?',
+        blocking: true,
+      }),
+    ]);
+    expect(result.routing?.clarificationQuestions).toHaveLength(2);
+    expect(result.routing?.suggestedFollowUp).toContain('structured clarification questions');
+  });
+
+  it('asks for a side-effect boundary before generating risky workflows', () => {
+    const result = intake(
+      natural('Generate a workflow that deletes obsolete files, commits the cleanup, and pushes the branch.'),
+    );
+
+    expect(result.success).toBe(false);
+    expect(result.routing?.target).toBe('clarify');
+    expect(result.clarificationQuestions).toEqual([
+      expect.objectContaining({
+        id: 'side-effect-approval',
+        question: expect.stringContaining('Which side effects'),
+        blocking: true,
+      }),
+    ]);
+  });
 });

--- a/src/product/spec-intake/router.ts
+++ b/src/product/spec-intake/router.ts
@@ -1,7 +1,11 @@
 import type { Confidence } from '../../runtime/failure/types.js';
-import type { NormalizedWorkflowSpec, RouteTarget, RoutingDecision, ValidationIssue } from './types.js';
+import type { ClarificationQuestion, NormalizedWorkflowSpec, RouteTarget, RoutingDecision, ValidationIssue } from './types.js';
 
-export function routeSpec(normalized: NormalizedWorkflowSpec, issues: ValidationIssue[] = []): RoutingDecision {
+export function routeSpec(
+  normalized: NormalizedWorkflowSpec,
+  issues: ValidationIssue[] = [],
+  clarificationQuestions: ClarificationQuestion[] = [],
+): RoutingDecision {
   const blockingIssue = issues.find((issue) => issue.severity === 'error');
   if (blockingIssue) {
     return decision(
@@ -10,12 +14,31 @@ export function routeSpec(normalized: NormalizedWorkflowSpec, issues: Validation
       `Cannot route until ${blockingIssue.field} is resolved: ${blockingIssue.message}`,
       normalized,
       blockingIssue.suggestion,
+      clarificationQuestions,
+    );
+  }
+  const blockingClarification = clarificationQuestions.find((question) => question.blocking);
+  if (blockingClarification) {
+    return decision(
+      'clarify',
+      'high',
+      `Spec has unresolved workflow authoring questions: ${blockingClarification.reason}`,
+      normalized,
+      'Answer the structured clarification questions, then retry workflow generation.',
+      clarificationQuestions,
     );
   }
 
   switch (normalized.intent) {
     case 'generate':
-      return decision('generate', normalized.description ? 'high' : 'low', 'Request asks Ricky to author a new workflow.', normalized);
+      return decision(
+        'generate',
+        normalized.description ? 'high' : 'low',
+        'Request asks Ricky to author a new workflow.',
+        normalized,
+        undefined,
+        clarificationQuestions,
+      );
     case 'debug':
       return routeDebug(normalized);
     case 'coordinate':
@@ -29,6 +52,7 @@ export function routeSpec(normalized: NormalizedWorkflowSpec, issues: Validation
         'Request is ambiguous and needs a targeted follow-up before Ricky can act.',
         normalized,
         'Ask whether Ricky should generate, debug, coordinate, or execute, and collect the missing target context.',
+        clarificationQuestions,
       );
     case 'unknown':
       return decision(
@@ -37,6 +61,7 @@ export function routeSpec(normalized: NormalizedWorkflowSpec, issues: Validation
         'No deterministic intent signal was available.',
         normalized,
         'Ask the user for the desired Ricky action and the workflow target.',
+        clarificationQuestions,
       );
   }
 }
@@ -109,6 +134,7 @@ function decision(
   reason: string,
   normalizedSpec: NormalizedWorkflowSpec,
   suggestedFollowUp?: string,
+  clarificationQuestions: ClarificationQuestion[] = [],
 ): RoutingDecision {
   return {
     target,
@@ -116,5 +142,6 @@ function decision(
     reason,
     normalizedSpec,
     suggestedFollowUp,
+    clarificationQuestions,
   };
 }

--- a/src/product/spec-intake/types.ts
+++ b/src/product/spec-intake/types.ts
@@ -88,6 +88,20 @@ export interface NormalizedAcceptanceGate {
   kind: 'deterministic' | 'review' | 'proof' | 'custom';
 }
 
+export interface ClarificationQuestion {
+  id: string;
+  question: string;
+  reason: string;
+  blocking: boolean;
+  defaultAssumption?: string;
+}
+
+export interface ClarificationRequest {
+  status: 'needs_clarification';
+  reason: string;
+  questions: ClarificationQuestion[];
+}
+
 export type ExecutionPreference = 'local' | 'cloud' | 'auto';
 
 export interface NormalizedWorkflowSpec {
@@ -115,6 +129,7 @@ export interface RoutingDecision {
   reason: string;
   normalizedSpec: NormalizedWorkflowSpec;
   suggestedFollowUp?: string;
+  clarificationQuestions?: ClarificationQuestion[];
 }
 
 export type ValidationSeverity = 'error' | 'warning' | 'info';
@@ -131,6 +146,7 @@ export interface IntakeResult {
   routing: RoutingDecision | null;
   validationIssues: ValidationIssue[];
   parseWarnings: string[];
+  clarificationQuestions: ClarificationQuestion[];
   requestId: string;
   receivedAt: string;
   processedAt: string;


### PR DESCRIPTION
## Summary

- Adds `analyzeClarificationNeeds()` to the spec-intake pipeline that detects when a spec has explicit open questions (`Open questions:`, `TBD`, `???`, etc.), a local-vs-cloud execution conflict, or risky side effects without an approval boundary.
- Returns structured `ClarificationQuestion[]` from `intake()` and routes the request to `clarify` instead of `generate` when blocking questions exist.
- Wires the questions through the local entrypoint as a `needs_clarification` generation stage and through the workforce-persona writer/repairer so persona-driven generation respects the same gate.

## Why

Today, when a user hands Ricky a spec with explicit unresolved questions or a destructive request without approval guardrails, the generator silently picks an interpretation. This change makes Ricky surface the questions back to the user instead of guessing.

## Test plan

- [x] `npm run typecheck`
- [x] `npm test` — new tests pass (`parser.test.ts`, `workforce-persona-writer.test.ts`, `entrypoint.test.ts` clarification cases)
- [x] Pre-existing subprocess/timing flakes (`entrypoint.test.ts:2949/3040`, `flat-layout-proof`, `local-run-monitor`) verified unrelated: all pass standalone, only fail under full parallel suite load.

## Provenance

The implementation came from a Codex Desktop session on 2026-05-07 prompted by *"if there is ambiguity in a spec or open questions during the workflow writing from spec process, ricky and the agent persona should actually ask the user those questions"*. The work was sitting uncommitted alongside a separate cloud-shorthand feature (already shipped in #60); this PR splits it onto its own branch off main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)