### PR TITLE
fix(cli): skip welcome wizard when a Cloud request is already prepared

### DIFF
--- a/src/surfaces/cli/entrypoint/interactive-cli.test.ts
+++ b/src/surfaces/cli/entrypoint/interactive-cli.test.ts
@@ -1571,6 +1571,29 @@ describe('runInteractiveCli', () => {
       );
     });
 
+    it('power-user cloud run: onboarding skips welcome wizard when cloudRequest is provided', async () => {
+      const onboardFn = vi.fn().mockResolvedValue(onboarding('cloud'));
+
+      await runInteractiveCli({
+        onboard: onboardFn,
+        mode: 'cloud',
+        cloudRequest: cloudRequest(),
+        cloudExecutor: {
+          generate: vi.fn().mockResolvedValue({
+            artifacts: [], warnings: [], followUpActions: [],
+          }),
+        },
+      });
+
+      expect(onboardFn).toHaveBeenCalledWith(
+        expect.objectContaining({
+          mode: 'cloud',
+          compactForExecution: true,
+          skipFirstRunPersistence: true,
+        }),
+      );
+    });
+
     it('welcome journey: onboarding result carries firstRun and bannerShown state', async () => {
       const firstRunResult = await runInteractiveCli({
         onboard: vi.fn().mockResolvedValue({

--- a/src/surfaces/cli/entrypoint/interactive-cli.ts
+++ b/src/surfaces/cli/entrypoint/interactive-cli.ts
@@ -1748,8 +1748,8 @@ export async function runInteractiveCli(
     mode: deps.mode,
     configStore: deps.configStore,
     providerStatus: deps.providerStatus,
-    compactForExecution: deps.handoff !== undefined,
-    skipFirstRunPersistence: deps.handoff !== undefined,
+    compactForExecution: deps.handoff !== undefined || deps.cloudRequest !== undefined,
+    skipFirstRunPersistence: deps.handoff !== undefined || deps.cloudRequest !== undefined,
     verbose: deps.verbose,
     signal: deps.signal,
   });


### PR DESCRIPTION
## Summary

Power-user invocations like \`ricky run <artifact> --cloud\` build a \`CloudGenerateRequest\` up front and never need the interactive setup flow, but the welcome banner and \"connect Google\" wizard were still running before the request was submitted.

The fix: treat a present \`cloudRequest\` the same as a present \`handoff\` when deciding \`compactForExecution\` and \`skipFirstRunPersistence\` in \`runInteractiveCli\`. Both signal a non-interactive run.

## Why

Reported during verification of PR #61. Reproduction:

\`\`\`
$ ricky run workflows/foo.ts --cloud
        __             RRRR
   ____/  \\__        RICKY
  ...
  Welcome to Ricky! Let's get you set up.
  ... ~50 lines of wizard ...
  Step 1: Connect Google (required for Cloud generation)
  ...
Ricky cloud: workflow run not_requested.
Warning: Cloud generate stub: received spec (115 chars) for workspace ...
\`\`\`

After this fix:

\`\`\`
$ ricky run workflows/foo.ts --cloud
Ricky cloud: workflow run not_requested.
Warning: Cloud generate stub: received spec (115 chars) for workspace ...
Next: Wire Cloud Runtime: Connect the real Cloud generation runtime to replace this stub.
\`\`\`

The \`Wire Cloud Runtime\` follow-up the user actually needs is the subject of the companion spec PR #62.

## Test plan
- [x] \`npm run typecheck\`
- [x] New test: \`onboarding skips welcome wizard when cloudRequest is provided\` — passes (62/62 in interactive-cli.test.ts)
- [x] Manual: \`ricky run workflows/<existing>.ts --cloud\` produces 3 lines of output, not 50

## Related
- PR #62 — spec for wiring the Cloud runtime so the next action above actually executes the workflow.
- PR #60 — added the \`run <artifact> --cloud\` shorthand parser.
- PR #61 — clarifications gate (parallel feature; verification of #61 surfaced this issue).

🤖 Generated with [Claude Code](https://claude.com/claude-code)