### PR TITLE
feat: add Ricky master executor workflow

### DIFF
--- a/.agents/skills/writing-agent-relay-workflows/SKILL.md
+++ b/.agents/skills/writing-agent-relay-workflows/SKILL.md
@@ -310,8 +310,8 @@ export function applyCloudRepoSetup<T>(wf: T, opts: CloudRepoSetupOptions): T {
 - **Record residual risks**
 - Call out what was not covered
 - **Ship the result as a PR**
-- Open the pull request from the workflow itself with the GitHub primitive
-- See [Shipping the Result — Open a PR via the GitHub Primitive](#shipping-the-result--open-a-pr-via-the-github-primitive) below
+- Open the pull request from the workflow itself with `createGitHubStep`
+- See [Shipping the Result — Open a PR via `createGitHubStep`](#shipping-the-result--open-a-pr-via-creategithubstep) below
 - A workflow that fixes a bug and stops short of the PR has only done half the loop
 - disposable sandbox / cloud workspace
 - Docker / containerized environment
@@ -321,21 +321,16 @@ export function applyCloudRepoSetup<T>(wf: T, opts: CloudRepoSetupOptions): T {
 - chooses the best swarm pattern
 - then authors the final fix/validation workflow
 
-### Shipping the Result — Open a PR via the GitHub Primitive
+### Shipping the Result — Open a PR via `createGitHubStep`
 
 #### The minimal "open a PR" recipe
 
 ```typescript
 import { workflow } from '@agent-relay/sdk/workflows';
-import { GitHubStepExecutor, createGitHubStep } from '@agent-relay/github-primitive';
+import { createGitHubStep } from '@agent-relay/sdk/github';
 
 const REPO = 'AgentWorkforce/cloud';
 const BRANCH = `agent-relay/run-${Date.now()}`;
-
-// Auto-detect runtime: gh CLI locally, Nango/relay-cloud in cloud.
-// You don't need to wire any of the cloud config yourself when running
-// in `agent-relay cloud run` — the cloud bootstrap injects it.
-const github = new GitHubStepExecutor({ runtime: 'auto' });
 
 await workflow('feature-x')
   // ... your real steps that produce code changes ...
@@ -345,17 +340,15 @@ await workflow('feature-x')
   })
 
   // Branch off main on the remote.
-  .step(createGitHubStep({
-    name: 'create-branch',
+  .step('create-branch', createGitHubStep({
     dependsOn: ['write-marker'],
     action: 'createBranch',
     repo: REPO,
     params: { branch: BRANCH, source: 'main' },
-  }), { executor: github })
+  }))
 
   // Commit the change to the branch via Contents API.
-  .step(createGitHubStep({
-    name: 'commit-change',
+  .step('commit-change', createGitHubStep({
     dependsOn: ['create-branch'],
     action: 'createFile',
     repo: REPO,
@@ -365,11 +358,10 @@ await workflow('feature-x')
       content: '<file body here>',
       message: 'chore: changelog entry',
     },
-  }), { executor: github })
+  }))
 
   // Open the PR. This is the load-bearing step.
-  .step(createGitHubStep({
-    name: 'open-pr',
+  .step('open-pr', createGitHubStep({
     dependsOn: ['commit-change'],
     action: 'createPR',
     repo: REPO,
@@ -381,7 +373,7 @@ await workflow('feature-x')
       draft: false,
     },
     output: { mode: 'data', format: 'json', path: 'html_url' },
-  }), { executor: github })
+  }))
 
   .run({ cwd: process.cwd() });
 ```
@@ -825,7 +817,7 @@ When you set `.pattern('supervisor')` (or `hub-spoke`, `fan-out`), the runner au
 | Hardcoding all channels at spawn time | Use `agent.subscribe()` / `agent.unsubscribe()` for dynamic channel membership post-spawn |
 | Using `preset: 'worker'` for Codex in *interactive team* patterns when coordination is needed | Codex interactive mode works fine with PTY channel injection. Drop the preset for interactive team patterns (keep it for one-shot DAG workers where clean stdout matters) |
 | Separate reviewer agent from lead in interactive team | Merge lead + reviewer into one interactive Claude agent — reviews between rounds, fewer agents |
-| Not printing PR URL after `gh pr create` | Add a final deterministic step: `echo "PR: $(cat pr-url.txt)"` or capture in the `gh pr create` command |
+| Not printing PR URL after `createGitHubStep({ action: 'createPR' })` | Capture `html_url` with `output: { mode: 'data', format: 'json', path: 'html_url' }` and echo or write it in a final deterministic step |
 | Workflow ending without worktree + PR for cross-repo changes | Add `setup-worktree` at start and `push-and-pr` + `cleanup-worktree` at end |
 
 ### YAML Alternative

--- a/.agents/skills/writing-agent-relay-workflows/SKILL.md
+++ b/.agents/skills/writing-agent-relay-workflows/SKILL.md
@@ -218,25 +218,6 @@ runWorkflow().catch((error) => {
 });
 ```
 
-#### 1b. Make commit and PR boundaries explicit
-
-Workflows do **not** get a PR for free just because they pass validation. If the intended deliverable is a branch, commit, push, or GitHub PR, the workflow itself must own that boundary explicitly and document the expected file scope.
-
-Use this pattern only when the workflow is supposed to own repository delivery:
-
-1. Preflight the git state and fail on unexpected staged changes.
-2. Create or verify the intended branch.
-3. Run implementation, review, soft validation, fix, and hard validation gates.
-4. Stage only the declared target files and review/signoff artifacts.
-5. Commit with a deterministic message.
-6. Push the branch.
-7. Use the GitHub primitive or `gh pr create` to open the PR.
-8. Verify the PR URL/state deterministically and write it into the final signoff artifact.
-
-Do not hide commit/PR work in agent prose. Model it as deterministic steps whenever possible. If using an agent or GitHub primitive for PR creation, the downstream hard gate must still verify the PR exists before signoff.
-
-If commit or PR creation is intentionally outside the workflow, say that directly in the workflow description and signoff so the operator knows to do it after completion.
-
 #### 2b. Standard preflight template for resumable workflows
 
 ```ts

--- a/.agents/skills/writing-agent-relay-workflows/SKILL.md
+++ b/.agents/skills/writing-agent-relay-workflows/SKILL.md
@@ -218,6 +218,25 @@ runWorkflow().catch((error) => {
 });
 ```
 
+#### 1b. Make commit and PR boundaries explicit
+
+Workflows do **not** get a PR for free just because they pass validation. If the intended deliverable is a branch, commit, push, or GitHub PR, the workflow itself must own that boundary explicitly and document the expected file scope.
+
+Use this pattern only when the workflow is supposed to own repository delivery:
+
+1. Preflight the git state and fail on unexpected staged changes.
+2. Create or verify the intended branch.
+3. Run implementation, review, soft validation, fix, and hard validation gates.
+4. Stage only the declared target files and review/signoff artifacts.
+5. Commit with a deterministic message.
+6. Push the branch.
+7. Use the GitHub primitive or `gh pr create` to open the PR.
+8. Verify the PR URL/state deterministically and write it into the final signoff artifact.
+
+Do not hide commit/PR work in agent prose. Model it as deterministic steps whenever possible. If using an agent or GitHub primitive for PR creation, the downstream hard gate must still verify the PR exists before signoff.
+
+If commit or PR creation is intentionally outside the workflow, say that directly in the workflow description and signoff so the operator knows to do it after completion.
+
 #### 2b. Standard preflight template for resumable workflows
 
 ```ts

--- a/.claude/skills/writing-agent-relay-workflows/SKILL.md
+++ b/.claude/skills/writing-agent-relay-workflows/SKILL.md
@@ -280,6 +280,25 @@ runWorkflow().catch((error) => {
 
 Do not end workflow files with bare top-level `await workflow(...).run(...)`.
 
+### 1b. Make commit and PR boundaries explicit
+
+Workflows do **not** get a PR for free just because they pass validation. If the intended deliverable is a branch, commit, push, or GitHub PR, the workflow itself must own that boundary explicitly and document the expected file scope.
+
+Use this pattern only when the workflow is supposed to own repository delivery:
+
+1. Preflight the git state and fail on unexpected staged changes.
+2. Create or verify the intended branch.
+3. Run implementation, review, soft validation, fix, and hard validation gates.
+4. Stage only the declared target files and review/signoff artifacts.
+5. Commit with a deterministic message.
+6. Push the branch.
+7. Use `createGitHubStep({ action: 'createPR', ... })` from `@agent-relay/sdk/github` to open the PR.
+8. Verify the PR URL/state deterministically and write it into the final signoff artifact.
+
+Do not hide commit/PR work in agent prose. Model it as deterministic steps whenever possible. For PR creation, issue updates, file reads, or any GitHub operation, prefer `createGitHubStep` over shelling out to `gh`; it is bundled with `@agent-relay/sdk`. The downstream hard gate must still verify the PR exists before signoff.
+
+If commit or PR creation is intentionally outside the workflow, say that directly in the workflow description and signoff so the operator knows to do it after completion.
+
 ### 2. Avoid raw fenced code blocks inside workflow task template literals
 
 Raw triple-backtick code fences inside large inline `task: \`...\`` template strings are fragile and can break outer TypeScript parsing, especially when they contain language tags like `swift` or `diff`.
@@ -331,7 +350,7 @@ The battle-tested template:
 - **Use `grep -vE "^(...)$"` for full-line match.** Substring matches bleed across unrelated files (e.g., `setup.ts` would also match `packages/core/src/bootstrap/setup.ts`).
 - **Append `|| true` to the grep.** Without it, an empty result triggers `set -e` and the whole preflight fails before the `if` can even run.
 - **Check the staging area separately.** A dirty index is different from a dirty working tree and both must be clean (modulo allow-list).
-- **Check `gh auth status` early** if any downstream step uses `gh pr create` or similar. Failing on auth at the end of a long DAG is painful.
+- **Check `gh auth status` early** if downstream GitHub operations will use the local transport. Failing on auth at the end of a long DAG is painful.
 
 **Never use `git diff --quiet` alone as your "clean tree" check.** It fails on any dirty file, including the ones the workflow is expected to rewrite, which causes false failures on every resume / re-run.
 
@@ -374,7 +393,7 @@ command: [
 
 Results in `set -e && cat > /tmp/f <<EOF && line 1 && line 2 && EOF && next-command` — a shell syntax error because `&&` cannot appear inside a heredoc body. Use `.join('\n')` or (better) sidestep the heredoc entirely.
 
-**The `printf` + `mktemp` alternative — use this for commit messages, PR bodies, and any other multi-line file content.** It avoids heredocs altogether and composes with `.join(' && ')`:
+**The `printf` + `mktemp` alternative — use this for commit messages, raw-CLI fallback PR bodies, and any other multi-line file content.** It avoids heredocs altogether and composes with `.join(' && ')`:
 
 ```ts
 command: [
@@ -388,7 +407,7 @@ command: [
 ].join(' && '),
 ```
 
-This pattern is specifically recommended over `git commit -m "$(cat <<'EOF' ... EOF)"` and `gh pr create --body "$(cat <<'BODY' ... BODY)"`. Nesting a heredoc inside `$(...)` forces the shell to match a closing paren across many lines of unparsed body text, and any stray parenthesis in the body text can silently break the match. `--body-file` + `mktemp` + `printf` is immune to that entire class of bug.
+This pattern is specifically recommended over `git commit -m "$(cat <<'EOF' ... EOF)"` and raw `gh pr create --body "$(cat <<'BODY' ... BODY)"`. Nesting a heredoc inside `$(...)` forces the shell to match a closing paren across many lines of unparsed body text, and any stray parenthesis in the body text can silently break the match. `--body-file` + `mktemp` + `printf` is immune to that entire class of bug. For workflow-owned PR creation, prefer `createGitHubStep` over raw `gh`; this shell pattern is for raw CLI fallback cases.
 
 ### 2d. Template-literal escape sequences are processed once before the string is rendered
 
@@ -579,8 +598,8 @@ For bug-fix or reliability workflows, do **not** stop at unit or integration tes
 8. **Record residual risks**
    - Call out what was not covered
 9. **Ship the result as a PR**
-   - Open the pull request from the workflow itself with the GitHub primitive
-   - See [Shipping the Result — Open a PR via the GitHub Primitive](#shipping-the-result--open-a-pr-via-the-github-primitive) below
+   - Open the pull request from the workflow itself with `createGitHubStep`
+   - See [Shipping the Result — Open a PR via `createGitHubStep`](#shipping-the-result--open-a-pr-via-creategithubstep) below
    - A workflow that fixes a bug and stops short of the PR has only done half the loop
 
 ### Clean-environment validation guidance
@@ -602,15 +621,15 @@ If the right proving environment is unclear, first write a **meta-workflow** tha
 
 This is often better than jumping straight to implementation.
 
-## Shipping the Result — Open a PR via the GitHub Primitive
+## Shipping the Result — Open a PR via `createGitHubStep`
 
-A workflow whose final artifact is "a clean working tree on a sandbox you'll throw away" has not shipped anything. **End every code-changing workflow by opening a pull request, and do it from inside the workflow** using the `@agent-relay/github-primitive`. Don't tell the operator to follow up with `gh pr create` — make the workflow's own last step the PR.
+A workflow whose final artifact is "a clean working tree on a sandbox you'll throw away" has not shipped anything. **End every code-changing workflow by opening a pull request, and do it from inside the workflow** using `createGitHubStep` from `@agent-relay/sdk/github`. Don't tell the operator to follow up with `gh pr create` — make the workflow's own last step the PR.
 
-### Why the primitive (and not raw `gh` / `octokit`)
+### Why `createGitHubStep` (and not raw `gh` / `octokit`)
 
 The primitive picks the right transport at runtime:
 
-| Where the workflow runs | Transport the primitive uses | What you provide |
+| Where the workflow runs | Transport `createGitHubStep` uses | What you provide |
 |---|---|---|
 | Local (`agent-relay run`) | `gh` CLI | `gh auth status` works |
 | Cloud (`agent-relay cloud run`) — tenant-scoped | Nango → workspace's GitHub App installation | Nothing — cloud injects credentials |
@@ -618,21 +637,16 @@ The primitive picks the right transport at runtime:
 
 You write **one** workflow. The same `createPR` step opens a PR via your local `gh` when you iterate on it on a laptop, and via the workspace's GitHub App when the same file runs in `agent-relay cloud run`. No branching by environment, no env-var sniffing in your task strings, no "this part only works in cloud" caveats. That's the whole point of the adapter.
 
-> **Phase C interaction (cloud only):** `agent-relay cloud run` already auto-pushes per-`paths[]` diffs as separate PRs after the workflow callback when the repos are allowlisted (see `pushedTo` in the run record). Phase C is the *catch-all* — if your workflow does nothing else, you still get one PR per declared path. Use the github primitive **on top of** that when you need PRs the catch-all can't produce: cross-cutting issues, follow-up tracking issues, opening one PR that spans multiple paths, draft PRs you want labeled/assigned in specific ways, or PRs against a repo you didn't `paths[]` in.
+> **Phase C interaction (cloud only):** `agent-relay cloud run` already auto-pushes per-`paths[]` diffs as separate PRs after the workflow callback when the repos are allowlisted (see `pushedTo` in the run record). Phase C is the *catch-all* — if your workflow does nothing else, you still get one PR per declared path. Use `createGitHubStep` **on top of** that when you need PRs the catch-all can't produce: cross-cutting issues, follow-up tracking issues, opening one PR that spans multiple paths, draft PRs you want labeled/assigned in specific ways, or PRs against a repo you didn't `paths[]` in.
 
 ### The minimal "open a PR" recipe
 
 ```typescript
 import { workflow } from '@agent-relay/sdk/workflows';
-import { GitHubStepExecutor, createGitHubStep } from '@agent-relay/github-primitive';
+import { createGitHubStep } from '@agent-relay/sdk/github';
 
 const REPO = 'AgentWorkforce/cloud';
 const BRANCH = `agent-relay/run-${Date.now()}`;
-
-// Auto-detect runtime: gh CLI locally, Nango/relay-cloud in cloud.
-// You don't need to wire any of the cloud config yourself when running
-// in `agent-relay cloud run` — the cloud bootstrap injects it.
-const github = new GitHubStepExecutor({ runtime: 'auto' });
 
 await workflow('feature-x')
   // ... your real steps that produce code changes ...
@@ -642,17 +656,15 @@ await workflow('feature-x')
   })
 
   // Branch off main on the remote.
-  .step(createGitHubStep({
-    name: 'create-branch',
+  .step('create-branch', createGitHubStep({
     dependsOn: ['write-marker'],
     action: 'createBranch',
     repo: REPO,
     params: { branch: BRANCH, source: 'main' },
-  }), { executor: github })
+  }))
 
   // Commit the change to the branch via Contents API.
-  .step(createGitHubStep({
-    name: 'commit-change',
+  .step('commit-change', createGitHubStep({
     dependsOn: ['create-branch'],
     action: 'createFile',
     repo: REPO,
@@ -662,11 +674,10 @@ await workflow('feature-x')
       content: '<file body here>',
       message: 'chore: changelog entry',
     },
-  }), { executor: github })
+  }))
 
   // Open the PR. This is the load-bearing step.
-  .step(createGitHubStep({
-    name: 'open-pr',
+  .step('open-pr', createGitHubStep({
     dependsOn: ['commit-change'],
     action: 'createPR',
     repo: REPO,
@@ -678,12 +689,12 @@ await workflow('feature-x')
       draft: false,
     },
     output: { mode: 'data', format: 'json', path: 'html_url' },
-  }), { executor: github })
+  }))
 
   .run({ cwd: process.cwd() });
 ```
 
-The primitive's actions are stable across runtimes: `getRepo`, `createBranch`, `createFile`, `updateFile`, `createPR`, `updatePR`, `getPR`, `listPRs`, `mergePR`, `createIssue`, etc. See `packages/github-primitive/src/types.ts` for the full enum.
+`createGitHubStep` is bundled with `@agent-relay/sdk`; do not add a separate install. Its actions are stable across runtimes: `getRepo`, `createBranch`, `createFile`, `updateFile`, `createPR`, `updatePR`, `getPR`, `listPRs`, `mergePR`, `createIssue`, etc. See the SDK GitHub primitive docs for the full enum.
 
 ### Authoring rules for PR-shipping workflows
 
@@ -692,7 +703,7 @@ The primitive's actions are stable across runtimes: `getRepo`, `createBranch`, `
 3. **Branch name encodes the run.** `agent-relay/run-${runId}` or `agent-relay/${workflow-name}-${timestamp}` so reviewers can tell the PR apart from other automation, and so reruns don't clash.
 4. **`draft: true` while iterating.** Once the workflow is stable end-to-end, flip to `draft: false`.
 5. **Body is a real PR description.** Summary + Test plan, generated from the workflow's own evidence (verification step output, diff stats, test run output). If you find yourself writing a placeholder body, the workflow isn't done — capture the real evidence in an earlier step and template it in.
-6. **Don't use the primitive to substitute for `paths[]` push-back in cloud.** If the diff lives in a tarballed `paths[]` mount, let cloud's Phase C push-back open that PR (it handles the patch generation, branch lifecycle, and per-repo allowlist). Use the primitive when you need a PR against a repo or branch outside the `paths[]` set, or when you want to add an extra PR (e.g. a tracking issue, a follow-up against a sibling repo, a docs-only PR).
+6. **Don't use `createGitHubStep` to substitute for `paths[]` push-back in cloud.** If the diff lives in a tarballed `paths[]` mount, let cloud's Phase C push-back open that PR (it handles the patch generation, branch lifecycle, and per-repo allowlist). Use `createGitHubStep` when you need a PR against a repo or branch outside the `paths[]` set, or when you want to add an extra PR (e.g. a tracking issue, a follow-up against a sibling repo, a docs-only PR).
 7. **Failure is a real failure.** If `createPR` errors (auth, permissions, branch conflict), the workflow should fail the step, not warn-and-continue. A "successful" workflow that silently failed to open the PR is the worst-case outcome — the human thinks the work shipped.
 
 ### Where this fits in the bug-fix phases
@@ -1305,7 +1316,7 @@ When you set `.pattern('supervisor')` (or `hub-spoke`, `fan-out`), the runner au
 | Hardcoding all channels at spawn time | Use `agent.subscribe()` / `agent.unsubscribe()` for dynamic channel membership post-spawn |
 | Using `preset: 'worker'` for Codex in *interactive team* patterns when coordination is needed | Codex interactive mode works fine with PTY channel injection. Drop the preset for interactive team patterns (keep it for one-shot DAG workers where clean stdout matters) |
 | Separate reviewer agent from lead in interactive team | Merge lead + reviewer into one interactive Claude agent — reviews between rounds, fewer agents |
-| Not printing PR URL after `gh pr create` | Add a final deterministic step: `echo "PR: $(cat pr-url.txt)"` or capture in the `gh pr create` command |
+| Not printing PR URL after `createGitHubStep({ action: 'createPR' })` | Capture `html_url` with `output: { mode: 'data', format: 'json', path: 'html_url' }` and echo or write it in a final deterministic step |
 | Workflow ending without worktree + PR for cross-repo changes | Add `setup-worktree` at start and `push-and-pr` + `cleanup-worktree` at end |
 
 ## YAML Alternative

--- a/prpm.lock
+++ b/prpm.lock
@@ -17,9 +17,9 @@
       }
     },
     "@agent-relay/writing-agent-relay-workflows#codex": {
-      "version": "1.6.1",
-      "resolved": "https://registry.prpm.dev/api/v1/packages/%40agent-relay%2Fwriting-agent-relay-workflows/1.6.1.tar.gz",
-      "integrity": "sha256-50db14f2519fa24013e49a91652ec692956b96a1cf1705edb5fa1398048d6524",
+      "version": "1.6.2",
+      "resolved": "https://registry.prpm.dev/api/v1/packages/%40agent-relay%2Fwriting-agent-relay-workflows/1.6.2.tar.gz",
+      "integrity": "sha256-2394f6b0cd6ef65e871720646d23b9406a2193a314bd82e1f9a6eb0416c672ed",
       "format": "codex",
       "subtype": "skill",
       "sourceFormat": "claude",
@@ -83,9 +83,9 @@
       }
     },
     "@agent-relay/writing-agent-relay-workflows#claude": {
-      "version": "1.6.1",
-      "resolved": "https://registry.prpm.dev/api/v1/packages/%40agent-relay%2Fwriting-agent-relay-workflows/1.6.1.tar.gz",
-      "integrity": "sha256-50db14f2519fa24013e49a91652ec692956b96a1cf1705edb5fa1398048d6524",
+      "version": "1.6.2",
+      "resolved": "https://registry.prpm.dev/api/v1/packages/%40agent-relay%2Fwriting-agent-relay-workflows/1.6.2.tar.gz",
+      "integrity": "sha256-2394f6b0cd6ef65e871720646d23b9406a2193a314bd82e1f9a6eb0416c672ed",
       "format": "claude",
       "subtype": "skill",
       "sourceFormat": "claude",
@@ -93,7 +93,7 @@
       "installedPath": ".claude/skills/writing-agent-relay-workflows/SKILL.md"
     }
   },
-  "generated": "2026-05-05T19:19:21.631Z",
+  "generated": "2026-05-07T12:22:44.425Z",
   "collections": {
     "agent-relay-starter": {
       "name_slug": "agent-relay-starter",

--- a/src/local/entrypoint.ts
+++ b/src/local/entrypoint.ts
@@ -86,6 +86,7 @@ export interface LocalGenerationStageResult {
   decisions?: {
     skill_matches?: unknown;
     tool_selection?: unknown;
+    master_execution?: unknown;
     refinement?: unknown;
     workforce_persona?: unknown;
     clarification_questions?: ClarificationQuestion[];
@@ -1026,6 +1027,12 @@ export function createLocalExecutor(options: LocalExecutorOptions = {}): LocalEx
 
         logs.push(`[local] workflow generation: ${generationResult.success ? 'passed' : 'failed'}`);
         logs.push(`[local] selected pattern: ${generationResult.patternDecision.pattern}`);
+        if (generationResult.masterExecutionPlan) {
+          logs.push(
+            `[local] master plan: ${generationResult.masterExecutionPlan.children.length} child workflows across ` +
+              `${new Set(generationResult.masterExecutionPlan.children.map((child) => child.wave)).size} waves`,
+          );
+        }
         if (generationResult.workforcePersona) {
           logs.push(`[local] workforce persona writer: ${generationResult.workforcePersona.personaId}@${generationResult.workforcePersona.tier}`);
         }
@@ -1576,6 +1583,22 @@ function createGenerationStage(
           decisions: {
             skill_matches: generationResult.skillContext.matches,
             tool_selection: generationResult.toolSelection.selections,
+            ...(generationResult.masterExecutionPlan
+              ? {
+                  master_execution: {
+                    child_count: generationResult.masterExecutionPlan.children.length,
+                    wave_count: new Set(generationResult.masterExecutionPlan.children.map((child) => child.wave)).size,
+                    children: generationResult.masterExecutionPlan.children.map((child) => ({
+                      id: child.id,
+                      title: child.title,
+                      workflow_file: child.workflowFilePath,
+                      wave: child.wave,
+                      parallelizable: child.parallelizable,
+                      depends_on: child.dependsOn,
+                    })),
+                  },
+                }
+              : {}),
             ...(generationResult.refinement ? { refinement: generationResult.refinement } : {}),
             ...(generationResult.workforcePersona ? { workforce_persona: generationResult.workforcePersona } : {}),
             ...((generationResult.clarificationQuestions?.length ?? 0) > 0 ? { clarification_questions: generationResult.clarificationQuestions } : {}),

--- a/src/product/generation/master-workflow-renderer.ts
+++ b/src/product/generation/master-workflow-renderer.ts
@@ -1,0 +1,588 @@
+import type { NormalizedWorkflowSpec } from '../spec-intake/types.js';
+import { planMasterExecution, type ChildWorkflowPlan, type MasterExecutionPlan } from '../orchestration/index.js';
+import type {
+  DeterministicGate,
+  PatternDecision,
+  RenderedArtifact,
+  SkillApplicationEvidence,
+  SkillContext,
+  ToolSelection,
+  WorkflowTask,
+} from './types.js';
+
+interface RenderMasterWorkflowInput {
+  spec: NormalizedWorkflowSpec;
+  pattern: PatternDecision;
+  skills: SkillContext;
+  artifactPath?: string;
+}
+
+interface RenderedMasterWorkflow {
+  artifact: RenderedArtifact;
+  plan: MasterExecutionPlan;
+}
+
+const MASTER_EXPLICIT_PATTERN =
+  /\b(master executor|master orchestration|smaller workflows|child workflows|several workflows|multiple workflows|break(?:ing)? (?:it )?(?:out|up)|divvy|decompos(?:e|ition)|workflow waves?)\b/i;
+
+const IMPLEMENTATION_PATTERN =
+  /\b(implement|wire|add|build|ship|migrate|refactor|replace|runtime|policy|telemetry|evals?|insights?|runner|api|cli|tests?)\b/i;
+
+export function shouldUseMasterExecutionWorkflow(spec: NormalizedWorkflowSpec): boolean {
+  const text = workflowText(spec);
+  if (!IMPLEMENTATION_PATTERN.test(text)) return false;
+  if (MASTER_EXPLICIT_PATTERN.test(text)) return true;
+  if (spec.targetFiles.length >= 4) return true;
+  return false;
+}
+
+export function renderMasterExecutionWorkflow(input: RenderMasterWorkflowInput): RenderedMasterWorkflow {
+  const slug = slugify(workflowNameFromArtifactPath(input.artifactPath) || input.spec.description || 'master-workflow');
+  const artifactPath = input.artifactPath ?? `workflows/generated/ricky-${slug}.ts`;
+  const workflowId = `ricky-${slug}`;
+  const artifactsDir = `.workflow-artifacts/generated/${slug}`;
+  const wavePrefix = `generated/${slug}-children`;
+  const plan = planMasterExecution({
+    title: input.spec.description,
+    description: input.spec.description,
+    targetFiles: input.spec.targetFiles,
+    workflowSlug: slug,
+    wavePrefix,
+    desiredSlices: desiredSlicesFor(input.spec),
+    constraints: {
+      maxChildren: 12,
+      requiredGateMarkers: ['RICKY_CHILD_WORKFLOW_COMPLETE'],
+    },
+  });
+  const channel = `wf-ricky-${slug}`;
+  const tasks = buildMasterTasks(plan);
+  const gates = buildMasterGates(artifactsDir, plan);
+  const skillApplicationEvidence = buildMasterSkillEvidence(input.skills);
+  const toolSelections = buildMasterToolSelections(plan);
+  const content = renderMasterSource({
+    spec: input.spec,
+    pattern: input.pattern,
+    workflowId,
+    channel,
+    artifactsDir,
+    plan,
+    skills: input.skills,
+    skillApplicationEvidence,
+  });
+
+  return {
+    plan,
+    artifact: {
+      fileName: artifactPath.split('/').at(-1) ?? `${workflowId}.ts`,
+      artifactPath,
+      workflowId,
+      content,
+      pattern: input.pattern.pattern,
+      channel,
+      taskCount: tasks.length,
+      gateCount: gates.length,
+      tasks,
+      gates,
+      skillApplicationEvidence,
+      skillMatches: input.skills.matches,
+      toolSelections,
+      artifactsDir,
+    },
+  };
+}
+
+function desiredSlicesFor(spec: NormalizedWorkflowSpec): NonNullable<Parameters<typeof planMasterExecution>[0]['desiredSlices']> {
+  if (spec.targetFiles.length >= 2) {
+    return spec.targetFiles.map((targetFile) => ({
+      title: titleForTargetFile(targetFile),
+      summary: `Own changes and validation for ${targetFile}.`,
+      targetFiles: [targetFile],
+    }));
+  }
+
+  const titles = extractSliceTitles(sliceSourceText(spec));
+  return titles.map((title) => ({
+    title,
+    summary: `Own the ${title.toLowerCase()} child workflow slice.`,
+    targetFiles: [],
+  }));
+}
+
+function renderMasterSource(input: {
+  spec: NormalizedWorkflowSpec;
+  pattern: PatternDecision;
+  workflowId: string;
+  channel: string;
+  artifactsDir: string;
+  plan: MasterExecutionPlan;
+  skills: SkillContext;
+  skillApplicationEvidence: SkillApplicationEvidence[];
+}): string {
+  const childSources = Object.fromEntries(
+    input.plan.children.map((child) => [child.workflowFilePath, childWorkflowSource(child, input.spec)]),
+  );
+  const planJson = JSON.stringify(input.plan, null, 2);
+  const skillMatchesJson = JSON.stringify(input.skills.matches, null, 2);
+  const skillBoundaryJson = JSON.stringify({
+    behavior: 'generation_time_only',
+    runtimeEmbodiment: false,
+    boundary: 'Skills shape this master workflow during Ricky generation. Runtime child agents receive rendered workflow instructions only.',
+    loadedSkills: input.skills.applicableSkillNames,
+    applicationEvidence: input.skillApplicationEvidence,
+  }, null, 2);
+  const materializeCommand = [
+    'node --input-type=module <<\'NODE\'',
+    'import { mkdirSync, writeFileSync } from \'node:fs\';',
+    'import { dirname } from \'node:path\';',
+    `const childSources = ${JSON.stringify(childSources, null, 2)};`,
+    'for (const [filePath, source] of Object.entries(childSources)) {',
+    '  mkdirSync(dirname(filePath), { recursive: true });',
+    '  writeFileSync(filePath, source, \'utf8\');',
+    '  console.log(`materialized_child_workflow=${filePath}`);',
+    '}',
+    'NODE',
+  ].join('\n');
+  const verifyChildrenCommand = [
+    'set -e',
+    ...input.plan.children.map((child) => `test -f ${shellQuote(child.workflowFilePath)}`),
+    'if command -v rg >/dev/null 2>&1; then rg "RICKY_CHILD_WORKFLOW_COMPLETE" workflows/generated >/dev/null; else grep -R "RICKY_CHILD_WORKFLOW_COMPLETE" workflows/generated >/dev/null; fi',
+    'echo RICKY_MASTER_CHILD_WORKFLOWS_READY',
+  ].join('\n');
+  const finalSignoffCommand = [
+    'set -e',
+    `mkdir -p ${shellQuote(input.artifactsDir)}`,
+    `cat > ${shellQuote(`${input.artifactsDir}/signoff.md`)} <<'EOF'`,
+    '# Ricky master executor signoff',
+    '',
+    `Master plan: ${input.plan.children.length} child workflows across ${waveCount(input.plan)} waves.`,
+    'The master executor ran child workflows through ricky run and checked deterministic signoff markers.',
+    'Source changes, code changes, tests, git diff evidence, and PR URL or explicit result reporting are required from child workflows.',
+    '',
+    'MASTER_EXECUTOR_RESULT_READY',
+    'EOF',
+    'echo MASTER_EXECUTOR_RESULT_READY',
+  ].join('\n');
+
+  return `${[
+    "import { workflow } from '@agent-relay/sdk/workflows';",
+    '',
+    '// IMPLEMENTATION_WORKFLOW_CONTRACT: broad implementation specs run as child workflows with source changes, tests, non-empty diff evidence, and PR/result reporting.',
+    '// RICKY_MASTER_EXECUTOR_WORKFLOW: Ricky kept the CLI interface stable and decomposed this spec internally.',
+    '// 80-to-100 master contract: child workflows perform fix-loop work, then the master performs final-review evidence checks before signoff.',
+    '',
+    'async function main() {',
+    `  const result = await workflow(${literal(input.workflowId)})`,
+    `    .description(${literal(input.spec.description)})`,
+    `    .pattern(${literal(input.pattern.pattern)})`,
+    `    .channel(${literal(input.channel)})`,
+    '    .maxConcurrency(4)',
+    '    .timeout(7200000)',
+    '    .onError(\'fail-fast\')',
+    '',
+    '    .agent("master-lead", { cli: "claude", interactive: false, role: "Plans child workflow boundaries, dependency waves, and final integration evidence.", retries: 1 })',
+    '    .agent("master-reviewer", { cli: "codex", preset: "reviewer", role: "Reviews child signoff evidence and master executor readiness.", retries: 1 })',
+    '',
+    '    .step("prepare-context", {',
+    '      type: "deterministic",',
+    `      command: ${literal([
+      'set -e',
+      `mkdir -p ${shellQuote(input.artifactsDir)}`,
+      `cat > ${shellQuote(`${input.artifactsDir}/master-plan.json`)} <<'EOF'`,
+      planJson,
+      'EOF',
+      `cat > ${shellQuote(`${input.artifactsDir}/skill-matches.json`)} <<'EOF'`,
+      skillMatchesJson,
+      'EOF',
+      `cat > ${shellQuote(`${input.artifactsDir}/skill-application-boundary.json`)} <<'EOF'`,
+      skillBoundaryJson,
+      'EOF',
+      `printf '%s\\n' 'generation_time_only' 'runtimeEmbodiment=false' > ${shellQuote(`${input.artifactsDir}/skill-runtime-boundary.txt`)}`,
+      'echo RICKY_MASTER_CONTEXT_READY',
+    ].join('\n'))},`,
+    '      captureOutput: true,',
+    '      failOnError: true,',
+    '    })',
+    '',
+    '    .step("lead-plan", {',
+    '      agent: "master-lead",',
+    '      dependsOn: ["prepare-context"],',
+    `      task: ${templateLiteral([
+      'Review the master execution plan at ' + `${input.artifactsDir}/master-plan.json` + '.',
+      'Confirm child workflow ownership, dependencies, non-goals, and 80-to-100 gates.',
+      'Do not edit source files in this step.',
+      `Write ${input.artifactsDir}/lead-plan.md ending with RICKY_MASTER_LEAD_PLAN_READY.`,
+    ].join('\n'))},`,
+    `      verification: { type: "file_exists", value: ${literal(`${input.artifactsDir}/lead-plan.md`)} },`,
+    '    })',
+    '',
+    '    .step("lead-plan-gate", {',
+    '      type: "deterministic",',
+    '      dependsOn: ["lead-plan"],',
+    `      command: ${literal(`set -e\nif command -v rg >/dev/null 2>&1; then rg "RICKY_MASTER_LEAD_PLAN_READY" ${shellQuote(`${input.artifactsDir}/lead-plan.md`)}; else grep -F "RICKY_MASTER_LEAD_PLAN_READY" ${shellQuote(`${input.artifactsDir}/lead-plan.md`)}; fi\necho RICKY_MASTER_LEAD_PLAN_VERIFIED`)},`,
+    '      captureOutput: true,',
+    '      failOnError: true,',
+    '    })',
+    '',
+    '    .step("materialize-child-workflows", {',
+    '      type: "deterministic",',
+    '      dependsOn: ["lead-plan-gate"],',
+    `      command: ${literal(materializeCommand)},`,
+    '      captureOutput: true,',
+    '      failOnError: true,',
+    '    })',
+    '',
+    '    .step("verify-child-workflows", {',
+    '      type: "deterministic",',
+    '      dependsOn: ["materialize-child-workflows"],',
+    `      command: ${literal(verifyChildrenCommand)},`,
+    '      captureOutput: true,',
+    '      failOnError: true,',
+    '    })',
+    '',
+    ...input.plan.children.flatMap((child) => renderChildRunStep(child)),
+    '    .step("review-child-evidence", {',
+    '      agent: "master-reviewer",',
+    `      dependsOn: ${literal(input.plan.children.map((child) => `run-${child.id}`))},`,
+    `      task: ${templateLiteral([
+      'Review child workflow signoffs and deterministic gates for the master executor run.',
+      `Read ${input.artifactsDir}/master-plan.json and each child signoff path.`,
+      `Write ${input.artifactsDir}/review-codex.md ending with RICKY_MASTER_REVIEW_READY.`,
+    ].join('\n'))},`,
+    `      verification: { type: "file_exists", value: ${literal(`${input.artifactsDir}/review-codex.md`)} },`,
+    '    })',
+    '',
+    '    .step("final-hard-validation", {',
+    '      type: "deterministic",',
+    '      dependsOn: ["review-child-evidence"],',
+    `      command: ${literal([
+      'set -e',
+      'npx tsc --noEmit',
+      'npm test',
+      'git diff --name-only',
+      `grep -F RICKY_MASTER_REVIEW_READY ${shellQuote(`${input.artifactsDir}/review-codex.md`)}`,
+      'echo RICKY_MASTER_FINAL_VALIDATION_READY',
+    ].join('\n'))},`,
+    '      captureOutput: true,',
+    '      failOnError: true,',
+    '    })',
+    '',
+    '    .step("final-signoff", {',
+    '      type: "deterministic",',
+    '      dependsOn: ["final-hard-validation"],',
+    `      command: ${literal(finalSignoffCommand)},`,
+    '      captureOutput: true,',
+    '      failOnError: true,',
+    '    })',
+    '    .run({ cwd: process.cwd() });',
+    '',
+    '  console.log(result.status);',
+    '}',
+    '',
+    'main().catch((error) => {',
+    '  console.error(error);',
+    '  process.exit(1);',
+    '});',
+    '',
+  ].join('\n')}`;
+}
+
+function renderChildRunStep(child: ChildWorkflowPlan): string[] {
+  const dependsOn = child.dependsOn.length > 0
+    ? child.dependsOn.map((dependencyId) => `run-${dependencyId}`)
+    : ['verify-child-workflows'];
+  const command = [
+    'set -e',
+    `ricky run ${shellQuote(child.workflowFilePath)} --foreground --no-auto-fix`,
+    `test -f ${shellQuote(child.signoffArtifactPath)}`,
+    `grep -F ${shellQuote(child.signoffMarker)} ${shellQuote(child.signoffArtifactPath)}`,
+    'echo RICKY_MASTER_CHILD_RUN_VERIFIED',
+  ].join('\n');
+
+  return [
+    `    .step(${literal(`run-${child.id}`)}, {`,
+    '      type: "deterministic",',
+    `      dependsOn: ${literal(dependsOn)},`,
+    `      command: ${literal(command)},`,
+    '      captureOutput: true,',
+    '      failOnError: true,',
+    '    })',
+    '',
+  ];
+}
+
+function childWorkflowSource(child: ChildWorkflowPlan, spec: NormalizedWorkflowSpec): string {
+  const artifactsDir = child.signoffArtifactPath.replace(/\/signoff\.md$/, '');
+  const validationCommand = child.validationCommands[0] ?? 'npm run typecheck';
+  const targetScope = child.targetFiles.length > 0 ? child.targetFiles.join(' ') : 'NO_TARGET_FILES_DECLARED';
+  const marker = child.signoffMarker;
+
+  return `${[
+    "import { workflow } from '@agent-relay/sdk/workflows';",
+    '',
+    '// IMPLEMENTATION_WORKFLOW_CONTRACT: child workflow must produce source changes, tests, non-empty diff evidence, and PR/result reporting when implementation scope applies.',
+    '',
+    'async function main() {',
+    `  const result = await workflow(${literal(`ricky-child-${child.id}`)})`,
+    `    .description(${literal(child.summary ?? child.title)})`,
+    '    .pattern("dag")',
+    `    .channel(${literal(`wf-ricky-child-${child.id}`)})`,
+    '    .maxConcurrency(2)',
+    '    .timeout(3600000)',
+    '    .onError(\'retry\', { maxRetries: 1, retryDelayMs: 1000 })',
+    '    .agent("lead-claude", { cli: "claude", interactive: false, role: "Plans this bounded child workflow slice.", retries: 1 })',
+    '    .agent("impl-codex", { cli: "codex", role: "Implements only this child workflow slice and its declared file scope.", retries: 2 })',
+    '    .agent("reviewer-codex", { cli: "codex", preset: "reviewer", role: "Reviews code, tests, deterministic gates, and PR/result evidence.", retries: 1 })',
+    '    .agent("validator-claude", { cli: "claude", preset: "worker", role: "Runs the 80-to-100 fix loop and writes final signoff.", retries: 2 })',
+    '    .step("prepare-context", {',
+    '      type: "deterministic",',
+    `      command: ${literal([
+      'set -e',
+      `mkdir -p ${shellQuote(artifactsDir)}`,
+      `printf '%s\\n' ${shellQuote(spec.description)} > ${shellQuote(`${artifactsDir}/normalized-spec.txt`)}`,
+      `printf '%s\\n' ${shellQuote(targetScope)} > ${shellQuote(`${artifactsDir}/target-files.txt`)}`,
+      'echo RICKY_CHILD_CONTEXT_READY',
+    ].join('\n'))},`,
+    '      captureOutput: true,',
+    '      failOnError: true,',
+    '    })',
+    '    .step("lead-plan", {',
+    '      agent: "lead-claude",',
+    '      dependsOn: ["prepare-context"],',
+    `      task: ${templateLiteral([
+      `Plan this child slice: ${child.title}.`,
+      `Target files: ${targetScope}.`,
+      'State non-goals, ownership, validation, source changes, code changes, tests, git diff evidence, and PR URL or explicit result status.',
+      `Write ${artifactsDir}/lead-plan.md ending with RICKY_CHILD_LEAD_PLAN_READY.`,
+    ].join('\n'))},`,
+    `      verification: { type: "file_exists", value: ${literal(`${artifactsDir}/lead-plan.md`)} },`,
+    '    })',
+    '    .step("implement-slice", {',
+    '      agent: "impl-codex",',
+    '      dependsOn: ["lead-plan"],',
+    `      task: ${templateLiteral([
+      `Implement the bounded child slice: ${child.title}.`,
+      `Edit only declared targets when possible: ${targetScope}.`,
+      'Produce deterministic evidence, tests, and a concise result or PR URL when applicable.',
+    ].join('\n'))},`,
+    '      verification: { type: "exit_code", value: "0" },',
+    '    })',
+    '    .step("initial-soft-validation", {',
+    '      type: "deterministic",',
+    '      dependsOn: ["implement-slice"],',
+    `      command: ${literal(`${validationCommand} 2>&1 | tail -160`)},`,
+    '      captureOutput: true,',
+    '      failOnError: false,',
+    '    })',
+    '    .step("review-codex", {',
+    '      agent: "reviewer-codex",',
+    '      dependsOn: ["initial-soft-validation"],',
+    `      task: ${templateLiteral([
+      'Review this child slice against the lead plan and validation output.',
+      `Write ${artifactsDir}/review-codex.md with PASS or FAIL and end with RICKY_CHILD_REVIEW_READY.`,
+    ].join('\n'))},`,
+    `      verification: { type: "file_exists", value: ${literal(`${artifactsDir}/review-codex.md`)} },`,
+    '    })',
+    '    .step("fix-loop", {',
+    '      agent: "validator-claude",',
+    '      dependsOn: ["review-codex"],',
+    `      task: ${templateLiteral([
+      'Run the 80-to-100 fix loop for this child slice.',
+      'Fix only failures from validation or review within the declared scope.',
+      `Write ${artifactsDir}/fix-loop-report.md ending with RICKY_CHILD_FIX_LOOP_READY.`,
+    ].join('\n'))},`,
+    `      verification: { type: "file_exists", value: ${literal(`${artifactsDir}/fix-loop-report.md`)} },`,
+    '    })',
+    '    .step("final-hard-validation", {',
+    '      type: "deterministic",',
+    '      dependsOn: ["fix-loop"],',
+    `      command: ${literal([
+      'set -e',
+      validationCommand,
+      'git diff --name-only',
+      `grep -F RICKY_CHILD_REVIEW_READY ${shellQuote(`${artifactsDir}/review-codex.md`)}`,
+      'echo RICKY_CHILD_FINAL_VALIDATION_READY',
+    ].join('\n'))},`,
+    '      captureOutput: true,',
+    '      failOnError: true,',
+    '    })',
+    '    .step("final-signoff", {',
+    '      type: "deterministic",',
+    '      dependsOn: ["final-hard-validation"],',
+    `      command: ${literal([
+      'set -e',
+      `mkdir -p ${shellQuote(artifactsDir)}`,
+      `cat > ${shellQuote(child.signoffArtifactPath)} <<'EOF'`,
+      `# Child workflow signoff: ${child.title}`,
+      '',
+      'RICKY_CHILD_WORKFLOW_COMPLETE',
+      marker,
+      'EOF',
+      'echo RICKY_CHILD_WORKFLOW_COMPLETE',
+    ].join('\n'))},`,
+    '      captureOutput: true,',
+    '      failOnError: true,',
+    '    })',
+    '    .run({ cwd: process.cwd() });',
+    '',
+    '  console.log(result.status);',
+    '}',
+    '',
+    'main().catch((error) => {',
+    '  console.error(error);',
+    '  process.exit(1);',
+    '});',
+    '',
+  ].join('\n')}`;
+}
+
+function buildMasterTasks(plan: MasterExecutionPlan): WorkflowTask[] {
+  return [
+    task('prepare-context', 'Prepare master context', 'deterministic', 'Write master plan and generation-time skill evidence.', []),
+    task('lead-plan', 'Plan child execution', 'master-lead', 'Review child ownership, dependencies, and validation gates.', ['prepare-context']),
+    task('materialize-child-workflows', 'Materialize child workflows', 'deterministic', 'Write focused child workflow artifacts.', ['lead-plan-gate']),
+    ...plan.children.map((child) =>
+      task(`run-${child.id}`, `Run ${child.title}`, 'deterministic', `Run child workflow ${child.workflowFilePath} through ricky run.`, child.dependsOn.map((id) => `run-${id}`)),
+    ),
+    task('review-child-evidence', 'Review child evidence', 'master-reviewer', 'Review child signoffs and master readiness.', plan.children.map((child) => `run-${child.id}`)),
+    task('final-signoff', 'Final signoff', 'deterministic', 'Write master signoff after hard validation.', ['final-hard-validation']),
+  ];
+}
+
+function buildMasterGates(artifactsDir: string, plan: MasterExecutionPlan): DeterministicGate[] {
+  return [
+    gate('skill-boundary-metadata-gate', `test -f ${artifactsDir}/skill-application-boundary.json`, 'file_exists', true, ['prepare-context'], 'pre_review'),
+    gate('lead-plan-gate', `grep -F RICKY_MASTER_LEAD_PLAN_READY ${artifactsDir}/lead-plan.md`, 'output_contains', true, ['lead-plan'], 'pre_review'),
+    gate('child-workflow-file-gate', plan.children.map((child) => `test -f ${child.workflowFilePath}`).join(' && '), 'file_exists', true, ['materialize-child-workflows'], 'pre_review'),
+    gate('initial-soft-validation', 'npx tsc --noEmit 2>&1 | tail -160', 'output_contains', false, ['child-workflow-file-gate'], 'pre_review'),
+    gate('final-review-pass-gate', `grep -F RICKY_MASTER_REVIEW_READY ${artifactsDir}/review-codex.md`, 'output_contains', true, ['review-child-evidence'], 'final'),
+    gate('final-hard-validation', 'npx tsc --noEmit && npm test', 'exit_code', true, ['final-review-pass-gate'], 'final'),
+    gate('git-diff-gate', 'git diff --name-only', 'output_contains', true, ['final-hard-validation'], 'final'),
+    gate('regression-gate', 'npm test', 'exit_code', true, ['git-diff-gate'], 'regression'),
+  ];
+}
+
+function buildMasterSkillEvidence(skills: SkillContext): SkillApplicationEvidence[] {
+  const names = skills.applicableSkillNames.length > 0
+    ? skills.applicableSkillNames
+    : ['choosing-swarm-patterns', 'writing-agent-relay-workflows', 'relay-80-100-workflow'];
+  return names.map((skillName) => ({
+    skillName,
+    stage: 'generation_rendering' as const,
+    effect: skillName === 'relay-80-100-workflow' ? 'validation_gates' as const : 'workflow_contract' as const,
+    behavior: 'generation_time_only' as const,
+    runtimeEmbodiment: false as const,
+    evidence: `Rendered master executor workflow using ${skillName} generation guidance.`,
+  }));
+}
+
+function buildMasterToolSelections(plan: MasterExecutionPlan): ToolSelection[] {
+  return [
+    { stepId: 'lead-plan', agent: 'master-lead', runner: 'claude', concurrency: 1, rule: 'master executor lead planning' },
+    ...plan.children.map((child) => ({
+      stepId: `run-${child.id}`,
+      agent: 'deterministic',
+      runner: '@agent-relay/sdk' as const,
+      concurrency: child.parallelizable ? 2 : 1,
+      rule: 'master executor runs child workflow through ricky run',
+    })),
+    { stepId: 'review-child-evidence', agent: 'master-reviewer', runner: 'codex', concurrency: 1, rule: 'master executor evidence review' },
+  ];
+}
+
+function task(id: string, name: string, agentRole: string, description: string, dependsOn: string[]): WorkflowTask {
+  return { id, name, agentRole, description, dependsOn };
+}
+
+function gate(
+  name: string,
+  command: string,
+  verificationType: DeterministicGate['verificationType'],
+  failOnError: boolean,
+  dependsOn: string[],
+  stage: DeterministicGate['stage'],
+): DeterministicGate {
+  return { name, command, verificationType, failOnError, dependsOn, stage };
+}
+
+function workflowText(spec: NormalizedWorkflowSpec): string {
+  return [
+    spec.description,
+    spec.targetContext,
+    spec.desiredAction.summary,
+    ...spec.constraints.map((constraint) => constraint.constraint),
+    ...spec.evidenceRequirements.map((requirement) => requirement.requirement),
+    ...spec.acceptanceGates.map((gate) => gate.gate),
+  ].filter(Boolean).join('\n');
+}
+
+function sliceSourceText(spec: NormalizedWorkflowSpec): string {
+  return [
+    spec.description,
+    spec.targetContext,
+    spec.desiredAction.summary,
+    ...spec.constraints.map((constraint) => constraint.constraint),
+  ].filter(Boolean).join('\n');
+}
+
+function extractSliceTitles(text: string): string[] {
+  const cleaned = text
+    .replace(/\b(?:implement|wire|add|build|ship|create|support|for|the|a|an)\b/gi, ' ')
+    .replace(/\b(?:as|with|using|via|through|by|run|runs|running|master executor|master orchestration|smaller workflows|child workflows|workflows?)\b/gi, ' ')
+    .replace(/[.;:]/g, ',');
+  const seen = new Set<string>();
+  const titles: string[] = [];
+  for (const rawPart of cleaned.split(/,|\band\b/gi)) {
+    const title = titleCase(rawPart.replace(/\s+/g, ' ').trim());
+    if (!title || title.length < 4 || title.length > 48) continue;
+    if (/^(deterministic|reliable|parallel|independent|several|multiple)$/i.test(title)) continue;
+    const key = slugify(title);
+    if (!key || seen.has(key)) continue;
+    seen.add(key);
+    titles.push(title);
+    if (titles.length >= 8) break;
+  }
+  return titles;
+}
+
+function titleForTargetFile(targetFile: string): string {
+  const basename = targetFile.split('/').at(-1)?.replace(/\.[^.]+$/, '') ?? targetFile;
+  return `Update ${titleCase(basename.replace(/[-_.]+/g, ' '))}`;
+}
+
+function waveCount(plan: MasterExecutionPlan): number {
+  return new Set(plan.children.map((child) => child.wave)).size;
+}
+
+function workflowNameFromArtifactPath(path: string | undefined): string | undefined {
+  if (!path) return undefined;
+  const fileName = path.split('/').at(-1) ?? path;
+  return fileName.replace(/\.[^.]+$/, '').trim() || undefined;
+}
+
+function slugify(value: string): string {
+  return value
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '')
+    .slice(0, 80) || 'master-workflow';
+}
+
+function titleCase(value: string): string {
+  return value
+    .split(/\s+/)
+    .filter(Boolean)
+    .map((part) => `${part.charAt(0).toUpperCase()}${part.slice(1).toLowerCase()}`)
+    .join(' ');
+}
+
+function literal(value: string | string[]): string {
+  return JSON.stringify(value);
+}
+
+function templateLiteral(value: string): string {
+  return `\`${value.replace(/\\/g, '\\\\').replace(/`/g, '\\`').replace(/\$\{/g, '\\${')}\``;
+}
+
+function shellQuote(value: string): string {
+  return `'${value.replace(/'/g, `'\\''`)}'`;
+}

--- a/src/product/generation/pipeline.test.ts
+++ b/src/product/generation/pipeline.test.ts
@@ -17,6 +17,72 @@ interface SpecFixtureOverrides {
 }
 
 describe('workflow generation pipeline', () => {
+  it('routes broad implementation specs through a master workflow without changing the CLI artifact contract', () => {
+    const result = generate({
+      spec: spec({
+        description:
+          'Implement nested runner, runtime policy, telemetry, evals, and insights as smaller workflows run by a master executor.',
+        constraints: ['Use independent child workflows with deterministic 80-to-100 validation.'],
+        acceptanceGates: ['npm test'],
+      }),
+      artifactPath: 'workflows/generated/runtime-master.ts',
+    });
+
+    expect(result.success).toBe(true);
+    expect(result.masterExecutionPlan).toBeDefined();
+    expect(result.masterExecutionPlan?.children.map((child) => child.id)).toEqual([
+      'nested-runner',
+      'runtime-policy',
+      'telemetry',
+      'evals',
+      'insights',
+    ]);
+    expect(result.executionRoute).toMatchObject({
+      artifactDelivery: 'write_local_file',
+      runnerCommand: 'npx agent-relay run --dry-run workflows/generated/runtime-master.ts',
+    });
+
+    const rendered = artifact(result);
+    expect(rendered.artifactPath).toBe('workflows/generated/runtime-master.ts');
+    expect(rendered.content).toContain('RICKY_MASTER_EXECUTOR_WORKFLOW');
+    expect(rendered.content).toContain('Master plan: 5 child workflows');
+    expect(rendered.content).toContain('ricky run \'workflows/generated/runtime-master-children/01-nested-runner.ts\' --foreground --no-auto-fix');
+    expect(rendered.content).toContain('MASTER_EXECUTOR_RESULT_READY');
+    expect(rendered.content).toContain('RICKY_CHILD_WORKFLOW_COMPLETE');
+    expect(rendered.content).toContain('.run({ cwd: process.cwd() })');
+  });
+
+  it('uses a master workflow for broad target-file specs and leaves narrow specs on the existing renderer', () => {
+    const broad = generate({
+      spec: spec({
+        description: 'Implement a broad runtime update with deterministic validation.',
+        targetFiles: [
+          'src/runtime/nested-runner.ts',
+          'src/runtime/policy.ts',
+          'src/runtime/telemetry.ts',
+          'src/product/evals.ts',
+        ],
+      }),
+      artifactPath: 'workflows/generated/broad-runtime.ts',
+    });
+    const narrow = generate({
+      spec: spec({
+        description: 'Implement one focused runtime policy update.',
+        targetFiles: ['src/runtime/policy.ts'],
+      }),
+      artifactPath: 'workflows/generated/narrow-runtime.ts',
+    });
+
+    expect(broad.masterExecutionPlan?.children.map((child) => child.workflowFilePath)).toEqual([
+      'workflows/generated/broad-runtime-children/01-update-nested-runner.ts',
+      'workflows/generated/broad-runtime-children/02-update-policy.ts',
+      'workflows/generated/broad-runtime-children/03-update-telemetry.ts',
+      'workflows/generated/broad-runtime-children/04-update-evals.ts',
+    ]);
+    expect(narrow.masterExecutionPlan).toBeUndefined();
+    expect(artifact(narrow).content).not.toContain('RICKY_MASTER_EXECUTOR_WORKFLOW');
+  });
+
   it('turns a code-writing spec into an implementation team workflow with 80-to-100 validation', () => {
     const result = generate({
       spec: spec({

--- a/src/product/generation/pipeline.ts
+++ b/src/product/generation/pipeline.ts
@@ -14,6 +14,7 @@ import type {
 import { selectPattern } from './pattern-selector.js';
 import { refineWithLlm } from './refine-with-llm.js';
 import { loadSkills } from './skill-loader.js';
+import { renderMasterExecutionWorkflow, shouldUseMasterExecutionWorkflow } from './master-workflow-renderer.js';
 import { renderWorkflow } from './template-renderer.js';
 import {
   applyPersonaArtifactToRenderedArtifact,
@@ -29,7 +30,15 @@ const MAX_WORKFORCE_PERSONA_PREWRITE_REPAIR_ATTEMPTS = 8;
 export function generate(input: GenerationInput): GenerationResult {
   const skillContext = loadSkills(input.spec, input.skillOverrides, input.templateOverride);
   const patternDecision = selectPattern(input.spec, input.patternOverride, skillContext);
-  const artifact = renderWorkflow({
+  const masterWorkflow = shouldUseMasterExecutionWorkflow(input.spec)
+    ? renderMasterExecutionWorkflow({
+        spec: input.spec,
+        pattern: patternDecision,
+        skills: skillContext,
+        artifactPath: input.artifactPath,
+      })
+    : null;
+  const artifact = masterWorkflow?.artifact ?? renderWorkflow({
     spec: input.spec,
     pattern: patternDecision,
     skills: skillContext,
@@ -37,7 +46,7 @@ export function generate(input: GenerationInput): GenerationResult {
   });
   let finalArtifact = artifact;
   let refinement = null;
-  if (input.refine) {
+  if (input.refine && !masterWorkflow) {
     const refined = refineWithLlm(input.spec, artifact, {
       model: input.refine.model,
       validate: (candidate) => validateGeneratedArtifact(candidate, patternDecision, skillContext, input.spec),
@@ -51,6 +60,7 @@ export function generate(input: GenerationInput): GenerationResult {
   return {
     success: validation.valid,
     artifact: finalArtifact,
+    ...(masterWorkflow ? { masterExecutionPlan: masterWorkflow.plan } : {}),
     patternDecision,
     skillContext,
     toolSelection: {
@@ -73,6 +83,9 @@ export function generate(input: GenerationInput): GenerationResult {
 
 export async function generateWithWorkforcePersona(input: GenerationInput): Promise<GenerationResult> {
   const baseResult = generate({ ...input, workforcePersonaWriter: false });
+  if (baseResult.masterExecutionPlan) {
+    return baseResult;
+  }
   if (input.workforcePersonaWriter === false || !baseResult.artifact || !baseResult.success) {
     return baseResult;
   }

--- a/src/product/generation/types.ts
+++ b/src/product/generation/types.ts
@@ -1,4 +1,5 @@
 import type { ClarificationQuestion, ExecutionPreference, NormalizedWorkflowSpec } from '../spec-intake/types.js';
+import type { MasterExecutionPlan } from '../orchestration/index.js';
 import type { SwarmPattern } from '../../shared/models/workflow-config.js';
 import type { VerificationType } from '../../shared/models/workflow-evidence.js';
 
@@ -235,6 +236,7 @@ export interface WorkflowExecutionRoute {
 export interface GenerationResult {
   success: boolean;
   artifact: RenderedArtifact | null;
+  masterExecutionPlan?: MasterExecutionPlan;
   clarificationQuestions?: ClarificationQuestion[];
   patternDecision: PatternDecision;
   skillContext: SkillContext;

--- a/src/product/index.ts
+++ b/src/product/index.ts
@@ -3,3 +3,4 @@ export * as generation from './generation/index.js';
 export * as specIntake from './spec-intake/index.js';
 export * as debuggerSpecialist from './specialists/debugger/index.js';
 export * as validatorSpecialist from './specialists/validator/index.js';
+export * as orchestration from './orchestration/index.js';

--- a/src/product/orchestration/index.ts
+++ b/src/product/orchestration/index.ts
@@ -1,0 +1,16 @@
+export { planMasterExecution } from './planner.js';
+export { runMasterExecution, DEFAULT_MASTER_EXECUTOR_OPTIONS } from './master-executor.js';
+
+export type {
+  ChildRunner,
+  ChildWorkflowGate,
+  ChildWorkflowPlan,
+  ChildWorkflowRunResult,
+  MasterChildStatus,
+  MasterExecutionPlan,
+  MasterExecutionResult,
+  MasterExecutorClassification,
+  MasterExecutorDecision,
+  MasterExecutorOptions,
+  PlannerInput,
+} from './types.js';

--- a/src/product/orchestration/index.ts
+++ b/src/product/orchestration/index.ts
@@ -4,6 +4,8 @@ export { runMasterExecution, DEFAULT_MASTER_EXECUTOR_OPTIONS } from './master-ex
 export type {
   ChildRunner,
   ChildWorkflowGate,
+  ChildWorkflowGateKind,
+  ChildWorkflowGateResult,
   ChildWorkflowPlan,
   ChildWorkflowRunResult,
   MasterChildStatus,
@@ -12,5 +14,7 @@ export type {
   MasterExecutorClassification,
   MasterExecutorDecision,
   MasterExecutorOptions,
+  PlannerConstraints,
+  PlannerDesiredSlice,
   PlannerInput,
 } from './types.js';

--- a/src/product/orchestration/master-executor.test.ts
+++ b/src/product/orchestration/master-executor.test.ts
@@ -58,7 +58,10 @@ describe('planMasterExecution', () => {
     expect(apiChild).toMatchObject({
       title: 'Implement billing API',
       targetFiles: ['src/product/billing/api.ts'],
-      allowedDirtyScope: ['src/product/billing/api.ts'],
+      allowedDirtyScope: [
+        'src/product/billing/api.ts',
+        '.workflow-artifacts/wave99-billing/implement-billing-api/signoff.md',
+      ],
       dependsOn: [],
       parallelizable: true,
       wave: 0,
@@ -126,6 +129,24 @@ describe('planMasterExecution', () => {
       ['telemetry', 1],
       ['insights', 2],
     ]);
+  });
+
+  it('promotes child-level ambiguities to the top-level plan', () => {
+    const plan = planMasterExecution({
+      title: 'Ambiguous dependency plan',
+      description: 'A child references an unknown dependency.',
+      desiredSlices: [
+        {
+          id: 'needs-missing',
+          title: 'Needs missing dependency',
+          targetFiles: ['src/needs.ts'],
+          dependsOn: ['missing-child'],
+        },
+      ],
+    });
+
+    expect(children(plan)[0].ambiguous?.reason).toContain('Unknown dependency: missing-child.');
+    expect(plan.ambiguous?.reason).toContain('Unknown dependency: missing-child.');
   });
 });
 
@@ -263,6 +284,111 @@ describe('runMasterExecution', () => {
       childId: target.id,
       missing: ['GITHUB_TOKEN'],
     });
+  });
+
+  it('classifies thrown missing environment errors as blocked', async () => {
+    const plan = singleChildPlan('Publish cloud workflow');
+    const target = children(plan)[0];
+
+    const result = await runMasterExecution(plan, async () => {
+      throw new Error('MISSING_ENV_VAR: GITHUB_TOKEN');
+    });
+
+    expect(result.decision).toEqual({
+      kind: 'blocked',
+      childId: target.id,
+      missing: ['GITHUB_TOKEN'],
+    });
+    expect(runFor(result, target.id)).toMatchObject({
+      status: 'blocked',
+      blockedReason: 'MISSING_ENV_VAR: GITHUB_TOKEN',
+    });
+  });
+
+  it('converts resume signoff reader failures into a child result', async () => {
+    const plan = singleChildPlan('Resume with unreadable signoff');
+    const target = children(plan)[0];
+
+    const result = await runMasterExecution(
+      plan,
+      async (plannedChild: ChildWorkflowPlan, ctx: RunnerContext) => passedRun(plannedChild, ctx.attempt),
+      {
+        resume: true,
+        signoffArtifactReader: async () => {
+          throw new Error('cannot read signoff');
+        },
+      },
+    );
+
+    expect(result.childResults).toHaveLength(1);
+    expect(runFor(result, target.id)).toMatchObject({
+      status: 'failed',
+      errorMessage: 'cannot read signoff',
+    });
+  });
+
+  it('does not duplicate cancelled children in continue mode', async () => {
+    const plan = planMasterExecution({
+      title: 'Continue after dependency failure',
+      description: 'A failed upstream cancels downstream once.',
+      desiredSlices: [
+        { id: 'upstream', title: 'Upstream', targetFiles: ['src/up.ts'] },
+        {
+          id: 'downstream',
+          title: 'Downstream',
+          targetFiles: ['src/down.ts'],
+          dependsOn: ['upstream'],
+        },
+      ],
+    });
+    const upstream = child(plan, 'upstream');
+
+    const result = await runMasterExecution(
+      plan,
+      async () => failedRun(upstream, {
+        signoffPresent: false,
+        errorMessage: 'unit test failed',
+      }),
+      { failurePolicy: 'continue' },
+    );
+
+    expect(result.childResults.filter((run) => run.childId === 'downstream')).toHaveLength(1);
+    expect(runFor(result, 'downstream').status).toBe('cancelled');
+  });
+
+  it('falls back to default bounded concurrency for non-finite maxConcurrency values', async () => {
+    const plan = planMasterExecution({
+      title: 'Non-finite concurrency',
+      description: 'Concurrency should stay bounded.',
+      desiredSlices: [
+        { id: 'one', title: 'One', targetFiles: ['src/one.ts'] },
+        { id: 'two', title: 'Two', targetFiles: ['src/two.ts'] },
+        { id: 'three', title: 'Three', targetFiles: ['src/three.ts'] },
+      ],
+    });
+    const controls = new Map<string, Deferred<void>>();
+    const starts: string[] = [];
+
+    const execution = runMasterExecution(
+      plan,
+      async (plannedChild: ChildWorkflowPlan, ctx: RunnerContext) => {
+        starts.push(plannedChild.id);
+        const control = deferred<void>();
+        controls.set(plannedChild.id, control);
+        await control.promise;
+        return passedRun(plannedChild, ctx.attempt);
+      },
+      { maxConcurrency: Number.POSITIVE_INFINITY },
+    );
+
+    await waitUntil(() => expect(starts).toHaveLength(2));
+    controls.get('one')?.resolve();
+    controls.get('two')?.resolve();
+    await waitUntil(() => expect(starts).toHaveLength(3));
+    controls.get('three')?.resolve();
+
+    const result = await execution;
+    expect(result.decision).toEqual({ kind: 'complete' });
   });
 
   it('only completes when every required gate for every required child passes', async () => {

--- a/src/product/orchestration/master-executor.test.ts
+++ b/src/product/orchestration/master-executor.test.ts
@@ -1,0 +1,593 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  planMasterExecution,
+  runMasterExecution,
+  type ChildRunner,
+  type ChildWorkflowPlan,
+  type ChildWorkflowRunResult,
+  type ChildWorkflowGate,
+  type MasterExecutionPlan,
+} from './index.js';
+
+const STARTED_AT = '2026-05-07T10:00:00.000Z';
+const COMPLETED_AT = '2026-05-07T10:00:01.000Z';
+
+interface RunnerContext {
+  attempt: number;
+  resume: boolean;
+  abortSignal: AbortSignal;
+}
+
+describe('planMasterExecution', () => {
+  it('decomposes a spec into stable child workflow plans with default 80-to-100 gates', () => {
+    const plan = planMasterExecution({
+      title: 'Ship billing automation',
+      description: 'Split billing API, tests, and docs into bounded execution slices.',
+      wavePrefix: 'wave99-billing',
+      desiredSlices: [
+        {
+          title: 'Implement billing API',
+          targetFiles: ['src/product/billing/api.ts'],
+        },
+        {
+          id: 'billing-tests',
+          title: 'Add billing tests',
+          targetFiles: ['src/product/billing/api.test.ts'],
+          dependsOn: ['implement-billing-api'],
+        },
+        {
+          title: 'Document billing rollout',
+          targetFiles: ['docs/product/billing-rollout.md'],
+        },
+      ],
+    });
+
+    expect(children(plan).map((plannedChild: ChildWorkflowPlan) => plannedChild.id)).toEqual([
+      'implement-billing-api',
+      'document-billing-rollout',
+      'billing-tests',
+    ]);
+    expect(children(plan).map((plannedChild: ChildWorkflowPlan) => plannedChild.workflowFilePath)).toEqual([
+      'workflows/wave99-billing/01-implement-billing-api.ts',
+      'workflows/wave99-billing/02-document-billing-rollout.ts',
+      'workflows/wave99-billing/03-billing-tests.ts',
+    ]);
+
+    const apiChild = child(plan, 'implement-billing-api');
+    expect(apiChild).toMatchObject({
+      title: 'Implement billing API',
+      targetFiles: ['src/product/billing/api.ts'],
+      allowedDirtyScope: ['src/product/billing/api.ts'],
+      dependsOn: [],
+      parallelizable: true,
+      wave: 0,
+      signoffArtifactPath:
+        '.workflow-artifacts/wave99-billing/implement-billing-api/signoff.md',
+      signoffMarker: 'RICKY_IMPLEMENT_BILLING_API_IMPLEMENTED',
+      validationCommands: ['npm run typecheck'],
+      retryPolicy: { maxAttempts: 2, backoffMs: 1000 },
+    });
+    expect(apiChild.gates).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          kind: 'signoff_artifact',
+          required: true,
+          artifactPath: apiChild.signoffArtifactPath,
+        }),
+        expect.objectContaining({
+          kind: 'marker_string',
+          required: true,
+          marker: apiChild.signoffMarker,
+        }),
+        expect.objectContaining({
+          kind: 'changed_files',
+          required: true,
+          fileScope: ['src/product/billing/api.ts'],
+        }),
+        expect.objectContaining({
+          kind: 'test_command',
+          required: true,
+          command: 'npm run typecheck',
+        }),
+      ]),
+    );
+
+    const testsChild = child(plan, 'billing-tests');
+    expect(testsChild.dependsOn).toEqual(['implement-billing-api']);
+    expect(testsChild.wave).toBe(1);
+  });
+
+  it('assigns dependency waves and preserves topological child ordering', () => {
+    const plan = planMasterExecution({
+      title: 'Coordinate runtime rollout',
+      description: 'Runtime policy gates telemetry and insight work.',
+      desiredSlices: [
+        { id: 'runtime-policy', title: 'Runtime policy', targetFiles: ['src/runtime/policy.ts'] },
+        {
+          id: 'telemetry',
+          title: 'Telemetry',
+          targetFiles: ['src/runtime/telemetry.ts'],
+          dependsOn: ['runtime-policy'],
+        },
+        {
+          id: 'insights',
+          title: 'Insights',
+          targetFiles: ['src/product/insights.ts'],
+          dependsOn: ['telemetry'],
+        },
+        { id: 'docs', title: 'Docs', targetFiles: ['docs/runtime-rollout.md'] },
+      ],
+    });
+
+    expect(children(plan).map((plannedChild: ChildWorkflowPlan) => [plannedChild.id, plannedChild.wave])).toEqual([
+      ['runtime-policy', 0],
+      ['docs', 0],
+      ['telemetry', 1],
+      ['insights', 2],
+    ]);
+  });
+});
+
+describe('runMasterExecution', () => {
+  it('enforces maxConcurrency while running independent children', async () => {
+    const plan = planMasterExecution({
+      title: 'Parallel product slices',
+      description: 'Four independent slices can run in a bounded pool.',
+      desiredSlices: [
+        { id: 'slice-one', title: 'Slice one', targetFiles: ['src/a.ts'] },
+        { id: 'slice-two', title: 'Slice two', targetFiles: ['src/b.ts'] },
+        { id: 'slice-three', title: 'Slice three', targetFiles: ['src/c.ts'] },
+        { id: 'slice-four', title: 'Slice four', targetFiles: ['src/d.ts'] },
+      ],
+    });
+    const controls = new Map<string, Deferred<void>>();
+    const starts: string[] = [];
+    let inFlight = 0;
+    let peakConcurrency = 0;
+
+    const runner: ChildRunner = async (plannedChild: ChildWorkflowPlan, ctx: RunnerContext) => {
+      starts.push(plannedChild.id);
+      inFlight += 1;
+      peakConcurrency = Math.max(peakConcurrency, inFlight);
+      const control = deferred<void>();
+      controls.set(plannedChild.id, control);
+      await control.promise;
+      inFlight -= 1;
+      return passedRun(plannedChild, ctx.attempt);
+    };
+
+    const execution = runMasterExecution(plan, runner, { maxConcurrency: 2 });
+
+    await waitUntil(() => expect(starts).toHaveLength(2));
+    expect(peakConcurrency).toBe(2);
+    expect(starts).toEqual(['slice-one', 'slice-two']);
+
+    controls.get('slice-one')?.resolve();
+    await waitUntil(() => expect(starts).toHaveLength(3));
+    expect(peakConcurrency).toBe(2);
+
+    controls.get('slice-two')?.resolve();
+    controls.get('slice-three')?.resolve();
+    await waitUntil(() => expect(starts).toHaveLength(4));
+    controls.get('slice-four')?.resolve();
+
+    const result = await execution;
+    expect(result.decision).toEqual({ kind: 'complete' });
+    expect(runs(result).map((run: ChildWorkflowRunResult) => run.childId)).toEqual([
+      'slice-one',
+      'slice-two',
+      'slice-three',
+      'slice-four',
+    ]);
+  });
+
+  it('skips signed-off children during resume without invoking the runner', async () => {
+    const plan = planMasterExecution({
+      title: 'Resume existing work',
+      description: 'One child already has a signoff marker on disk.',
+      desiredSlices: [
+        { id: 'already-done', title: 'Already done', targetFiles: ['src/done.ts'] },
+        { id: 'still-needed', title: 'Still needed', targetFiles: ['src/needed.ts'] },
+      ],
+    });
+    const invoked: string[] = [];
+    const signedOffChild = child(plan, 'already-done');
+
+    const result = await runMasterExecution(
+      plan,
+      async (plannedChild: ChildWorkflowPlan, ctx: RunnerContext) => {
+        invoked.push(plannedChild.id);
+        return passedRun(plannedChild, ctx.attempt);
+      },
+      {
+        resume: true,
+        signoffArtifactReader: async (artifactPath: string) =>
+          artifactPath === signedOffChild.signoffArtifactPath
+            ? `previous signoff\n${signedOffChild.signoffMarker}\n`
+            : null,
+      },
+    );
+
+    expect(invoked).toEqual(['still-needed']);
+    expect(runFor(result, 'already-done')).toMatchObject({
+      childId: 'already-done',
+      status: 'skipped',
+      evidence: {
+        signoffPresent: true,
+        markerPresent: true,
+      },
+    });
+    expect(runFor(result, 'already-done').evidence.gateResults).toEqual(
+      signedOffChild.gates
+        .filter((gate: ChildWorkflowGate) => gate.required)
+        .map((gate: ChildWorkflowGate) => ({ gateId: gate.id, kind: gate.kind, passed: true })),
+    );
+    expect(result.decision).toEqual({ kind: 'complete' });
+    expect(result.resumed).toBe(true);
+  });
+
+  it('classifies a failed child inside its retry budget as retry', async () => {
+    const plan = singleChildPlan('Implement repairable slice');
+    const target = children(plan)[0];
+
+    const result = await runMasterExecution(plan, async () =>
+      failedRun(target, {
+        signoffPresent: false,
+        errorMessage: 'unit test failed before signoff artifact was written',
+      }),
+    );
+
+    expect(result.decision).toMatchObject({
+      kind: 'retry',
+      childId: target.id,
+    });
+    expect(result.childResults).toHaveLength(1);
+    expect(result.childResults[0]).toMatchObject({
+      childId: target.id,
+      status: 'failed',
+      evidence: { signoffPresent: false },
+    });
+  });
+
+  it('classifies a missing environment variable as blocked', async () => {
+    const plan = singleChildPlan('Publish cloud workflow');
+    const target = children(plan)[0];
+
+    const result = await runMasterExecution(plan, async () =>
+      blockedRun(target, 'MISSING_ENV_VAR: GITHUB_TOKEN'),
+    );
+
+    expect(result.decision).toEqual({
+      kind: 'blocked',
+      childId: target.id,
+      missing: ['GITHUB_TOKEN'],
+    });
+  });
+
+  it('only completes when every required gate for every required child passes', async () => {
+    const plan = planMasterExecution({
+      title: 'Gate final completion',
+      description: 'Two children must both pass required evidence gates.',
+      desiredSlices: [
+        { id: 'source-change', title: 'Source change', targetFiles: ['src/source.ts'] },
+        {
+          id: 'test-change',
+          title: 'Test change',
+          targetFiles: ['src/source.test.ts'],
+          dependsOn: ['source-change'],
+        },
+      ],
+    });
+
+    const complete = await runMasterExecution(plan, async (plannedChild: ChildWorkflowPlan, ctx: RunnerContext) =>
+      passedRun(plannedChild, ctx.attempt),
+    );
+
+    expect(complete.decision).toEqual({ kind: 'complete' });
+
+    const incomplete = await runMasterExecution(plan, async (plannedChild: ChildWorkflowPlan, ctx: RunnerContext) => {
+      if (plannedChild.id === 'test-change') {
+        return passedRun(plannedChild, ctx.attempt, {
+          markerPresent: false,
+          gateResults: plannedChild.gates.map((gate: ChildWorkflowGate) => ({
+            gateId: gate.id,
+            kind: gate.kind,
+            passed: gate.kind !== 'marker_string',
+            detail: gate.kind === 'marker_string' ? 'required marker missing' : undefined,
+          })),
+        });
+      }
+
+      return passedRun(plannedChild, ctx.attempt);
+    });
+
+    expect(incomplete.decision).not.toEqual({ kind: 'complete' });
+    expect(runFor(incomplete, 'test-change').evidence).toMatchObject({
+      signoffPresent: true,
+      markerPresent: false,
+    });
+  });
+
+  it('does not invoke a dependent child when an upstream required gate failed', async () => {
+    const plan = planMasterExecution({
+      title: 'Gate-aware dependency block',
+      description: 'Upstream returns passed status but a required gate failed.',
+      desiredSlices: [
+        { id: 'upstream', title: 'Upstream', targetFiles: ['src/up.ts'] },
+        {
+          id: 'downstream',
+          title: 'Downstream',
+          targetFiles: ['src/down.ts'],
+          dependsOn: ['upstream'],
+        },
+      ],
+    });
+    const invoked: string[] = [];
+
+    const result = await runMasterExecution(plan, async (plannedChild: ChildWorkflowPlan, ctx: RunnerContext) => {
+      invoked.push(plannedChild.id);
+      if (plannedChild.id === 'upstream') {
+        return passedRun(plannedChild, ctx.attempt, {
+          markerPresent: false,
+          gateResults: plannedChild.gates.map((gate: ChildWorkflowGate) => ({
+            gateId: gate.id,
+            kind: gate.kind,
+            passed: gate.kind !== 'marker_string',
+            detail: gate.kind === 'marker_string' ? 'upstream marker missing' : undefined,
+          })),
+        });
+      }
+      return passedRun(plannedChild, ctx.attempt);
+    });
+
+    expect(invoked).toEqual(['upstream']);
+    expect(runFor(result, 'downstream').status).toBe('cancelled');
+    expect(result.decision).not.toEqual({ kind: 'complete' });
+  });
+
+  it('runs same-wave non-parallelizable children serially with no overlap', async () => {
+    const plan = planMasterExecution({
+      title: 'Non-parallelizable scheduling',
+      description: 'Two children share a file, so the second one must run alone.',
+      desiredSlices: [
+        { id: 'first', title: 'First', targetFiles: ['src/shared.ts'] },
+        { id: 'second', title: 'Second', targetFiles: ['src/shared.ts'] },
+      ],
+    });
+    expect(child(plan, 'first').parallelizable).toBe(true);
+    expect(child(plan, 'second').parallelizable).toBe(false);
+    expect(child(plan, 'first').wave).toBe(child(plan, 'second').wave);
+
+    const controls = new Map<string, Deferred<void>>();
+    const starts: string[] = [];
+    let inFlight = 0;
+    let peakConcurrency = 0;
+
+    const runner: ChildRunner = async (plannedChild: ChildWorkflowPlan, ctx: RunnerContext) => {
+      starts.push(plannedChild.id);
+      inFlight += 1;
+      peakConcurrency = Math.max(peakConcurrency, inFlight);
+      const control = deferred<void>();
+      controls.set(plannedChild.id, control);
+      await control.promise;
+      inFlight -= 1;
+      return passedRun(plannedChild, ctx.attempt);
+    };
+
+    const execution = runMasterExecution(plan, runner, { maxConcurrency: 4 });
+
+    await waitUntil(() => expect(starts).toHaveLength(1));
+    expect(starts).toEqual(['first']);
+    expect(peakConcurrency).toBe(1);
+
+    controls.get('first')?.resolve();
+    await waitUntil(() => expect(starts).toHaveLength(2));
+    expect(starts).toEqual(['first', 'second']);
+    expect(peakConcurrency).toBe(1);
+
+    controls.get('second')?.resolve();
+    const result = await execution;
+    expect(result.decision).toEqual({ kind: 'complete' });
+  });
+
+  it('preserves distinct required gates of the same kind via stable gate ids', async () => {
+    const plan = planMasterExecution({
+      title: 'Duplicate-kind gate identity',
+      description: 'requiredGateMarkers add extra marker_string gates that must merge by id.',
+      desiredSlices: [
+        { id: 'with-extra-markers', title: 'With markers', targetFiles: ['src/x.ts'] },
+      ],
+      constraints: { requiredGateMarkers: ['EXTRA_MARKER_A', 'EXTRA_MARKER_B'] },
+    });
+    const target = children(plan)[0];
+    const markerGates = target.gates.filter((gate: ChildWorkflowGate) => gate.kind === 'marker_string');
+    expect(markerGates.length).toBeGreaterThanOrEqual(3);
+    expect(new Set(markerGates.map((gate: ChildWorkflowGate) => gate.id)).size).toBe(markerGates.length);
+
+    const result = await runMasterExecution(plan, async (plannedChild: ChildWorkflowPlan, ctx: RunnerContext) => ({
+      childId: plannedChild.id,
+      status: 'passed' as const,
+      attempt: ctx.attempt,
+      startedAt: STARTED_AT,
+      completedAt: COMPLETED_AT,
+      durationMs: 1000,
+      evidence: {
+        signoffPresent: true,
+        markerPresent: true,
+        changedFiles: plannedChild.targetFiles,
+        gateResults: plannedChild.gates.map((gate: ChildWorkflowGate) => ({
+          gateId: gate.id,
+          kind: gate.kind,
+          passed: gate.id !== 'marker_string:EXTRA_MARKER_B',
+          detail:
+            gate.id === 'marker_string:EXTRA_MARKER_B'
+              ? 'second extra marker not yet observed'
+              : undefined,
+        })),
+      },
+    }));
+
+    const merged = runFor(result, target.id).evidence.gateResults;
+    const markerResults = merged.filter((gateResult) => gateResult.kind === 'marker_string');
+    expect(markerResults.length).toBeGreaterThanOrEqual(3);
+    expect(merged.find((gateResult) => gateResult.gateId === 'marker_string:EXTRA_MARKER_A')?.passed).toBe(true);
+    expect(merged.find((gateResult) => gateResult.gateId === 'marker_string:EXTRA_MARKER_B')?.passed).toBe(false);
+    expect(result.decision).not.toEqual({ kind: 'complete' });
+  });
+});
+
+function singleChildPlan(title: string): MasterExecutionPlan {
+  return planMasterExecution({
+    title,
+    description: 'A single child plan for focused executor classification.',
+    desiredSlices: [{ title, targetFiles: ['src/product/example.ts'] }],
+  });
+}
+
+function child(plan: MasterExecutionPlan, childId: string): ChildWorkflowPlan {
+  const plannedChild = children(plan).find((candidate: ChildWorkflowPlan) => candidate.id === childId);
+  if (!plannedChild) {
+    throw new Error(`Missing child ${childId}`);
+  }
+
+  return plannedChild;
+}
+
+function runFor(
+  result: Awaited<ReturnType<typeof runMasterExecution>>,
+  childId: string,
+): ChildWorkflowRunResult {
+  const run = runs(result).find((candidate: ChildWorkflowRunResult) => candidate.childId === childId);
+  if (!run) {
+    throw new Error(`Missing run ${childId}`);
+  }
+
+  return run;
+}
+
+function passedRun(
+  childPlan: ChildWorkflowPlan,
+  attempt: number,
+  evidenceOverrides: Partial<ChildWorkflowRunResult['evidence']> = {},
+): ChildWorkflowRunResult {
+  return {
+    childId: childPlan.id,
+    status: 'passed',
+    attempt,
+    startedAt: STARTED_AT,
+    completedAt: COMPLETED_AT,
+    durationMs: 1000,
+    evidence: {
+      signoffPresent: true,
+      markerPresent: true,
+      changedFiles: childPlan.targetFiles,
+      gateResults: passedGateResults(childPlan.gates),
+      ...evidenceOverrides,
+    },
+  };
+}
+
+function failedRun(
+  childPlan: ChildWorkflowPlan,
+  overrides: {
+    signoffPresent: boolean;
+    errorMessage: string;
+  },
+): ChildWorkflowRunResult {
+  return {
+    childId: childPlan.id,
+    status: 'failed',
+    attempt: 1,
+    startedAt: STARTED_AT,
+    completedAt: COMPLETED_AT,
+    durationMs: 1000,
+    evidence: {
+      signoffPresent: overrides.signoffPresent,
+      markerPresent: false,
+      changedFiles: [],
+      gateResults: childPlan.gates.map((gate: ChildWorkflowGate) => ({
+        gateId: gate.id,
+        kind: gate.kind,
+        passed: false,
+        detail: 'gate did not pass',
+      })),
+    },
+    errorMessage: overrides.errorMessage,
+  };
+}
+
+function blockedRun(childPlan: ChildWorkflowPlan, blockedReason: string): ChildWorkflowRunResult {
+  return {
+    childId: childPlan.id,
+    status: 'blocked',
+    attempt: 1,
+    startedAt: STARTED_AT,
+    completedAt: COMPLETED_AT,
+    durationMs: 1000,
+    evidence: {
+      signoffPresent: false,
+      markerPresent: false,
+      changedFiles: [],
+      gateResults: childPlan.gates.map((gate: ChildWorkflowGate) => ({
+        gateId: gate.id,
+        kind: gate.kind,
+        passed: false,
+        detail: blockedReason,
+      })),
+    },
+    blockedReason,
+  };
+}
+
+function passedGateResults(
+  gates: readonly ChildWorkflowGate[],
+): ChildWorkflowRunResult['evidence']['gateResults'] {
+  return gates.map((gate: ChildWorkflowGate) => ({ gateId: gate.id, kind: gate.kind, passed: true }));
+}
+
+function children(plan: MasterExecutionPlan): readonly ChildWorkflowPlan[] {
+  return plan.children;
+}
+
+function runs(result: Awaited<ReturnType<typeof runMasterExecution>>): readonly ChildWorkflowRunResult[] {
+  return result.childResults;
+}
+
+interface Deferred<T> {
+  promise: Promise<T>;
+  resolve: (value: T | PromiseLike<T>) => void;
+  reject: (reason?: unknown) => void;
+}
+
+function deferred<T>(): Deferred<T> {
+  let resolve: Deferred<T>['resolve'] = () => undefined;
+  let reject: Deferred<T>['reject'] = () => undefined;
+  const promise = new Promise<T>((promiseResolve, promiseReject) => {
+    resolve = promiseResolve;
+    reject = promiseReject;
+  });
+
+  return { promise, resolve, reject };
+}
+
+async function waitUntil(assertion: () => void, timeoutMs = 1000): Promise<void> {
+  const startedAt = Date.now();
+  let lastError: unknown;
+
+  while (Date.now() - startedAt < timeoutMs) {
+    try {
+      assertion();
+      return;
+    } catch (error) {
+      lastError = error;
+      await new Promise((resolve) => setTimeout(resolve, 0));
+    }
+  }
+
+  if (lastError instanceof Error) {
+    throw lastError;
+  }
+
+  throw new Error('Timed out waiting for assertion.');
+}

--- a/src/product/orchestration/master-executor.ts
+++ b/src/product/orchestration/master-executor.ts
@@ -42,8 +42,9 @@ export async function runMasterExecution(
       break;
     }
 
-    const readyChildren = wave.filter((child) => dependenciesSatisfied(child, finishedByChildId));
-    const blockedByDependency = wave.filter((child) => !dependenciesSatisfied(child, finishedByChildId));
+    const unfinishedWave = wave.filter((child) => !finishedByChildId.has(child.id));
+    const readyChildren = unfinishedWave.filter((child) => dependenciesSatisfied(child, finishedByChildId));
+    const blockedByDependency = unfinishedWave.filter((child) => !dependenciesSatisfied(child, finishedByChildId));
     for (const child of blockedByDependency) {
       const cancelled = cancelledRun(child, resolvedOptions, 'A dependency did not complete successfully.');
       childResults.push(cancelled);
@@ -55,15 +56,15 @@ export async function runMasterExecution(
         return;
       }
 
-      const resumeSkip = await maybeResumeSkip(child, resolvedOptions);
-      if (resumeSkip) {
-        childResults.push(resumeSkip);
-        finishedByChildId.set(child.id, resumeSkip);
-        return;
-      }
-
       const pending = startChild(child, resolvedOptions, activeControllers);
       try {
+        const resumeSkip = await maybeResumeSkip(child, resolvedOptions);
+        if (resumeSkip) {
+          childResults.push(resumeSkip);
+          finishedByChildId.set(child.id, resumeSkip);
+          return;
+        }
+
         const result = normalizeRunResult(await runner(child, {
           attempt: 1,
           resume: resolvedOptions.resume,
@@ -124,8 +125,15 @@ function resolveOptions(options: Partial<MasterExecutorOptions>): RuntimeOptions
 
   return {
     ...merged,
-    maxConcurrency: Math.max(1, Math.floor(merged.maxConcurrency)),
+    maxConcurrency: boundedConcurrency(merged.maxConcurrency),
   };
+}
+
+function boundedConcurrency(value: number): number {
+  if (!Number.isFinite(value)) {
+    return DEFAULT_MASTER_EXECUTOR_OPTIONS.maxConcurrency;
+  }
+  return Math.max(1, Math.floor(value));
 }
 
 function executionWaves(children: readonly ChildWorkflowPlan[]): ChildWorkflowPlan[][] {
@@ -306,7 +314,7 @@ function failedRunFromError(
 
   return {
     childId: child.id,
-    status: 'failed',
+    status: hasEnvBlockHint(message) ? 'blocked' : 'failed',
     attempt: 1,
     startedAt: completedAtDate.toISOString(),
     completedAt: completedAtDate.toISOString(),
@@ -319,7 +327,7 @@ function failedRunFromError(
         .filter((gate) => gate.required)
         .map((gate) => ({ gateId: gate.id, kind: gate.kind, passed: false, detail: message })),
     },
-    errorMessage: message,
+    ...(hasEnvBlockHint(message) ? { blockedReason: message } : { errorMessage: message }),
   };
 }
 

--- a/src/product/orchestration/master-executor.ts
+++ b/src/product/orchestration/master-executor.ts
@@ -1,0 +1,498 @@
+import type {
+  ChildRunner,
+  ChildWorkflowGate,
+  ChildWorkflowPlan,
+  ChildWorkflowRunResult,
+  MasterExecutionPlan,
+  MasterExecutionResult,
+  MasterExecutorDecision,
+  MasterExecutorOptions,
+} from './types.js';
+
+export const DEFAULT_MASTER_EXECUTOR_OPTIONS: Readonly<MasterExecutorOptions> = {
+  maxConcurrency: 2,
+  resume: false,
+  failurePolicy: 'stop',
+};
+
+type RuntimeOptions = MasterExecutorOptions & {
+  now: () => Date;
+};
+
+interface PendingChild {
+  child: ChildWorkflowPlan;
+  controller: AbortController;
+}
+
+export async function runMasterExecution(
+  plan: MasterExecutionPlan,
+  runner: ChildRunner,
+  options: Partial<MasterExecutorOptions> = {},
+): Promise<MasterExecutionResult> {
+  const resolvedOptions = resolveOptions(options);
+  const startedAtDate = resolvedOptions.now();
+  const startedAt = startedAtDate.toISOString();
+  const childResults: ChildWorkflowRunResult[] = [];
+  const finishedByChildId = new Map<string, ChildWorkflowRunResult>();
+  const activeControllers = new Set<AbortController>();
+  let haltedByFailure: ChildWorkflowRunResult | undefined;
+
+  for (const wave of executionWaves(plan.children)) {
+    if (haltedByFailure) {
+      break;
+    }
+
+    const readyChildren = wave.filter((child) => dependenciesSatisfied(child, finishedByChildId));
+    const blockedByDependency = wave.filter((child) => !dependenciesSatisfied(child, finishedByChildId));
+    for (const child of blockedByDependency) {
+      const cancelled = cancelledRun(child, resolvedOptions, 'A dependency did not complete successfully.');
+      childResults.push(cancelled);
+      finishedByChildId.set(child.id, cancelled);
+    }
+
+    const runChild = async (child: ChildWorkflowPlan): Promise<void> => {
+      if (haltedByFailure && resolvedOptions.failurePolicy === 'stop') {
+        return;
+      }
+
+      const resumeSkip = await maybeResumeSkip(child, resolvedOptions);
+      if (resumeSkip) {
+        childResults.push(resumeSkip);
+        finishedByChildId.set(child.id, resumeSkip);
+        return;
+      }
+
+      const pending = startChild(child, resolvedOptions, activeControllers);
+      try {
+        const result = normalizeRunResult(await runner(child, {
+          attempt: 1,
+          resume: resolvedOptions.resume,
+          abortSignal: pending.controller.signal,
+        }), child, resolvedOptions);
+
+        childResults.push(result);
+        finishedByChildId.set(child.id, result);
+
+        if (isBlockingResult(result) && resolvedOptions.failurePolicy === 'stop') {
+          haltedByFailure = result;
+          abortActive(activeControllers);
+        }
+      } catch (error) {
+        const failed = failedRunFromError(child, error, resolvedOptions);
+        childResults.push(failed);
+        finishedByChildId.set(child.id, failed);
+        if (resolvedOptions.failurePolicy === 'stop') {
+          haltedByFailure = failed;
+          abortActive(activeControllers);
+        }
+      } finally {
+        activeControllers.delete(pending.controller);
+      }
+    };
+
+    await runWaveRespectingParallelizable(readyChildren, resolvedOptions.maxConcurrency, runChild);
+
+    if (resolvedOptions.failurePolicy === 'continue') {
+      cancelDependentsOfFailedChildren(plan.children, childResults, finishedByChildId, resolvedOptions);
+    }
+  }
+
+  if (haltedByFailure) {
+    cancelUnstartedDependents(plan.children, childResults, finishedByChildId, resolvedOptions);
+  }
+
+  const completedAtDate = resolvedOptions.now();
+  const completedAt = completedAtDate.toISOString();
+
+  return {
+    plan,
+    childResults,
+    decision: classifyDecision(plan.children, childResults),
+    startedAt,
+    completedAt,
+    durationMs: Math.max(0, completedAtDate.getTime() - startedAtDate.getTime()),
+    resumed: resolvedOptions.resume,
+  };
+}
+
+function resolveOptions(options: Partial<MasterExecutorOptions>): RuntimeOptions {
+  const merged = {
+    ...DEFAULT_MASTER_EXECUTOR_OPTIONS,
+    ...options,
+    now: options.now ?? (() => new Date()),
+  };
+
+  return {
+    ...merged,
+    maxConcurrency: Math.max(1, Math.floor(merged.maxConcurrency)),
+  };
+}
+
+function executionWaves(children: readonly ChildWorkflowPlan[]): ChildWorkflowPlan[][] {
+  const byWave = new Map<number, ChildWorkflowPlan[]>();
+  for (const child of children) {
+    const wave = byWave.get(child.wave) ?? [];
+    wave.push(child);
+    byWave.set(child.wave, wave);
+  }
+
+  return [...byWave.entries()]
+    .sort(([left], [right]) => left - right)
+    .map(([, wave]) => wave);
+}
+
+function dependenciesSatisfied(
+  child: ChildWorkflowPlan,
+  finishedByChildId: ReadonlyMap<string, ChildWorkflowRunResult>,
+): boolean {
+  return child.dependsOn.every((dependencyId) => {
+    const dependency = finishedByChildId.get(dependencyId);
+    if (!dependency) return false;
+    if (dependency.status !== 'passed' && dependency.status !== 'skipped') return false;
+    return dependency.evidence.gateResults.every((gateResult) => gateResult.passed);
+  });
+}
+
+async function maybeResumeSkip(
+  child: ChildWorkflowPlan,
+  options: RuntimeOptions,
+): Promise<ChildWorkflowRunResult | undefined> {
+  if (!options.resume || !options.signoffArtifactReader) {
+    return undefined;
+  }
+
+  const artifact = await options.signoffArtifactReader(child.signoffArtifactPath);
+  if (!artifact?.includes(child.signoffMarker)) {
+    return undefined;
+  }
+
+  const completedAtDate = options.now();
+  const requiredGates = child.gates.filter((gate) => gate.required);
+  options.logger?.({
+    kind: 'resume_skip',
+    childId: child.id,
+    message: `Skipping ${child.id}; signoff marker is already present.`,
+  });
+
+  return {
+    childId: child.id,
+    status: 'skipped',
+    attempt: 0,
+    startedAt: completedAtDate.toISOString(),
+    completedAt: completedAtDate.toISOString(),
+    durationMs: 0,
+    evidence: {
+      signoffPresent: true,
+      markerPresent: true,
+      changedFiles: child.targetFiles,
+      gateResults: requiredGates.map((gate) => ({ gateId: gate.id, kind: gate.kind, passed: true })),
+      rawNotes: 'Skipped during resume because the signoff artifact contains the required marker.',
+    },
+  };
+}
+
+function startChild(
+  child: ChildWorkflowPlan,
+  options: RuntimeOptions,
+  activeControllers?: Set<AbortController>,
+): PendingChild {
+  options.logger?.({
+    kind: 'child_start',
+    childId: child.id,
+    message: `Starting ${child.id}.`,
+  });
+
+  const pending = { child, controller: new AbortController() };
+  activeControllers?.add(pending.controller);
+  return pending;
+}
+
+function normalizeRunResult(
+  result: ChildWorkflowRunResult,
+  child: ChildWorkflowPlan,
+  options: RuntimeOptions,
+): ChildWorkflowRunResult {
+  const gateResults = mergeGateResults(child, result.evidence.gateResults);
+  const normalized: ChildWorkflowRunResult = {
+    ...result,
+    evidence: {
+      ...result.evidence,
+      gateResults,
+    },
+  };
+
+  options.logger?.({
+    kind: 'child_complete',
+    childId: child.id,
+    message: `${child.id} completed with status ${normalized.status}.`,
+  });
+
+  return normalized;
+}
+
+function mergeGateResults(
+  child: ChildWorkflowPlan,
+  gateResults: ChildWorkflowRunResult['evidence']['gateResults'],
+): ChildWorkflowRunResult['evidence']['gateResults'] {
+  const observed = new Map<string, ChildWorkflowRunResult['evidence']['gateResults'][number]>();
+  for (const gateResult of gateResults) {
+    observed.set(gateResult.gateId, gateResult);
+  }
+
+  return child.gates
+    .filter((gate) => gate.required)
+    .map((gate) => observed.get(gate.id) ?? {
+      gateId: gate.id,
+      kind: gate.kind,
+      passed: false,
+      detail: 'Required gate was not reported by the child runner.',
+    });
+}
+
+async function runWaveRespectingParallelizable(
+  items: readonly ChildWorkflowPlan[],
+  maxConcurrency: number,
+  worker: (item: ChildWorkflowPlan) => Promise<void>,
+): Promise<void> {
+  const inFlight = new Set<Promise<void>>();
+  const limit = Math.max(1, Math.floor(maxConcurrency));
+
+  for (const child of items) {
+    if (!child.parallelizable) {
+      while (inFlight.size > 0) {
+        await Promise.race(inFlight);
+      }
+      await worker(child);
+      continue;
+    }
+
+    while (inFlight.size >= limit) {
+      await Promise.race(inFlight);
+    }
+
+    let task!: Promise<void>;
+    task = (async () => {
+      try {
+        await worker(child);
+      } finally {
+        inFlight.delete(task);
+      }
+    })();
+    inFlight.add(task);
+  }
+
+  while (inFlight.size > 0) {
+    await Promise.race(inFlight);
+  }
+}
+
+function isBlockingResult(result: ChildWorkflowRunResult): boolean {
+  return result.status === 'failed' || result.status === 'blocked';
+}
+
+function abortActive(activeControllers: ReadonlySet<AbortController>): void {
+  for (const controller of activeControllers) {
+    controller.abort();
+  }
+}
+
+function failedRunFromError(
+  child: ChildWorkflowPlan,
+  error: unknown,
+  options: RuntimeOptions,
+): ChildWorkflowRunResult {
+  const completedAtDate = options.now();
+  const message = error instanceof Error ? error.message : String(error);
+
+  return {
+    childId: child.id,
+    status: 'failed',
+    attempt: 1,
+    startedAt: completedAtDate.toISOString(),
+    completedAt: completedAtDate.toISOString(),
+    durationMs: 0,
+    evidence: {
+      signoffPresent: false,
+      markerPresent: false,
+      changedFiles: [],
+      gateResults: child.gates
+        .filter((gate) => gate.required)
+        .map((gate) => ({ gateId: gate.id, kind: gate.kind, passed: false, detail: message })),
+    },
+    errorMessage: message,
+  };
+}
+
+function cancelDependentsOfFailedChildren(
+  children: readonly ChildWorkflowPlan[],
+  childResults: ChildWorkflowRunResult[],
+  finishedByChildId: Map<string, ChildWorkflowRunResult>,
+  options: RuntimeOptions,
+): void {
+  const failedIds = new Set(
+    childResults
+      .filter((result) => result.status === 'failed' || result.status === 'blocked' || result.status === 'cancelled')
+      .map((result) => result.childId),
+  );
+
+  for (const child of children) {
+    if (finishedByChildId.has(child.id)) {
+      continue;
+    }
+
+    if (child.dependsOn.some((dependencyId) => failedIds.has(dependencyId))) {
+      const cancelled = cancelledRun(child, options, 'An upstream dependency did not complete successfully.');
+      childResults.push(cancelled);
+      finishedByChildId.set(child.id, cancelled);
+      failedIds.add(child.id);
+    }
+  }
+}
+
+function cancelUnstartedDependents(
+  children: readonly ChildWorkflowPlan[],
+  childResults: ChildWorkflowRunResult[],
+  finishedByChildId: Map<string, ChildWorkflowRunResult>,
+  options: RuntimeOptions,
+): void {
+  for (const child of children) {
+    if (finishedByChildId.has(child.id)) {
+      continue;
+    }
+
+    const cancelled = cancelledRun(child, options, 'Execution stopped after an earlier child did not complete.');
+    childResults.push(cancelled);
+    finishedByChildId.set(child.id, cancelled);
+  }
+}
+
+function cancelledRun(child: ChildWorkflowPlan, options: RuntimeOptions, reason: string): ChildWorkflowRunResult {
+  const completedAtDate = options.now();
+  return {
+    childId: child.id,
+    status: 'cancelled',
+    attempt: 0,
+    startedAt: completedAtDate.toISOString(),
+    completedAt: completedAtDate.toISOString(),
+    durationMs: 0,
+    evidence: {
+      signoffPresent: false,
+      markerPresent: false,
+      changedFiles: [],
+      gateResults: child.gates
+        .filter((gate) => gate.required)
+        .map((gate) => ({ gateId: gate.id, kind: gate.kind, passed: false, detail: reason })),
+      rawNotes: reason,
+    },
+    errorMessage: reason,
+  };
+}
+
+function classifyDecision(
+  children: readonly ChildWorkflowPlan[],
+  childResults: readonly ChildWorkflowRunResult[],
+): MasterExecutorDecision {
+  const blocked = childResults.find((result) => result.status === 'blocked');
+  if (blocked) {
+    return {
+      kind: 'blocked',
+      childId: blocked.childId,
+      missing: extractMissingNames(blocked.blockedReason ?? blocked.errorMessage ?? ''),
+    };
+  }
+
+  for (const result of childResults) {
+    const child = children.find((candidate) => candidate.id === result.childId);
+    if (!child || result.status !== 'failed') {
+      continue;
+    }
+
+    const failedGateKinds = new Set(
+      result.evidence.gateResults
+        .filter((gateResult) => !gateResult.passed)
+        .map((gateResult) => gateResult.kind),
+    );
+    if (result.attempt >= child.retryPolicy.maxAttempts && failedGateKinds.size >= 2) {
+      return {
+        kind: 'split',
+        childId: result.childId,
+        reason: `Child ${result.childId} exhausted retry budget with multiple failed gate kinds.`,
+      };
+    }
+  }
+
+  for (const result of childResults) {
+    const child = children.find((candidate) => candidate.id === result.childId);
+    if (!child || result.status !== 'failed') {
+      continue;
+    }
+
+    const message = result.errorMessage ?? '';
+    if (
+      result.attempt < child.retryPolicy.maxAttempts &&
+      !result.evidence.signoffPresent &&
+      !hasEnvBlockHint(message)
+    ) {
+      return {
+        kind: 'retry',
+        childId: result.childId,
+        reason: result.errorMessage ?? `Child ${result.childId} failed before signoff was written.`,
+      };
+    }
+  }
+
+  for (const result of childResults) {
+    if (result.status === 'failed' && result.evidence.signoffPresent && !result.evidence.markerPresent) {
+      return {
+        kind: 'repair',
+        childId: result.childId,
+        reason: result.errorMessage ?? `Child ${result.childId} wrote signoff evidence without the required marker.`,
+      };
+    }
+  }
+
+  if (children.every((child) => childComplete(child, childResults))) {
+    return { kind: 'complete' };
+  }
+
+  const incomplete = childResults.find((result) => !childResultComplete(result));
+  return {
+    kind: 'escalate',
+    childId: incomplete?.childId,
+    reason: incomplete
+      ? `Child ${incomplete.childId} did not satisfy all required evidence gates.`
+      : 'No executable child results were recorded.',
+  };
+}
+
+function childComplete(child: ChildWorkflowPlan, childResults: readonly ChildWorkflowRunResult[]): boolean {
+  const result = childResults.find((candidate) => candidate.childId === child.id);
+  if (!result) {
+    return false;
+  }
+
+  return childResultComplete(result);
+}
+
+function childResultComplete(result: ChildWorkflowRunResult): boolean {
+  if (result.status !== 'passed' && result.status !== 'skipped') {
+    return false;
+  }
+
+  return result.evidence.gateResults.every((gateResult) => gateResult.passed);
+}
+
+function extractMissingNames(text: string): readonly string[] {
+  const missing = new Set<string>();
+  const envVarPattern = /MISSING_ENV_VAR:\s*([A-Z_][A-Z0-9_]*)/g;
+  let match: RegExpExecArray | null;
+  while ((match = envVarPattern.exec(text)) !== null) {
+    missing.add(match[1]);
+  }
+
+  return [...missing];
+}
+
+function hasEnvBlockHint(text: string): boolean {
+  return /MISSING_ENV_VAR:\s*[A-Z_][A-Z0-9_]*/.test(text);
+}

--- a/src/product/orchestration/planner.ts
+++ b/src/product/orchestration/planner.ts
@@ -1,0 +1,300 @@
+import type {
+  ChildWorkflowGate,
+  ChildWorkflowPlan,
+  MasterExecutionPlan,
+  PlannerDesiredSlice,
+  PlannerInput,
+} from './types.js';
+
+const DEFAULT_WAVE_PREFIX = 'wave13-master-executor';
+const DEFAULT_VALIDATION_COMMAND = 'npm run typecheck';
+const DEFAULT_RETRY_POLICY = { maxAttempts: 2, backoffMs: 1000 } as const;
+const DEFAULT_TIMEOUT_MS = 30 * 60 * 1000;
+
+interface PlannedSlice {
+  readonly input: PlannerDesiredSlice;
+  readonly index: number;
+  readonly id: string;
+  readonly targetFiles: readonly string[];
+  readonly dependsOn: readonly string[];
+  wave: number;
+  ambiguousReasons: string[];
+}
+
+export function planMasterExecution(input: PlannerInput): MasterExecutionPlan {
+  const wavePrefix = input.wavePrefix ?? DEFAULT_WAVE_PREFIX;
+  const desiredSlices = normalizeDesiredSlices(input);
+  const reservedIds = new Map<string, number>();
+  const slices: PlannedSlice[] = desiredSlices.map((slice, index) => {
+    const id = uniqueSlug(slice.id ?? slice.title, reservedIds);
+    return {
+      input: slice,
+      index,
+      id,
+      targetFiles: [...(slice.targetFiles ?? [])],
+      dependsOn: [...(slice.dependsOn ?? [])],
+      wave: 0,
+      ambiguousReasons: [],
+    };
+  });
+
+  const planAmbiguities: string[] = [];
+  if (slices.length === 0) {
+    planAmbiguities.push('No desired slices or target files were provided for decomposition.');
+  }
+  if (input.constraints?.maxChildren !== undefined && slices.length > input.constraints.maxChildren) {
+    planAmbiguities.push(
+      `Plan contains ${slices.length} children, exceeding maxChildren ${input.constraints.maxChildren}.`,
+    );
+  }
+
+  markSliceAmbiguities(slices, input.constraints?.forbiddenPaths ?? []);
+  assignDependencyWaves(slices);
+
+  const orderedSlices = [...slices].sort(
+    (left, right) => left.wave - right.wave || left.index - right.index,
+  );
+  const sharedFileLaterIds = findLaterSharedFileIds(orderedSlices);
+  const children = orderedSlices.map((slice, index) =>
+    buildChildPlan({
+      slice,
+      planIndex: index + 1,
+      wavePrefix,
+      requiredGateMarkers: input.constraints?.requiredGateMarkers ?? [],
+      forceSequential: sharedFileLaterIds.has(slice.id),
+    }),
+  );
+
+  return {
+    title: input.title,
+    description: input.description,
+    wavePrefix,
+    workflowSlug: input.workflowSlug,
+    targetFiles: [...(input.targetFiles ?? [])],
+    children,
+    ...(planAmbiguities.length > 0 ? { ambiguous: { reason: planAmbiguities.join(' ') } } : {}),
+  };
+}
+
+function normalizeDesiredSlices(input: PlannerInput): readonly PlannerDesiredSlice[] {
+  if (input.desiredSlices && input.desiredSlices.length > 0) {
+    return input.desiredSlices;
+  }
+
+  if (input.targetFiles && input.targetFiles.length > 0) {
+    return [
+      {
+        title: input.title,
+        summary: input.description,
+        targetFiles: input.targetFiles,
+      },
+    ];
+  }
+
+  return [];
+}
+
+function markSliceAmbiguities(slices: readonly PlannedSlice[], forbiddenPaths: readonly string[]): void {
+  const knownIds = new Set(slices.map((slice) => slice.id));
+  const forbidden = new Set(forbiddenPaths);
+
+  for (const slice of slices) {
+    if (slice.targetFiles.length === 0 && slugify(slice.input.title).length === 0) {
+      slice.ambiguousReasons.push('Slice has no target files and no inferable slug.');
+    }
+
+    for (const dependencyId of slice.dependsOn) {
+      if (!knownIds.has(dependencyId)) {
+        slice.ambiguousReasons.push(`Unknown dependency: ${dependencyId}.`);
+      }
+    }
+
+    const forbiddenTarget = slice.targetFiles.find((targetFile) => forbidden.has(targetFile));
+    if (forbiddenTarget) {
+      slice.ambiguousReasons.push(`Target file is forbidden: ${forbiddenTarget}.`);
+    }
+  }
+}
+
+function assignDependencyWaves(slices: readonly PlannedSlice[]): void {
+  const byId = new Map(slices.map((slice) => [slice.id, slice]));
+  const visiting = new Set<string>();
+  const visited = new Set<string>();
+
+  const resolveWave = (slice: PlannedSlice): number => {
+    if (visited.has(slice.id)) {
+      return slice.wave;
+    }
+    if (visiting.has(slice.id)) {
+      slice.ambiguousReasons.push('Dependency cycle detected.');
+      return slice.wave;
+    }
+
+    visiting.add(slice.id);
+    const dependencyWaves = slice.dependsOn
+      .map((dependencyId) => byId.get(dependencyId))
+      .filter((dependency): dependency is PlannedSlice => dependency !== undefined)
+      .map((dependency) => resolveWave(dependency));
+    visiting.delete(slice.id);
+    visited.add(slice.id);
+
+    slice.wave = dependencyWaves.length === 0 ? 0 : Math.max(...dependencyWaves) + 1;
+    return slice.wave;
+  };
+
+  for (const slice of slices) {
+    resolveWave(slice);
+  }
+}
+
+function findLaterSharedFileIds(orderedSlices: readonly PlannedSlice[]): Set<string> {
+  const seenByWave = new Map<number, Set<string>>();
+  const laterSharedIds = new Set<string>();
+
+  for (const slice of orderedSlices) {
+    const seenFiles = seenByWave.get(slice.wave) ?? new Set<string>();
+    if (!seenByWave.has(slice.wave)) {
+      seenByWave.set(slice.wave, seenFiles);
+    }
+
+    if (slice.targetFiles.some((targetFile) => seenFiles.has(targetFile))) {
+      laterSharedIds.add(slice.id);
+    }
+    for (const targetFile of slice.targetFiles) {
+      seenFiles.add(targetFile);
+    }
+  }
+
+  return laterSharedIds;
+}
+
+function buildChildPlan(input: {
+  slice: PlannedSlice;
+  planIndex: number;
+  wavePrefix: string;
+  requiredGateMarkers: readonly string[];
+  forceSequential: boolean;
+}): ChildWorkflowPlan {
+  const signoffArtifactPath = `.workflow-artifacts/${input.wavePrefix}/${input.slice.id}/signoff.md`;
+  const signoffMarker = markerForId(input.slice.id);
+  const validationCommands = [DEFAULT_VALIDATION_COMMAND];
+  const gates = buildDefaultGates({
+    signoffArtifactPath,
+    signoffMarker,
+    targetFiles: input.slice.targetFiles,
+    validationCommands,
+    requiredGateMarkers: input.requiredGateMarkers,
+  });
+
+  return {
+    id: input.slice.id,
+    title: input.slice.input.title,
+    ...(input.slice.input.summary ? { summary: input.slice.input.summary } : {}),
+    workflowFilePath: `workflows/${input.wavePrefix}/${String(input.planIndex).padStart(2, '0')}-${input.slice.id}.ts`,
+    targetFiles: input.slice.targetFiles,
+    allowedDirtyScope: input.slice.targetFiles,
+    dependsOn: input.slice.dependsOn,
+    parallelizable: input.slice.input.parallelizable === false ? false : !input.forceSequential,
+    wave: input.slice.wave,
+    gates,
+    signoffArtifactPath,
+    signoffMarker,
+    validationCommands,
+    retryPolicy: { ...DEFAULT_RETRY_POLICY },
+    timeoutMs: DEFAULT_TIMEOUT_MS,
+    escalationRules: [
+      'Retry once for missing signoff evidence before escalating.',
+      'Block immediately on missing environment or credential evidence.',
+    ],
+    ...(input.slice.ambiguousReasons.length > 0
+      ? { ambiguous: { reason: input.slice.ambiguousReasons.join(' ') } }
+      : {}),
+  };
+}
+
+function buildDefaultGates(input: {
+  signoffArtifactPath: string;
+  signoffMarker: string;
+  targetFiles: readonly string[];
+  validationCommands: readonly string[];
+  requiredGateMarkers: readonly string[];
+}): readonly ChildWorkflowGate[] {
+  const gates: ChildWorkflowGate[] = [
+    {
+      id: `signoff_artifact:${input.signoffArtifactPath}`,
+      kind: 'signoff_artifact',
+      description: 'Child workflow writes its required signoff artifact.',
+      required: true,
+      artifactPath: input.signoffArtifactPath,
+    },
+    {
+      id: `marker_string:${input.signoffMarker}`,
+      kind: 'marker_string',
+      description: 'Child workflow signoff contains the required marker.',
+      required: true,
+      marker: input.signoffMarker,
+    },
+    ...input.requiredGateMarkers.map(
+      (marker): ChildWorkflowGate => ({
+        id: `marker_string:${marker}`,
+        kind: 'marker_string',
+        description: `Child workflow signoff contains required marker ${marker}.`,
+        required: true,
+        marker,
+      }),
+    ),
+    {
+      id: `changed_files:${[...input.targetFiles].join('|') || 'unscoped'}`,
+      kind: 'changed_files',
+      description: 'Child workflow changes stay within the declared target file scope.',
+      required: true,
+      fileScope: input.targetFiles,
+    },
+    ...input.validationCommands.map(
+      (command): ChildWorkflowGate => ({
+        id: `test_command:${command}`,
+        kind: 'test_command',
+        description: `Child workflow passes validation command: ${command}.`,
+        required: true,
+        command,
+      }),
+    ),
+  ];
+
+  if (input.targetFiles.some((targetFile) => /^workflows\/.+\.ts$/.test(targetFile))) {
+    const dryrunCommand = 'npm run typecheck';
+    gates.push({
+      id: `dryrun_command:${dryrunCommand}`,
+      kind: 'dryrun_command',
+      description: 'Generated workflow passes a dry-run validation.',
+      required: true,
+      command: dryrunCommand,
+    });
+  }
+
+  return gates;
+}
+
+function uniqueSlug(value: string, reservedIds: Map<string, number>): string {
+  const baseSlug = slugify(value) || 'child-workflow';
+  const seen = reservedIds.get(baseSlug) ?? 0;
+  reservedIds.set(baseSlug, seen + 1);
+
+  if (seen === 0) {
+    return baseSlug;
+  }
+
+  return `${baseSlug}-${seen + 1}`;
+}
+
+function slugify(value: string): string {
+  return value
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '');
+}
+
+function markerForId(id: string): string {
+  return `RICKY_${id.toUpperCase().replace(/[^A-Z0-9]+/g, '_')}_IMPLEMENTED`;
+}

--- a/src/product/orchestration/planner.ts
+++ b/src/product/orchestration/planner.ts
@@ -64,6 +64,11 @@ export function planMasterExecution(input: PlannerInput): MasterExecutionPlan {
       forceSequential: sharedFileLaterIds.has(slice.id),
     }),
   );
+  planAmbiguities.push(
+    ...children
+      .map((child) => child.ambiguous?.reason)
+      .filter((reason): reason is string => Boolean(reason)),
+  );
 
   return {
     title: input.title,
@@ -192,7 +197,7 @@ function buildChildPlan(input: {
     ...(input.slice.input.summary ? { summary: input.slice.input.summary } : {}),
     workflowFilePath: `workflows/${input.wavePrefix}/${String(input.planIndex).padStart(2, '0')}-${input.slice.id}.ts`,
     targetFiles: input.slice.targetFiles,
-    allowedDirtyScope: input.slice.targetFiles,
+    allowedDirtyScope: [...input.slice.targetFiles, signoffArtifactPath],
     dependsOn: input.slice.dependsOn,
     parallelizable: input.slice.input.parallelizable === false ? false : !input.forceSequential,
     wave: input.slice.wave,

--- a/src/product/orchestration/types.ts
+++ b/src/product/orchestration/types.ts
@@ -1,0 +1,153 @@
+export type MasterChildStatus =
+  | 'pending'
+  | 'running'
+  | 'passed'
+  | 'failed'
+  | 'skipped'
+  | 'blocked'
+  | 'cancelled';
+
+export type MasterExecutorClassification =
+  | 'complete'
+  | 'retry'
+  | 'repair'
+  | 'split'
+  | 'blocked'
+  | 'escalate';
+
+export type ChildWorkflowGateKind =
+  | 'signoff_artifact'
+  | 'marker_string'
+  | 'changed_files'
+  | 'test_command'
+  | 'dryrun_command';
+
+export interface PlannerInput {
+  title: string;
+  description: string;
+  desiredSlices?: ReadonlyArray<PlannerDesiredSlice>;
+  constraints?: PlannerConstraints;
+  targetFiles?: readonly string[];
+  wavePrefix?: string;
+  workflowSlug?: string;
+}
+
+export interface PlannerDesiredSlice {
+  id?: string;
+  title: string;
+  summary?: string;
+  targetFiles?: readonly string[];
+  dependsOn?: readonly string[];
+  parallelizable?: boolean;
+}
+
+export interface PlannerConstraints {
+  maxChildren?: number;
+  requiredGateMarkers?: readonly string[];
+  forbiddenPaths?: readonly string[];
+}
+
+export interface MasterExecutionPlan {
+  title: string;
+  description: string;
+  wavePrefix: string;
+  workflowSlug?: string;
+  targetFiles: readonly string[];
+  children: readonly ChildWorkflowPlan[];
+  ambiguous?: { reason: string };
+}
+
+export interface ChildWorkflowGate {
+  id: string;
+  kind: ChildWorkflowGateKind;
+  description: string;
+  required: boolean;
+  artifactPath?: string;
+  marker?: string;
+  fileScope?: readonly string[];
+  command?: string;
+}
+
+export interface ChildWorkflowPlan {
+  id: string;
+  title: string;
+  summary?: string;
+  workflowFilePath: string;
+  targetFiles: readonly string[];
+  allowedDirtyScope: readonly string[];
+  dependsOn: readonly string[];
+  parallelizable: boolean;
+  wave: number;
+  gates: readonly ChildWorkflowGate[];
+  signoffArtifactPath: string;
+  signoffMarker: string;
+  validationCommands: readonly string[];
+  retryPolicy: {
+    maxAttempts: number;
+    backoffMs: number;
+  };
+  timeoutMs: number;
+  escalationRules: readonly string[];
+  ambiguous?: { reason: string };
+}
+
+export type ChildRunner = (
+  child: ChildWorkflowPlan,
+  ctx: {
+    attempt: number;
+    resume: boolean;
+    abortSignal: AbortSignal;
+  },
+) => Promise<ChildWorkflowRunResult>;
+
+export interface ChildWorkflowRunResult {
+  childId: string;
+  status: MasterChildStatus;
+  attempt: number;
+  startedAt: string;
+  completedAt: string;
+  durationMs: number;
+  evidence: {
+    signoffPresent: boolean;
+    markerPresent: boolean;
+    changedFiles: readonly string[];
+    gateResults: readonly ChildWorkflowGateResult[];
+    rawNotes?: string;
+  };
+  blockedReason?: string;
+  errorMessage?: string;
+}
+
+export interface ChildWorkflowGateResult {
+  gateId: string;
+  kind: ChildWorkflowGate['kind'];
+  passed: boolean;
+  detail?: string;
+}
+
+export type MasterExecutorDecision =
+  | { kind: 'complete' }
+  | { kind: 'retry'; childId: string; reason: string }
+  | { kind: 'repair'; childId: string; reason: string }
+  | { kind: 'split'; childId: string; reason: string }
+  | { kind: 'blocked'; childId: string; missing: readonly string[] }
+  | { kind: 'escalate'; childId?: string; reason: string };
+
+export interface MasterExecutionResult {
+  plan: MasterExecutionPlan;
+  childResults: ReadonlyArray<ChildWorkflowRunResult>;
+  decision: MasterExecutorDecision;
+  startedAt: string;
+  completedAt: string;
+  durationMs: number;
+  resumed: boolean;
+}
+
+export interface MasterExecutorOptions {
+  maxConcurrency: number;
+  resume: boolean;
+  failurePolicy: 'stop' | 'continue';
+  signoffArtifactReader?: (path: string) => Promise<string | null>;
+  now?: () => Date;
+  logger?: (event: { kind: string; childId?: string; message: string }) => void;
+}

--- a/src/surfaces/cli/commands/cli-main.ts
+++ b/src/surfaces/cli/commands/cli-main.ts
@@ -1861,10 +1861,12 @@ function renderLocalHuman(localResult: NonNullable<InteractiveCliResult['localRe
     if (localResult.execution?.status === 'success') {
       lines.push(`Generation: ok${artifactPath ? ` — ${artifactPath}` : ''}`);
       if (workflowName) lines.push(`Workflow name: ${workflowName}`);
+      lines.push(...masterExecutionSummaryLines(localResult));
       lines.push(`Execution: success${localResult.execution.execution.run_id ? ` — run ${localResult.execution.execution.run_id}` : ''}`);
     } else if (localResult.generation) {
       lines.push(`Generation: ok${artifactPath ? ` — ${artifactPath}` : ''}`);
       if (workflowName) lines.push(`Workflow name: ${workflowName}`);
+      lines.push(...masterExecutionSummaryLines(localResult));
       if (localResult.generation.next) {
         lines.push(`Run: ${localResult.generation.next.run_command}`);
         lines.push(`Background: ${localResult.generation.next.run_command} --background`);
@@ -1879,6 +1881,7 @@ function renderLocalHuman(localResult: NonNullable<InteractiveCliResult['localRe
     if (localResult.execution) {
       lines.push(`Generation: ok${artifactPath ? ` — ${artifactPath}` : ''}`);
       if (workflowName) lines.push(`Workflow name: ${workflowName}`);
+      lines.push(...masterExecutionSummaryLines(localResult));
       lines.push(executionFailureSummary(localResult));
       const resume = resumeCommandFor(localResult);
       if (resume) lines.push(`Resume: ${resume}`);
@@ -1949,6 +1952,16 @@ function renderLocalHuman(localResult: NonNullable<InteractiveCliResult['localRe
     }
   }
   return lines;
+}
+
+function masterExecutionSummaryLines(localResult: NonNullable<InteractiveCliResult['localResult']>): string[] {
+  const masterExecution = localResult.generation?.decisions?.master_execution;
+  if (!masterExecution || typeof masterExecution !== 'object') return [];
+  const record = masterExecution as Record<string, unknown>;
+  const childCount = typeof record.child_count === 'number' ? record.child_count : undefined;
+  const waveCount = typeof record.wave_count === 'number' ? record.wave_count : undefined;
+  if (childCount === undefined) return [];
+  return [`Master plan: ${childCount} child workflows${waveCount !== undefined ? ` across ${waveCount} waves` : ''}`];
 }
 
 function createLocalProgressReporter(

--- a/workflows/meta/spec/ricky-master-executor-workflow-program.md
+++ b/workflows/meta/spec/ricky-master-executor-workflow-program.md
@@ -1,0 +1,176 @@
+# Ricky Master Executor Workflow Program
+
+## Objective
+
+Ricky should move from large monolithic implementation workflows toward a master executor model that decomposes a user or product spec into smaller, bounded 80-to-100 workflows, runs independent work in parallel, and advances only through explicit evidence and merge gates.
+
+The goal is not just to generate more workflow files. The goal is for Ricky to decide how to divide a spec into reliable execution slices, produce or select the right child workflows, run them in dependency order, inspect their evidence, and either advance, repair, split, block, or ask for human input.
+
+## Product Need
+
+The current workflow style can complete useful work, but large workflows become hard to resume, hard to review, and sensitive to agent drift. The successful pattern from adjacent AgentWorkforce projects is a smaller workflow model: each child workflow owns a narrow deliverable and proves it with deterministic validation, while a master executor owns ordering, parallelism, status, and final integration.
+
+Ricky should make that pattern first-class. Given a spec such as "implement nested runner, runtime policy, telemetry, evals, and insights", Ricky should produce an execution plan that identifies independent child workflows, dependency barriers, merge or PR gates, validation requirements, and final signoff criteria.
+
+## Source Of Truth
+
+When implementing this program, use this order:
+
+1. `docs/workflows/WORKFLOW_STANDARDS.md`
+2. `AGENTS.md`
+3. This spec
+4. `workflows/shared/WORKFLOW_AUTHORING_RULES.md`
+5. `.agents/skills/writing-agent-relay-workflows/SKILL.md`
+6. `.agents/skills/relay-80-100-workflow/SKILL.md`
+7. Local code reality
+
+## Target Architecture
+
+The master executor has four layers.
+
+### Spec Decomposition
+
+The planner accepts a normalized spec and produces an execution plan. The plan includes child workflow candidates, file scopes, dependency edges, parallelization groups, validation requirements, merge gates, and known non-goals.
+
+Child workflows should be created around bounded deliverables, not agent count. A good child workflow owns one slice such as runtime policy, telemetry ingestion, eval fixtures, insight summarization, CLI proof, or a narrow integration path. A poor child workflow owns an entire product milestone with ambiguous file ownership.
+
+### Child Workflow Contract
+
+Each child workflow must declare:
+
+- stable id and human-readable title
+- target workflow file path
+- target files and allowed dirty scope
+- dependency ids
+- whether it can run in parallel with siblings
+- validation commands
+- required signoff artifact and marker
+- optional PR or merge gate
+- retry policy
+- timeout
+- escalation rules
+
+### Execution Coordinator
+
+The master executor runs child workflows by dependency wave. It may run independent children concurrently up to a configured limit. A child is considered complete only when its run exits successfully and its evidence gate passes.
+
+Evidence gates should verify concrete artifacts: signoff files, marker strings, changed file scopes, test output, dry-run output, PR state, or merge state. The master executor must not advance based only on agent text.
+
+### Failure And Replanning
+
+When a child fails, the master executor should classify the outcome into one of these decisions:
+
+- retry the child as-is
+- repair the child workflow and retry
+- split the child into smaller workflows
+- block on missing environment or credentials
+- escalate to the user with evidence
+
+The master executor should preserve partial evidence and should not hide environmental blockers.
+
+## First Implementation Slice
+
+The first workflow should implement a deterministic, unit-tested local planning and execution model. It does not need to run live remote PRs or perform real GitHub merges.
+
+### Required Files
+
+The first implementation slice should create:
+
+- `src/product/orchestration/types.ts`
+- `src/product/orchestration/planner.ts`
+- `src/product/orchestration/master-executor.ts`
+- `src/product/orchestration/index.ts`
+- `src/product/orchestration/master-executor.test.ts`
+
+It may update:
+
+- `src/product/index.ts`
+
+### Required Types
+
+The implementation should expose:
+
+- `MasterExecutionPlan`
+- `ChildWorkflowPlan`
+- `ChildWorkflowGate`
+- `ChildWorkflowRunResult`
+- `MasterExecutionResult`
+- `MasterExecutorOptions`
+- `MasterExecutorDecision`
+
+The types should be plain TypeScript interfaces and discriminated unions. They should not require a live Agent Relay runtime to test.
+
+### Planner Requirements
+
+The planner should:
+
+- accept a spec title, description, optional desired slices, optional constraints, and optional target files
+- produce stable child workflow ids and paths
+- assign dependency waves
+- mark independent slices as parallelizable
+- attach default 80-to-100 gates to every child
+- reject or mark ambiguous specs that cannot be decomposed safely
+
+### Executor Requirements
+
+The executor should:
+
+- accept a `MasterExecutionPlan`
+- accept an injected child runner function
+- execute child workflows by dependency wave
+- enforce `maxConcurrency`
+- skip children whose signoff gate is already satisfied when resume mode is enabled
+- stop or continue according to failure policy
+- return structured evidence for every child
+- classify next action as `complete`, `retry`, `repair`, `split`, `blocked`, or `escalate`
+
+### Test Requirements
+
+The implementation must include deterministic tests for:
+
+- spec decomposition into multiple child workflows
+- dependency wave ordering
+- bounded concurrency
+- signoff-gated resume skip
+- failed child classification
+- blocked child classification for missing environment
+- final result only marked complete when all required gates pass
+
+Tests must use injected fakes, not a live `agent-relay` invocation.
+
+## Workflow Authoring Requirements
+
+The implementation workflow must:
+
+- live under `workflows/wave13-master-executor/`
+- use a numeric prefix and a concrete slug
+- use a dedicated `wf-ricky-*` channel
+- read this spec and Ricky workflow standards deterministically
+- include a review stage with artifacts under `.workflow-artifacts/`
+- use the 80-to-100 soft-gate, fix, hard-gate loop
+- include scoped change detection for the intended files
+- keep commit and push outside the workflow unless a later spec explicitly owns those boundaries
+
+## Acceptance Criteria
+
+The first slice is complete when:
+
+- all required source and test files exist
+- product exports are available from `src/product/orchestration/index.ts`
+- `npx vitest run src/product/orchestration/master-executor.test.ts` passes
+- `npm run typecheck` passes
+- a final signoff artifact exists under `.workflow-artifacts/wave13-master-executor/implement-master-executor/`
+- the signoff artifact contains `RICKY_MASTER_EXECUTOR_IMPLEMENTED`
+
+## Non-Goals
+
+This first slice should not:
+
+- create or merge GitHub PRs
+- run hosted cloud workflows
+- mutate existing unrelated generated workflows
+- replace the local coordinator
+- require live provider credentials
+- implement a web UI
+
+Those are later child workflows that the master executor model should eventually be able to plan and run.

--- a/workflows/wave13-master-executor/01-implement-master-executor-planner.ts
+++ b/workflows/wave13-master-executor/01-implement-master-executor-planner.ts
@@ -1,0 +1,502 @@
+import { existsSync, readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+import { workflow } from '@agent-relay/sdk/workflows';
+
+const artifactDir = '.workflow-artifacts/wave13-master-executor/implement-master-executor';
+const workflowFile = 'workflows/wave13-master-executor/01-implement-master-executor-planner.ts';
+const specFile = 'workflows/meta/spec/ricky-master-executor-workflow-program.md';
+const targetFiles = [
+  'src/product/orchestration/types.ts',
+  'src/product/orchestration/planner.ts',
+  'src/product/orchestration/master-executor.ts',
+  'src/product/orchestration/index.ts',
+  'src/product/orchestration/master-executor.test.ts',
+  'src/product/index.ts',
+] as const;
+
+function loadEnvFile(path: string): void {
+  const fullPath = resolve(process.cwd(), path);
+  if (!existsSync(fullPath)) return;
+
+  for (const rawLine of readFileSync(fullPath, 'utf8').split(/\r?\n/)) {
+    const line = rawLine.trim();
+    if (!line || line.startsWith('#')) continue;
+    const match = /^export\s+([A-Za-z_][A-Za-z0-9_]*)=(.*)$/.exec(line) ??
+      /^([A-Za-z_][A-Za-z0-9_]*)=(.*)$/.exec(line);
+    if (!match) continue;
+    const [, key, rawValue] = match;
+    if (process.env[key] !== undefined) continue;
+    const value = rawValue.replace(/^(['"])(.*)\1$/, '$2');
+    process.env[key] = value;
+  }
+}
+
+function loadRepoEnv(): void {
+  loadEnvFile('.env.local');
+  loadEnvFile('.env');
+}
+
+async function main() {
+  loadRepoEnv();
+
+  const result = await workflow('ricky-wave13-implement-master-executor-planner')
+    .description([
+      'Implement the first Ricky master executor slice: a spec decomposition planner, child workflow execution model, evidence gates, and deterministic unit tests.',
+      'This workflow follows the 80-to-100 pattern: write tests, implement bounded files, verify scoped changes, review, fix captured failures, rerun hard gates, run regression checks, and sign off with evidence.',
+      'The selected pattern is dag because tests, planner, executor, and type contracts can move through explicit dependencies and converge through deterministic gates.',
+    ].join(' '))
+    .pattern('dag')
+    .channel('wf-ricky-wave13-master-executor')
+    .maxConcurrency(4)
+    .timeout(7_200_000)
+    .onError('retry', { maxRetries: 2, retryDelayMs: 10_000 })
+
+    .agent('lead-claude', {
+      cli: 'claude',
+      role: 'Owns the master executor architecture, decomposition rules, file scope discipline, and final implementation plan.',
+      retries: 1,
+    })
+    .agent('tests-codex', {
+      cli: 'codex',
+      role: 'Writes deterministic unit tests for planner and executor behavior using injected fakes only.',
+      retries: 2,
+    })
+    .agent('planner-codex', {
+      cli: 'codex',
+      role: 'Implements master execution planning, child workflow wave assignment, dependency ordering, and default gate construction.',
+      retries: 2,
+    })
+    .agent('executor-codex', {
+      cli: 'codex',
+      role: 'Implements the injected child workflow runner coordinator, bounded concurrency, resume skips, gate evaluation, and failure classification.',
+      retries: 2,
+    })
+    .agent('reviewer-claude', {
+      cli: 'claude',
+      preset: 'reviewer',
+      role: 'Reviews product architecture, scope fit, and whether the implementation matches the master executor spec.',
+      retries: 1,
+    })
+    .agent('reviewer-codex', {
+      cli: 'codex',
+      preset: 'reviewer',
+      role: 'Reviews TypeScript correctness, deterministic test quality, injected seams, and 80-to-100 evidence quality.',
+      retries: 1,
+    })
+    .agent('validator-claude', {
+      cli: 'claude',
+      preset: 'worker',
+      role: 'Runs the 80-to-100 fix loop from captured failures and review artifacts, applying bounded repairs only to declared target files.',
+      retries: 2,
+    })
+
+    .step('preflight', {
+      type: 'deterministic',
+      command: [
+        'set -e',
+        `DIR=${artifactDir}`,
+        'mkdir -p "$DIR"',
+        'test -f package.json',
+        `test -f ${specFile}`,
+        'test -f docs/workflows/WORKFLOW_STANDARDS.md',
+        'test -f workflows/shared/WORKFLOW_AUTHORING_RULES.md',
+        'test -f .agents/skills/writing-agent-relay-workflows/SKILL.md',
+        'test -f .agents/skills/relay-80-100-workflow/SKILL.md',
+        'node --version > "$DIR/node-version.txt"',
+        'npm --version > "$DIR/npm-version.txt"',
+        'git rev-parse --show-toplevel > "$DIR/repo-root.txt"',
+        'git status --short > "$DIR/preflight-git-status.txt"',
+        'if ! git diff --cached --quiet; then echo "ERROR: staging area is dirty"; git diff --cached --stat; exit 1; fi',
+        'for cli in claude codex; do if ! command -v "$cli" >/dev/null 2>&1; then echo "MISSING_ENV_VAR: ${cli}_CLI_AVAILABLE"; exit 1; fi; done',
+        'echo RICKY_MASTER_EXECUTOR_PREFLIGHT_OK',
+      ].join(' && '),
+      captureOutput: true,
+      failOnError: true,
+    })
+    .step('read-source-contracts', {
+      type: 'deterministic',
+      dependsOn: ['preflight'],
+      command: [
+        `cat ${specFile}`,
+        'printf "\\n\\n--- WORKFLOW STANDARDS ---\\n\\n"',
+        'cat docs/workflows/WORKFLOW_STANDARDS.md',
+        'printf "\\n\\n--- AUTHORING RULES ---\\n\\n"',
+        'cat workflows/shared/WORKFLOW_AUTHORING_RULES.md',
+        'printf "\\n\\n--- WRITING SKILL ---\\n\\n"',
+        'sed -n "1,420p" .agents/skills/writing-agent-relay-workflows/SKILL.md',
+        'printf "\\n\\n--- 80 TO 100 SKILL ---\\n\\n"',
+        'sed -n "1,420p" .agents/skills/relay-80-100-workflow/SKILL.md',
+      ].join(' && '),
+      captureOutput: true,
+      failOnError: true,
+    })
+    .step('snapshot-current-code', {
+      type: 'deterministic',
+      dependsOn: ['preflight'],
+      command: [
+        'printf "%s\\n" "--- src/runtime/types.ts ---"',
+        'sed -n "1,260p" src/runtime/types.ts',
+        'printf "\\n%s\\n" "--- src/runtime/local-coordinator.ts ---"',
+        'sed -n "1,320p" src/runtime/local-coordinator.ts',
+        'printf "\\n%s\\n" "--- src/product/generation/types.ts ---"',
+        'sed -n "1,260p" src/product/generation/types.ts',
+        'printf "\\n%s\\n" "--- src/product/index.ts ---"',
+        'sed -n "1,220p" src/product/index.ts',
+      ].join(' && '),
+      captureOutput: true,
+      failOnError: true,
+    })
+    .step('write-acceptance-matrix', {
+      type: 'deterministic',
+      dependsOn: ['read-source-contracts'],
+      command: [
+        'set -e',
+        `DIR=${artifactDir}`,
+        "cat > \"$DIR/acceptance-matrix.md\" <<'EOF'",
+        '# Ricky master executor acceptance matrix',
+        '',
+        'The first implementation slice is complete only when these deterministic behaviors are present and tested.',
+        '',
+        '## Planner behavior',
+        '- Accepts a spec title, description, optional slices, constraints, and target files.',
+        '- Produces stable child workflow ids and wave-scoped workflow paths.',
+        '- Assigns dependency waves from child dependencies.',
+        '- Marks independent children as parallelizable.',
+        '- Adds default 80-to-100 gates to every child.',
+        '- Marks ambiguous specs instead of pretending decomposition is safe.',
+        '',
+        '## Executor behavior',
+        '- Accepts an injected child runner function.',
+        '- Executes children by dependency wave.',
+        '- Enforces maxConcurrency.',
+        '- Skips already-signed-off children in resume mode.',
+        '- Records structured evidence for every child.',
+        '- Classifies next action as complete, retry, repair, split, blocked, or escalate.',
+        '',
+        '## Required test cases',
+        '- Spec decomposition into multiple child workflows.',
+        '- Dependency wave ordering.',
+        '- Bounded concurrency.',
+        '- Signoff-gated resume skip.',
+        '- Failed child classification.',
+        '- Missing environment classification as blocked.',
+        '- Final result only complete when all required gates pass.',
+        '',
+        'RICKY_MASTER_EXECUTOR_ACCEPTANCE_MATRIX_READY',
+        'EOF',
+      ].join('\n'),
+      captureOutput: true,
+      failOnError: true,
+    })
+    .step('lead-plan', {
+      agent: 'lead-claude',
+      dependsOn: ['read-source-contracts', 'snapshot-current-code', 'write-acceptance-matrix'],
+      task: `Create the implementation plan for the Ricky master executor first slice.
+
+Inputs:
+- Source contracts: {{steps.read-source-contracts.output}}
+- Current code snapshot: {{steps.snapshot-current-code.output}}
+- Acceptance matrix: ${artifactDir}/acceptance-matrix.md
+
+Write ${artifactDir}/lead-plan.md ending with RICKY_MASTER_EXECUTOR_LEAD_PLAN_READY.
+The plan must assign exact file ownership, define non-goals, specify exported API names, and preserve the existing LocalCoordinator as the low-level run seam.
+Do not implement in this step.`,
+      verification: { type: 'file_exists', value: `${artifactDir}/lead-plan.md` },
+    })
+    .step('lead-plan-gate', {
+      type: 'deterministic',
+      dependsOn: ['lead-plan'],
+      command: [
+        'set -e',
+        `grep -F RICKY_MASTER_EXECUTOR_LEAD_PLAN_READY ${artifactDir}/lead-plan.md`,
+        `grep -E "planner|executor|types|test|LocalCoordinator|80-to-100" ${artifactDir}/lead-plan.md`,
+        'echo RICKY_MASTER_EXECUTOR_PLAN_VERIFIED',
+      ].join(' && '),
+      captureOutput: true,
+      failOnError: true,
+    })
+
+    .step('write-tests-first', {
+      agent: 'tests-codex',
+      dependsOn: ['lead-plan-gate'],
+      task: `Write deterministic tests first for the master executor.
+
+Read ${specFile}, ${artifactDir}/acceptance-matrix.md, and ${artifactDir}/lead-plan.md.
+Own only src/product/orchestration/master-executor.test.ts.
+Tests must use Vitest and injected fake child runners; do not invoke live agent-relay.
+Cover decomposition, wave ordering, maxConcurrency, resume signoff skip, failed child classification, missing environment blocked classification, and complete-only-after-gates behavior.
+It is acceptable for tests to fail before implementation exists.`,
+      verification: { type: 'exit_code', value: '0' },
+    })
+    .step('verify-tests-written', {
+      type: 'deterministic',
+      dependsOn: ['write-tests-first'],
+      command: [
+        'set -e',
+        'test -f src/product/orchestration/master-executor.test.ts',
+        'grep -E "describe|it\\(" src/product/orchestration/master-executor.test.ts',
+        'grep -E "maxConcurrency|resume|blocked|dependency|decomposition|signoff|complete" src/product/orchestration/master-executor.test.ts',
+        'echo RICKY_MASTER_EXECUTOR_TESTS_WRITTEN',
+      ].join(' && '),
+      captureOutput: true,
+      failOnError: true,
+    })
+    .step('run-tests-red-or-green', {
+      type: 'deterministic',
+      dependsOn: ['verify-tests-written'],
+      command: 'npx vitest run src/product/orchestration/master-executor.test.ts 2>&1 | tail -120',
+      captureOutput: true,
+      failOnError: false,
+    })
+
+    .step('implement-planner-and-types', {
+      agent: 'planner-codex',
+      dependsOn: ['verify-tests-written'],
+      task: `Implement the master executor type contracts and planner.
+
+Read ${specFile}, ${artifactDir}/lead-plan.md, and src/product/orchestration/master-executor.test.ts.
+Own only:
+- src/product/orchestration/types.ts
+- src/product/orchestration/planner.ts
+- src/product/orchestration/index.ts
+- src/product/index.ts
+
+Expose plain TypeScript types and a planner API that satisfies the tests.
+Do not edit executor implementation or tests.`,
+      verification: { type: 'exit_code', value: '0' },
+    })
+    .step('implement-master-executor', {
+      agent: 'executor-codex',
+      dependsOn: ['verify-tests-written'],
+      task: `Implement the master executor runtime coordinator.
+
+Read ${specFile}, ${artifactDir}/lead-plan.md, and src/product/orchestration/master-executor.test.ts.
+Own only src/product/orchestration/master-executor.ts.
+Use an injected child runner function and in-memory gate evaluator hooks so tests never invoke live agent-relay.
+Implement dependency-wave execution, maxConcurrency, resume signoff skip, structured evidence, and next-action classification.
+Do not edit planner files or tests unless the fix loop later requests it.`,
+      verification: { type: 'exit_code', value: '0' },
+    })
+    .step('verify-implementation-files', {
+      type: 'deterministic',
+      dependsOn: ['implement-planner-and-types', 'implement-master-executor'],
+      command: [
+        'set -e',
+        ...targetFiles.map((file) => `test -f ${file}`),
+        'grep -F "MasterExecutionPlan" src/product/orchestration/types.ts',
+        'grep -E "planMasterExecution|createMasterExecutionPlan" src/product/orchestration/planner.ts',
+        'grep -E "executeMasterPlan|MasterExecutor" src/product/orchestration/master-executor.ts',
+        'grep -F "orchestration" src/product/index.ts',
+        `changed="$(git diff --name-only -- ${targetFiles.join(' ')}; git ls-files --others --exclude-standard -- ${targetFiles.join(' ')})"`,
+        'if [ -z "$changed" ]; then echo "NO_CHANGES_DETECTED"; exit 1; fi',
+        'echo "$changed" > "' + artifactDir + '/scoped-changes.txt"',
+        'echo RICKY_MASTER_EXECUTOR_IMPLEMENTATION_FILES_VERIFIED',
+      ].join(' && '),
+      captureOutput: true,
+      failOnError: true,
+    })
+
+    .step('run-focused-tests-soft', {
+      type: 'deterministic',
+      dependsOn: ['verify-implementation-files'],
+      command: 'npx vitest run src/product/orchestration/master-executor.test.ts 2>&1 | tail -160',
+      captureOutput: true,
+      failOnError: false,
+    })
+    .step('run-typecheck-soft', {
+      type: 'deterministic',
+      dependsOn: ['verify-implementation-files'],
+      command: 'npm run typecheck 2>&1 | tail -160',
+      captureOutput: true,
+      failOnError: false,
+    })
+    .step('review-claude', {
+      agent: 'reviewer-claude',
+      dependsOn: ['run-focused-tests-soft', 'run-typecheck-soft'],
+      task: `Review the master executor implementation against ${specFile}.
+
+Soft focused test output:
+{{steps.run-focused-tests-soft.output}}
+
+Soft typecheck output:
+{{steps.run-typecheck-soft.output}}
+
+Write ${artifactDir}/review-claude.md with:
+- PASS or FAIL
+- any product/architecture gaps
+- exact file references for required fixes
+End with RICKY_MASTER_EXECUTOR_CLAUDE_REVIEW_READY.`,
+      verification: { type: 'file_exists', value: `${artifactDir}/review-claude.md` },
+    })
+    .step('review-codex', {
+      agent: 'reviewer-codex',
+      dependsOn: ['run-focused-tests-soft', 'run-typecheck-soft'],
+      task: `Review the TypeScript implementation and tests for deterministic quality.
+
+Soft focused test output:
+{{steps.run-focused-tests-soft.output}}
+
+Soft typecheck output:
+{{steps.run-typecheck-soft.output}}
+
+Write ${artifactDir}/review-codex.md with:
+- PASS or FAIL
+- type/API/test gaps
+- exact file references for required fixes
+End with RICKY_MASTER_EXECUTOR_CODEX_REVIEW_READY.`,
+      verification: { type: 'file_exists', value: `${artifactDir}/review-codex.md` },
+    })
+    .step('verify-review-artifacts', {
+      type: 'deterministic',
+      dependsOn: ['review-claude', 'review-codex'],
+      command: [
+        'set -e',
+        `grep -F RICKY_MASTER_EXECUTOR_CLAUDE_REVIEW_READY ${artifactDir}/review-claude.md`,
+        `grep -F RICKY_MASTER_EXECUTOR_CODEX_REVIEW_READY ${artifactDir}/review-codex.md`,
+        'echo RICKY_MASTER_EXECUTOR_REVIEWS_CAPTURED',
+      ].join(' && '),
+      captureOutput: true,
+      failOnError: true,
+    })
+    .step('fix-from-soft-gates-and-review', {
+      agent: 'validator-claude',
+      dependsOn: ['verify-review-artifacts'],
+      task: `Run the 80-to-100 fix loop for the master executor first slice.
+
+Focused test output:
+{{steps.run-focused-tests-soft.output}}
+
+Typecheck output:
+{{steps.run-typecheck-soft.output}}
+
+Claude review: ${artifactDir}/review-claude.md
+Codex review: ${artifactDir}/review-codex.md
+
+Fix failures and review findings only within:
+${targetFiles.map((file) => `- ${file}`).join('\n')}
+
+Run locally until green:
+- npx vitest run src/product/orchestration/master-executor.test.ts
+- npm run typecheck
+
+Do not commit, push, or edit unrelated files.`,
+      verification: { type: 'exit_code', value: '0' },
+    })
+    .step('verify-post-fix-scope', {
+      type: 'deterministic',
+      dependsOn: ['fix-from-soft-gates-and-review'],
+      command: [
+        'set -e',
+        `changed="$(git diff --name-only -- ${targetFiles.join(' ')}; git ls-files --others --exclude-standard -- ${targetFiles.join(' ')})"`,
+        'if [ -z "$changed" ]; then echo "NO_SCOPED_CHANGES_AFTER_FIX"; exit 1; fi',
+        'unexpected="$(git diff --name-only; git ls-files --others --exclude-standard)"',
+        'printf "%s\\n" "$unexpected" > "' + artifactDir + '/all-workspace-changes-after-fix.txt"',
+        'echo RICKY_MASTER_EXECUTOR_POST_FIX_SCOPE_RECORDED',
+      ].join(' && '),
+      captureOutput: true,
+      failOnError: true,
+    })
+    .step('run-focused-tests-final', {
+      type: 'deterministic',
+      dependsOn: ['verify-post-fix-scope'],
+      command: 'npx vitest run src/product/orchestration/master-executor.test.ts',
+      captureOutput: true,
+      failOnError: true,
+    })
+    .step('run-typecheck-final', {
+      type: 'deterministic',
+      dependsOn: ['verify-post-fix-scope'],
+      command: 'npm run typecheck',
+      captureOutput: true,
+      failOnError: true,
+    })
+    .step('run-regression-soft', {
+      type: 'deterministic',
+      dependsOn: ['run-focused-tests-final', 'run-typecheck-final'],
+      command: 'npm test 2>&1 | tail -200',
+      captureOutput: true,
+      failOnError: false,
+    })
+    .step('fix-regressions', {
+      agent: 'validator-claude',
+      dependsOn: ['run-regression-soft'],
+      task: `Check the full regression output for failures caused by the master executor changes.
+
+Regression output:
+{{steps.run-regression-soft.output}}
+
+If all tests passed, do nothing.
+If there are failures caused by this slice, fix only the declared target files and rerun npm test until green.
+If failures are clearly unrelated pre-existing workspace issues, document them in ${artifactDir}/regression-notes.md and do not hide them.`,
+      verification: { type: 'exit_code', value: '0' },
+    })
+    .step('quarantine-generated-workflow-residue', {
+      type: 'deterministic',
+      dependsOn: ['fix-regressions'],
+      command: [
+        'set -e',
+        `DIR=${artifactDir}`,
+        'mkdir -p "$DIR/quarantined-generated-workflows"',
+        'allowed="workflows/generated/ricky-i-want-to-clean-up-the-codebase-to-remove-outdat.ts"',
+        'for file in workflows/generated/*.ts; do',
+        '  [ -e "$file" ] || continue',
+        '  if [ "$file" = "$allowed" ]; then continue; fi',
+        '  if git ls-files --error-unmatch "$file" >/dev/null 2>&1; then',
+        '    echo "TRACKED_UNEXPECTED_GENERATED_WORKFLOW: $file"',
+        '    exit 1',
+        '  fi',
+        '  mv "$file" "$DIR/quarantined-generated-workflows/$(basename "$file")"',
+        '  echo "quarantined_untracked_generated_workflow=$file"',
+        'done',
+        'echo RICKY_MASTER_EXECUTOR_GENERATED_RESIDUE_QUARANTINED',
+      ].join('\n'),
+      captureOutput: true,
+      failOnError: true,
+    })
+    .step('run-regression-final', {
+      type: 'deterministic',
+      dependsOn: ['quarantine-generated-workflow-residue'],
+      command: 'npm test',
+      captureOutput: true,
+      failOnError: true,
+    })
+    .step('final-signoff', {
+      type: 'deterministic',
+      dependsOn: ['run-regression-final'],
+      command: [
+        'set -e',
+        `DIR=${artifactDir}`,
+        "cat > \"$DIR/signoff.md\" <<'EOF'",
+        '# Ricky master executor first-slice signoff',
+        '',
+        'Implemented and verified:',
+        '- Master execution plan and child workflow contract types.',
+        '- Spec decomposition planner with child workflow waves and default gates.',
+        '- Injected master executor with bounded concurrency, resume skip, evidence recording, and failure classification.',
+        '- Deterministic Vitest coverage for the acceptance matrix.',
+        '',
+        'Validation gates:',
+        '- npx vitest run src/product/orchestration/master-executor.test.ts',
+        '- npm run typecheck',
+        '- npm test',
+        '',
+        'Commit and push are intentionally outside this workflow.',
+        '',
+        'RICKY_MASTER_EXECUTOR_IMPLEMENTED',
+        'EOF',
+        'grep -F RICKY_MASTER_EXECUTOR_IMPLEMENTED "$DIR/signoff.md"',
+      ].join('\n'),
+      captureOutput: true,
+      failOnError: true,
+    })
+
+    .run({ cwd: process.cwd() });
+
+  console.log(result.status);
+}
+
+main().catch((error) => {
+  console.error(error);
+  process.exitCode = 1;
+});


### PR DESCRIPTION
## Summary

- Add a first-slice Ricky master executor model with planner, child workflow contract types, injected executor, resume/signoff handling, bounded concurrency, and failure classification.
- Add deterministic orchestration tests covering decomposition, dependency waves, concurrency, resume skips, blocked runs, failed children, and final gate requirements.
- Add the wave13 master-executor spec/workflow.

## Signoff

The Ricky workflow completed successfully with final marker `RICKY_MASTER_EXECUTOR_IMPLEMENTED`.

Run ID: `c2d074fddb9211706a985f6a`

## Validation

- `npx vitest run src/product/orchestration/master-executor.test.ts`
- `npm run typecheck`
- `npm test`