### PR TITLE
chore(timeout): bump default run wallclock 45m -> 4h

### DIFF
--- a/src/shared/constants.ts
+++ b/src/shared/constants.ts
@@ -17,7 +17,7 @@ export const DEFAULT_MAX_CONCURRENCY = 4;
 // exceed the longest sequential path of per-step budgets below so that the
 // outer process killer never fires before per-step timeouts can do their job.
 // Per-step timeouts are the meaningful constraint; this is a safety net.
-export const DEFAULT_RUN_TIMEOUT_MS = 2_700_000; // 45 min
+export const DEFAULT_RUN_TIMEOUT_MS = 14_400_000; // 4 h
 
 export const DEFAULT_TIMEOUT_MS = DEFAULT_RUN_TIMEOUT_MS;
 


### PR DESCRIPTION
## Summary
- Bumps \`DEFAULT_RUN_TIMEOUT_MS\` from 45 min (2,700,000) to 4 h (14,400,000).
- The outer process killer was firing before long pipelines (multi-adapter scaffolds, large monorepo build/test) could finish their per-step work.
- Per-step timeouts remain the meaningful constraint; this is the outer safety net per the existing comment block.

## Test plan
- [x] \`npm run typecheck\` clean
- [x] \`npm run bundle\` produces a dist where the constant is inlined as \`144e5\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)