### PR TITLE
Fix Ricky clarification question flow

### DIFF
--- a/src/product/spec-intake/clarifications.ts
+++ b/src/product/spec-intake/clarifications.ts
@@ -33,6 +33,8 @@ export function blockingClarificationQuestions(questions: ClarificationQuestion[
 }
 
 function explicitOpenQuestionQuestions(text: string): ClarificationQuestion[] {
+  if (/\b(?:clarification answers|resolved clarifications):/i.test(text)) return [];
+
   const lower = text.toLowerCase();
   const unresolvedMarkers = [
     /\bopen questions?\b/,
@@ -46,10 +48,9 @@ function explicitOpenQuestionQuestions(text: string): ClarificationQuestion[] {
   ];
   if (!unresolvedMarkers.some((pattern) => pattern.test(lower))) return [];
 
-  const questionLines = text
-    .split(/\r?\n/)
-    .map((line) => line.trim().replace(/^[-*]\s*/, ''))
-    .filter((line) => line.endsWith('?'))
+  const questionLines = openQuestionLines(text)
+    .map(questionFromOpenQuestionLine)
+    .filter((line): line is string => Boolean(line))
     .slice(0, 3);
 
   if (questionLines.length > 0) {
@@ -67,6 +68,68 @@ function explicitOpenQuestionQuestions(text: string): ClarificationQuestion[] {
     reason: 'The spec contains explicit unresolved markers such as open questions, TBD, or unclear requirements.',
     blocking: true,
   }];
+}
+
+function openQuestionLines(text: string): string[] {
+  const lines = text.split(/\r?\n/);
+  const questionLines: string[] = [];
+  let inOpenQuestionSection = false;
+
+  for (const rawLine of lines) {
+    const line = stripListMarker(rawLine.trim());
+    if (!line) {
+      inOpenQuestionSection = false;
+      continue;
+    }
+
+    if (/^(#{1,6}\s*)?(open questions?|questions?|clarifications needed|unresolved|tbd)\s*:?\s*$/i.test(line)) {
+      inOpenQuestionSection = true;
+      continue;
+    }
+
+    if (/^(#{1,6}\s*)?[A-Z][\w\s/-]{2,80}:$/.test(line) && !/^(tbd|todo|unclear|unspecified|open question)/i.test(line)) {
+      inOpenQuestionSection = false;
+    }
+
+    const explicitQuestion = line.endsWith('?');
+    const unresolvedItem = /^(?:tbd|todo|unclear|unspecified|not sure|decide later|open question)\b/i.test(line) ||
+      /\b(?:tbd|unclear|unspecified|not sure|decide later|\?\?\?)\b/i.test(line);
+    if (explicitQuestion || inOpenQuestionSection || unresolvedItem) {
+      questionLines.push(line);
+    }
+  }
+
+  return questionLines;
+}
+
+function questionFromOpenQuestionLine(line: string): string | null {
+  const cleaned = stripListMarker(line)
+    .replace(/^(?:open question|question|tbd|todo|unclear|unspecified|not sure|decide later)\s*[:—-]?\s*/i, '')
+    .replace(/^todo:\s*(?:decide|choose|clarify|ask)\s*[:—-]?\s*/i, '')
+    .trim();
+  if (!cleaned || /^open questions?$/i.test(cleaned)) return null;
+  if (cleaned.endsWith('?')) return cleaned;
+
+  const whether = cleaned.match(/^whether\s+(.+)$/i);
+  if (whether) return `Should ${lowercaseFirst(whether[1])}?`;
+
+  if (/^(?:decide|choose|clarify|confirm|select)\b/i.test(cleaned)) {
+    return `Please clarify: ${cleaned.replace(/[.。]+$/, '')}?`;
+  }
+
+  return `Please clarify: ${cleaned.replace(/[.。]+$/, '')}?`;
+}
+
+function stripListMarker(line: string): string {
+  return line
+    .replace(/^[-*+]\s+/, '')
+    .replace(/^\d+[.)]\s+/, '')
+    .replace(/^\[[ xX]\]\s+/, '')
+    .trim();
+}
+
+function lowercaseFirst(value: string): string {
+  return value.charAt(0).toLowerCase() + value.slice(1);
 }
 
 function executionModeConflictQuestion(

--- a/src/product/spec-intake/clarifications.ts
+++ b/src/product/spec-intake/clarifications.ts
@@ -33,9 +33,7 @@ export function blockingClarificationQuestions(questions: ClarificationQuestion[
 }
 
 function explicitOpenQuestionQuestions(text: string): ClarificationQuestion[] {
-  if (/\b(?:clarification answers|resolved clarifications):/i.test(text)) return [];
-
-  const lower = text.toLowerCase();
+  const lower = textWithoutClarificationAnswerSections(text).toLowerCase();
   const unresolvedMarkers = [
     /\bopen questions?\b/,
     /\btbd\b/,
@@ -48,9 +46,12 @@ function explicitOpenQuestionQuestions(text: string): ClarificationQuestion[] {
   ];
   if (!unresolvedMarkers.some((pattern) => pattern.test(lower))) return [];
 
-  const questionLines = openQuestionLines(text)
+  const answeredQuestions = answeredClarificationQuestions(text);
+  const openLines = openQuestionLines(text)
     .map(questionFromOpenQuestionLine)
-    .filter((line): line is string => Boolean(line))
+    .filter((line): line is string => Boolean(line));
+  const questionLines = openLines
+    .filter((line) => !answeredQuestions.has(normalizeQuestion(line)))
     .slice(0, 3);
 
   if (questionLines.length > 0) {
@@ -62,6 +63,8 @@ function explicitOpenQuestionQuestions(text: string): ClarificationQuestion[] {
     }));
   }
 
+  if (openLines.length > 0 && answeredQuestions.size > 0) return [];
+
   return [{
     id: 'resolve-open-questions',
     question: 'What should Ricky decide for the unresolved or TBD parts of this workflow spec?',
@@ -70,26 +73,65 @@ function explicitOpenQuestionQuestions(text: string): ClarificationQuestion[] {
   }];
 }
 
+function textWithoutClarificationAnswerSections(text: string): string {
+  const retained: string[] = [];
+  let inAnswerSection = false;
+
+  for (const rawLine of text.split(/\r?\n/)) {
+    const line = stripListMarker(rawLine.trim());
+    if (!line) {
+      inAnswerSection = false;
+      retained.push(rawLine);
+      continue;
+    }
+
+    if (/^(#{1,6}\s*)?(clarification answers?|resolved clarifications?)\s*:?\s*$/i.test(line)) {
+      inAnswerSection = true;
+      continue;
+    }
+
+    if (/^(#{1,6}\s*)?[A-Z][\w\s/-]{2,80}:$/.test(line)) {
+      inAnswerSection = false;
+    }
+
+    if (!inAnswerSection) retained.push(rawLine);
+  }
+
+  return retained.join('\n');
+}
+
 function openQuestionLines(text: string): string[] {
   const lines = text.split(/\r?\n/);
   const questionLines: string[] = [];
   let inOpenQuestionSection = false;
+  let inClarificationAnswerSection = false;
 
   for (const rawLine of lines) {
     const line = stripListMarker(rawLine.trim());
     if (!line) {
       inOpenQuestionSection = false;
+      inClarificationAnswerSection = false;
+      continue;
+    }
+
+    if (/^(#{1,6}\s*)?(clarification answers?|resolved clarifications?)\s*:?\s*$/i.test(line)) {
+      inOpenQuestionSection = false;
+      inClarificationAnswerSection = true;
       continue;
     }
 
     if (/^(#{1,6}\s*)?(open questions?|questions?|clarifications needed|unresolved|tbd)\s*:?\s*$/i.test(line)) {
       inOpenQuestionSection = true;
+      inClarificationAnswerSection = false;
       continue;
     }
 
     if (/^(#{1,6}\s*)?[A-Z][\w\s/-]{2,80}:$/.test(line) && !/^(tbd|todo|unclear|unspecified|open question)/i.test(line)) {
       inOpenQuestionSection = false;
+      inClarificationAnswerSection = false;
     }
+
+    if (inClarificationAnswerSection) continue;
 
     const explicitQuestion = line.endsWith('?');
     const unresolvedItem = /^(?:tbd|todo|unclear|unspecified|not sure|decide later|open question)\b/i.test(line) ||
@@ -102,10 +144,47 @@ function openQuestionLines(text: string): string[] {
   return questionLines;
 }
 
+function answeredClarificationQuestions(text: string): Set<string> {
+  const answered = new Set<string>();
+  let inAnswerSection = false;
+
+  for (const rawLine of text.split(/\r?\n/)) {
+    const line = stripListMarker(rawLine.trim());
+    if (!line) {
+      inAnswerSection = false;
+      continue;
+    }
+
+    if (/^(#{1,6}\s*)?(clarification answers?|resolved clarifications?)\s*:?\s*$/i.test(line)) {
+      inAnswerSection = true;
+      continue;
+    }
+
+    if (/^(#{1,6}\s*)?[A-Z][\w\s/-]{2,80}:$/.test(line)) {
+      inAnswerSection = false;
+    }
+
+    if (!inAnswerSection) continue;
+
+    const answeredQuestion = questionFromAnswerLine(line);
+    if (answeredQuestion) answered.add(normalizeQuestion(answeredQuestion));
+  }
+
+  return answered;
+}
+
+function questionFromAnswerLine(line: string): string | null {
+  const questionMatch = line.match(/^(.+\?)\s*[:=-]\s*\S/);
+  if (questionMatch) return questionMatch[1].trim();
+
+  const generatedQuestion = questionFromOpenQuestionLine(line);
+  return generatedQuestion?.endsWith('?') ? generatedQuestion : null;
+}
+
 function questionFromOpenQuestionLine(line: string): string | null {
   const cleaned = stripListMarker(line)
-    .replace(/^(?:open question|question|tbd|todo|unclear|unspecified|not sure|decide later)\s*[:—-]?\s*/i, '')
-    .replace(/^todo:\s*(?:decide|choose|clarify|ask)\s*[:—-]?\s*/i, '')
+    .replace(/^(?:open question|question|tbd|todo|unclear|unspecified|not sure|decide later)\s*[:\u2014-]?\s*/i, '')
+    .replace(/^todo:\s*(?:decide|choose|clarify|ask)\s*[:\u2014-]?\s*/i, '')
     .trim();
   if (!cleaned || /^open questions?$/i.test(cleaned)) return null;
   if (cleaned.endsWith('?')) return cleaned;
@@ -114,10 +193,10 @@ function questionFromOpenQuestionLine(line: string): string | null {
   if (whether) return `Should ${lowercaseFirst(whether[1])}?`;
 
   if (/^(?:decide|choose|clarify|confirm|select)\b/i.test(cleaned)) {
-    return `Please clarify: ${cleaned.replace(/[.。]+$/, '')}?`;
+    return `Please clarify: ${cleaned.replace(/[.\u3002]+$/, '')}?`;
   }
 
-  return `Please clarify: ${cleaned.replace(/[.。]+$/, '')}?`;
+  return `Please clarify: ${cleaned.replace(/[.\u3002]+$/, '')}?`;
 }
 
 function stripListMarker(line: string): string {
@@ -130,6 +209,14 @@ function stripListMarker(line: string): string {
 
 function lowercaseFirst(value: string): string {
   return value.charAt(0).toLowerCase() + value.slice(1);
+}
+
+function normalizeQuestion(value: string): string {
+  return value
+    .toLowerCase()
+    .replace(/\s+/g, ' ')
+    .replace(/[?!.\u3002]+$/g, '')
+    .trim();
 }
 
 function executionModeConflictQuestion(

--- a/src/product/spec-intake/parser.test.ts
+++ b/src/product/spec-intake/parser.test.ts
@@ -386,6 +386,32 @@ describe('spec intake parser, normalizer, and router', () => {
     expect(result.routing?.target).toBe('generate');
   });
 
+  it('keeps asking for unresolved questions when clarification answers are partial', () => {
+    const result = intake(
+      natural(
+        [
+          'Generate a workflow for Slack migration.',
+          '',
+          'Open questions:',
+          '- TBD: choose direct Slack OAuth or Nango provider credentials',
+          '- Unclear: who owns final rollout signoff',
+          '',
+          'Clarification answers:',
+          '- Please clarify: choose direct Slack OAuth or Nango provider credentials?: Use Nango provider credentials.',
+        ].join('\n'),
+      ),
+    );
+
+    expect(result.success).toBe(false);
+    expect(result.clarificationQuestions).toEqual([
+      expect.objectContaining({
+        id: 'open-question-1',
+        question: 'Please clarify: who owns final rollout signoff?',
+        blocking: true,
+      }),
+    ]);
+  });
+
   it('asks for a side-effect boundary before generating risky workflows', () => {
     const result = intake(
       natural('Generate a workflow that deletes obsolete files, commits the cleanup, and pushes the branch.'),

--- a/src/product/spec-intake/parser.test.ts
+++ b/src/product/spec-intake/parser.test.ts
@@ -339,6 +339,53 @@ describe('spec intake parser, normalizer, and router', () => {
     expect(result.routing?.suggestedFollowUp).toContain('structured clarification questions');
   });
 
+  it('turns unresolved open-question bullets into concrete clarification questions', () => {
+    const result = intake(
+      natural(
+        [
+          'Generate a workflow for Slack migration.',
+          '',
+          'Open questions:',
+          '- TBD: choose direct Slack OAuth or Nango provider credentials',
+          '- Unclear: who owns final rollout signoff',
+        ].join('\n'),
+      ),
+    );
+
+    expect(result.success).toBe(false);
+    expect(result.clarificationQuestions).toEqual([
+      expect.objectContaining({
+        id: 'open-question-1',
+        question: 'Please clarify: choose direct Slack OAuth or Nango provider credentials?',
+        blocking: true,
+      }),
+      expect.objectContaining({
+        id: 'open-question-2',
+        question: 'Please clarify: who owns final rollout signoff?',
+        blocking: true,
+      }),
+    ]);
+  });
+
+  it('treats appended clarification answers as resolving explicit open-question markers', () => {
+    const result = intake(
+      natural(
+        [
+          'Generate a workflow for Slack migration.',
+          '',
+          'Open questions:',
+          '- TBD: choose direct Slack OAuth or Nango provider credentials',
+          '',
+          'Clarification answers:',
+          '- Please clarify: choose direct Slack OAuth or Nango provider credentials?: Use Nango provider credentials.',
+        ].join('\n'),
+      ),
+    );
+
+    expect(result.clarificationQuestions).toEqual([]);
+    expect(result.routing?.target).toBe('generate');
+  });
+
   it('asks for a side-effect boundary before generating risky workflows', () => {
     const result = intake(
       natural('Generate a workflow that deletes obsolete files, commits the cleanup, and pushes the branch.'),

--- a/src/surfaces/cli/commands/cli-main.ts
+++ b/src/surfaces/cli/commands/cli-main.ts
@@ -1675,6 +1675,7 @@ export async function cliMain(deps: CliMainDeps = {}): Promise<CliMainResult> {
     ...(cloudRequest ? { cloudRequest } : {}),
     ...(localProgress ? { localProgress } : {}),
     ...(localRuntimeOutput ? { localRuntimeOutput } : {}),
+    allowClarificationPrompts: cliHandoff !== undefined && !parsed.json && !parsed.quiet,
     ...cloudRecoveryDeps,
     preferWorkforcePersonaWorkflowWriter:
       deps.preferWorkforcePersonaWorkflowWriter ??
@@ -1947,8 +1948,15 @@ function renderLocalHuman(localResult: NonNullable<InteractiveCliResult['localRe
     );
 
   if (shouldRenderNextActions) {
-    for (const action of localResult.nextActions.slice(0, 2)) {
-      lines.push(`Next: ${action}`);
+    const clarificationQuestions = localResult.clarificationQuestions ?? [];
+    if (localResult.generation?.status === 'needs_clarification' && clarificationQuestions.length > 0) {
+      for (const question of clarificationQuestions.slice(0, 5)) {
+        lines.push(`Next: Clarify: ${question.question}`);
+      }
+    } else {
+      for (const action of localResult.nextActions.slice(0, 2)) {
+        lines.push(`Next: ${action}`);
+      }
     }
   }
   return lines;

--- a/src/surfaces/cli/entrypoint/interactive-cli.test.ts
+++ b/src/surfaces/cli/entrypoint/interactive-cli.test.ts
@@ -80,6 +80,62 @@ describe('runInteractiveCli', () => {
     expect(result.awaitingInput).toBe(false);
   });
 
+  it('asks handoff clarification questions and retries local generation with the answers', async () => {
+    const clarification = {
+      id: 'open-question-1',
+      question: 'Please clarify: choose package A or package B?',
+      reason: 'The spec contains an explicit unresolved question.',
+      blocking: true,
+    };
+    const blockedResponse: LocalResponse = {
+      ok: false,
+      exitCode: 1,
+      artifacts: [],
+      logs: ['[local] spec intake route: clarify'],
+      warnings: ['routing: Spec has unresolved workflow authoring questions'],
+      nextActions: ['Clarify: Please clarify: choose package A or package B?'],
+      clarificationQuestions: [clarification],
+      generation: {
+        stage: 'generate',
+        status: 'needs_clarification',
+        decisions: { clarification_questions: [clarification] },
+      },
+    };
+    const successResponse: LocalResponse = {
+      ok: true,
+      artifacts: [{ path: 'out/workflow.ts', type: 'text/typescript' }],
+      logs: ['[local] workflow generation: passed'],
+      warnings: [],
+      nextActions: ['Review workflow'],
+    };
+    const execute = vi.fn()
+      .mockResolvedValueOnce(blockedResponse)
+      .mockResolvedValueOnce(successResponse);
+
+    const result = await runInteractiveCli({
+      onboard: vi.fn().mockResolvedValue(onboarding('local')),
+      handoff: {
+        source: 'cli',
+        spec: [
+          'Generate a workflow.',
+          'Open questions:',
+          '- TBD: choose package A or package B',
+        ].join('\n'),
+        mode: 'local',
+      },
+      localExecutor: { execute },
+      inputClarificationAnswer: vi.fn().mockResolvedValue('Package B.'),
+    });
+
+    expect(result.ok).toBe(true);
+    expect(result.localResult).toBe(successResponse);
+    expect(execute).toHaveBeenCalledTimes(2);
+    expect(execute.mock.calls[1][0]).toMatchObject({
+      spec: expect.stringContaining('Clarification answers:'),
+    });
+    expect(execute.mock.calls[1][0].spec).toContain('Package B.');
+  });
+
   it('passes deps.cwd as invocationRoot to an injected local executor when the handoff omits it', async () => {
     const localResponse: LocalResponse = {
       ok: true,

--- a/src/surfaces/cli/entrypoint/interactive-cli.ts
+++ b/src/surfaces/cli/entrypoint/interactive-cli.ts
@@ -29,7 +29,7 @@ import type {
 import type { CloudWorkflowSummary } from '../flows/workflow-summary.js';
 import type { LocalWorkflowFlowDeps, LocalWorkflowFlowResult } from '../flows/local-workflow-flow.js';
 import type { LocalExecutor, LocalEntrypointOptions, LocalExecutorOptions, LocalResponse } from '../../../local/entrypoint.js';
-import type { RawHandoff } from '../../../local/request-normalizer.js';
+import type { RawHandoff, SpecInput, StructuredSpec } from '../../../local/request-normalizer.js';
 import type { Diagnosis, DiagnosticSignal } from '../../../runtime/diagnostics/failure-diagnosis.js';
 import type { ConnectProviderOptions, ConnectProviderResult, StoredAuth, WhoAmIResponse } from '@agent-relay/cloud';
 
@@ -53,11 +53,14 @@ import { runSpecIntakeFlow, type CapturedWorkflowSpec, type SpecIntakePrompts } 
 import {
   createInquirerPromptKit,
   isPromptCancellation,
+  PromptCancelledError,
   type PromptKit,
 } from '../prompts/index.js';
 import { resolve } from 'node:path';
 import { spawn } from 'node:child_process';
 import { DEFAULT_AUTO_FIX_ATTEMPTS } from '../../../shared/constants.js';
+import { input as inquirerInput } from '@inquirer/prompts';
+import type { ClarificationQuestion } from '../../../product/spec-intake/index.js';
 
 // ---------------------------------------------------------------------------
 // Interactive CLI result contract
@@ -137,6 +140,16 @@ export interface InteractiveCliDeps extends CloudWorkflowFlowDeps {
 
   /** The raw handoff to execute (spec, source, mode). */
   handoff?: RawHandoff;
+
+  /** Whether a direct local handoff may ask dynamic clarification questions before retrying generation. */
+  allowClarificationPrompts?: boolean;
+
+  /** Optional injected clarification answer prompt for deterministic tests and alternate shells. */
+  inputClarificationAnswer?: (input: {
+    question: ClarificationQuestion;
+    index: number;
+    total: number;
+  }) => Promise<string>;
 
   /** Cloud request context — required when mode is 'cloud'. */
   cloudRequest?: CloudGenerateRequest;
@@ -282,8 +295,7 @@ async function executeLocalPath(
 
   const invocationRoot = resolveLocalInvocationRoot(deps);
   const handoff = withInvocationRoot(deps.handoff, invocationRoot);
-
-  const localResult = await runLocal(handoff, {
+  const localOptions = {
     executor: deps.localExecutor,
     ...(deps.localProgress ? { onProgress: deps.localProgress } : {}),
     ...(deps.localRuntimeOutput ? { onRuntimeOutput: deps.localRuntimeOutput } : {}),
@@ -293,7 +305,16 @@ async function executeLocalPath(
           cwd: invocationRoot,
           returnGeneratedArtifactOnly: handoff.stageMode !== 'run',
         }),
-  });
+  };
+
+  let localResult = await runLocal(handoff, localOptions);
+  if (canPromptForClarification(deps, localResult)) {
+    const answers = await collectClarificationAnswers(deps, localResult.clarificationQuestions ?? []);
+    if (answers.length > 0) {
+      const clarifiedHandoff = appendClarificationAnswers(handoff, answers);
+      localResult = await runLocal(clarifiedHandoff, localOptions);
+    }
+  }
 
   const diagnoses: Diagnosis[] = [];
   const guidance: string[] = [];
@@ -322,6 +343,115 @@ async function executeLocalPath(
   }
 
   return { localResult, diagnoses, guidance, awaitingInput: false };
+}
+
+interface ClarificationAnswer {
+  question: ClarificationQuestion;
+  answer: string;
+}
+
+function canPromptForClarification(deps: InteractiveCliDeps, localResult: LocalResponse): boolean {
+  if (deps.allowClarificationPrompts === false) return false;
+  if (localResult.generation?.status !== 'needs_clarification') return false;
+  if ((localResult.clarificationQuestions?.length ?? 0) === 0) return false;
+  if (deps.inputClarificationAnswer) return true;
+
+  const input = deps.input ?? process.stdin;
+  const output = deps.output ?? process.stdout;
+  return ownsInteractiveTerminal(deps, input, output);
+}
+
+async function collectClarificationAnswers(
+  deps: InteractiveCliDeps,
+  questions: ClarificationQuestion[],
+): Promise<ClarificationAnswer[]> {
+  const answers: ClarificationAnswer[] = [];
+  for (const [index, question] of questions.entries()) {
+    const answer = deps.inputClarificationAnswer
+      ? await deps.inputClarificationAnswer({ question, index: index + 1, total: questions.length })
+      : await inputClarificationAnswer(deps, question, index + 1, questions.length);
+    if (answer.trim()) {
+      answers.push({ question, answer: answer.trim() });
+    }
+  }
+  return answers;
+}
+
+async function inputClarificationAnswer(
+  deps: InteractiveCliDeps,
+  question: ClarificationQuestion,
+  index: number,
+  total: number,
+): Promise<string> {
+  try {
+    return await inquirerInput({
+      message: total > 1 ? `Clarification ${index}/${total}: ${question.question}` : question.question,
+      required: true,
+    }, {
+      input: deps.input,
+      output: deps.output,
+      signal: deps.signal,
+    });
+  } catch (error) {
+    if (error instanceof Error && (error.name === 'AbortPromptError' || error.name === 'ExitPromptError')) {
+      throw new PromptCancelledError(error.name === 'AbortPromptError' ? 'abort' : 'exit');
+    }
+    if (deps.signal?.aborted === true) {
+      throw new PromptCancelledError('abort');
+    }
+    throw error;
+  }
+}
+
+function appendClarificationAnswers(handoff: RawHandoff, answers: ClarificationAnswer[]): RawHandoff {
+  switch (handoff.source) {
+    case 'free-form':
+      return { ...handoff, spec: appendClarificationAnswersToText(handoff.spec, answers) };
+    case 'structured':
+      return { ...handoff, spec: appendClarificationAnswersToStructuredSpec(handoff.spec, answers) };
+    case 'cli':
+    case 'claude':
+      return { ...handoff, spec: appendClarificationAnswersToSpec(handoff.spec, answers) };
+    case 'mcp':
+      if (handoff.spec !== undefined) {
+        return { ...handoff, spec: appendClarificationAnswersToSpec(handoff.spec, answers) };
+      }
+      return { ...handoff, arguments: appendClarificationAnswersToStructuredSpec(handoff.arguments ?? {}, answers) };
+    case 'workflow-artifact':
+      return handoff;
+  }
+}
+
+function appendClarificationAnswersToSpec(spec: SpecInput, answers: ClarificationAnswer[]): SpecInput {
+  if (typeof spec === 'string') return appendClarificationAnswersToText(spec, answers);
+  return appendClarificationAnswersToStructuredSpec(spec, answers);
+}
+
+function appendClarificationAnswersToStructuredSpec(spec: StructuredSpec, answers: ClarificationAnswer[]): StructuredSpec {
+  const description = typeof spec.description === 'string'
+    ? spec.description
+    : typeof spec.prompt === 'string'
+      ? spec.prompt
+      : typeof spec.spec === 'string'
+        ? spec.spec
+        : JSON.stringify(spec, null, 2);
+  return {
+    ...spec,
+    description: appendClarificationAnswersToText(description, answers),
+    clarificationAnswers: answers.map(({ question, answer }) => ({
+      question: question.question,
+      answer,
+    })),
+  };
+}
+
+function appendClarificationAnswersToText(text: string, answers: ClarificationAnswer[]): string {
+  return [
+    text.trimEnd(),
+    '',
+    'Clarification answers:',
+    ...answers.map(({ question, answer }) => `- ${question.question}: ${answer}`),
+  ].join('\n');
 }
 
 function collectLocalDiagnosticSignals(localResult: LocalResponse): DiagnosticSignal[] {


### PR DESCRIPTION
## Summary
- extract concrete clarification questions from unresolved/TBD open-question spec bullets
- prompt for clarification answers during interactive local CLI generation and retry once with the answers appended to the spec
- render all concrete clarification prompts in non-interactive CLI output

## Verification
- npm run typecheck
- npm test -- --run src/product/spec-intake/parser.test.ts
- npm test -- --run src/surfaces/cli/entrypoint/interactive-cli.test.ts
- npm test -- --run src/surfaces/cli/commands/cli-main.test.ts
- git diff --check