### PR TITLE
Fix Ricky persona cwd repair path

### DIFF
--- a/src/product/generation/pipeline.test.ts
+++ b/src/product/generation/pipeline.test.ts
@@ -532,6 +532,31 @@ describe('workflow generation pipeline', () => {
     expect(result.validation.issues).toEqual([]);
   });
 
+  it('requires the runtime run call itself to pass explicit cwd, ignoring embedded examples', () => {
+    const result = generate({
+      spec: spec({
+        description: 'Implement workflow generation tests with deterministic validation.',
+        targetFiles: ['src/product/generation/pipeline.test.ts'],
+        acceptanceGates: ['npx vitest run src/product/generation/pipeline.test.ts'],
+      }),
+      artifactPath: 'workflows/generated/pipeline-cwd.ts',
+    });
+    const baseArtifact = artifact(result);
+    const weakArtifact = {
+      ...baseArtifact,
+      content: replaceLast(baseArtifact.content, '.run({ cwd: process.cwd() });', '.run();'),
+    };
+
+    const validation = validateGeneratedArtifact(weakArtifact, result.patternDecision, result.skillContext);
+
+    expect(validation.valid).toBe(false);
+    expect(validation.issues).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ code: 'RUN_CWD_MISSING' }),
+      ]),
+    );
+  });
+
   it('marks implementation workflows with source-change and result evidence contracts', () => {
     const result = generate({
       spec: spec({
@@ -1528,6 +1553,12 @@ function gate(
   const match = artifact.gates.find((candidate) => candidate.name === name);
   expect(match).toBeDefined();
   return match!;
+}
+
+function replaceLast(value: string, search: string, replacement: string): string {
+  const index = value.lastIndexOf(search);
+  expect(index).toBeGreaterThanOrEqual(0);
+  return `${value.slice(0, index)}${replacement}${value.slice(index + search.length)}`;
 }
 
 function spec(overrides: SpecFixtureOverrides = {}): NormalizedWorkflowSpec {

--- a/src/product/generation/pipeline.ts
+++ b/src/product/generation/pipeline.ts
@@ -18,6 +18,7 @@ import { renderMasterExecutionWorkflow, shouldUseMasterExecutionWorkflow } from 
 import { renderWorkflow } from './template-renderer.js';
 import {
   applyPersonaArtifactToRenderedArtifact,
+  hasExplicitWorkflowRunCwd,
   writeWorkflowWithWorkforcePersona,
   WorkforcePersonaClarificationError,
   WorkforcePersonaWriterError,
@@ -314,7 +315,7 @@ export function validateGeneratedArtifact(
   if (!/skill-application-boundary\.json/.test(content) || !/generation_time_only/.test(content) || !/runtimeEmbodiment/.test(content)) {
     issues.push(blockingIssue('validation', 'SKILL_BOUNDARY_EVIDENCE_MISSING', 'Rendered workflow does not expose generation-time skill boundary metadata.'));
   }
-  if (!/\.run\(\{ cwd: process\.cwd\(\) \}\)/.test(content)) {
+  if (!hasExplicitWorkflowRunCwd(content)) {
     issues.push(blockingIssue('validation', 'RUN_CWD_MISSING', 'Rendered workflow does not run with explicit cwd.'));
   }
 

--- a/src/product/generation/workforce-persona-repairer.test.ts
+++ b/src/product/generation/workforce-persona-repairer.test.ts
@@ -116,6 +116,45 @@ describe('workforce persona workflow repairer', () => {
     expect(resolverOptions).toEqual([{ tier: 'best-value', installRoot: '/state/ricky/persona-repair-skills' }]);
   });
 
+  it('rejects repaired artifacts that do not run with explicit cwd', async () => {
+    const resolver: WorkforcePersonaResolver = async () => ({
+      source: 'package',
+      intent: 'agent-relay-workflow',
+      warnings: [],
+      context: {
+        selection: {
+          personaId: 'agent-relay-workflow',
+          tier: 'best',
+          runtime: { harness: 'codex', model: 'codex/test' },
+        },
+        sendMessage() {
+          return execution(JSON.stringify({
+            artifact: {
+              path: 'workflows/generated/failing.ts',
+              content: workflowSource('after').replace('.run({ cwd: process.cwd() });', '.run();'),
+            },
+            metadata: { summary: 'repaired without cwd' },
+          }));
+        },
+      },
+    });
+
+    await expect(repairWorkflowWithWorkforcePersona({
+      repoRoot: '/repo',
+      artifactPath: 'workflows/generated/failing.ts',
+      artifactContent: workflowSource('before'),
+      evidence: { runId: 'relay-run-1', status: 'failed' },
+      classification: { failureClass: 'environment_error' },
+      debuggerResult: { repairMode: 'guided', summary: 'missing setup' },
+      attempt: 1,
+      maxAttempts: 3,
+      resolver,
+    })).rejects.toMatchObject({
+      name: 'WorkforcePersonaWriterError',
+      message: expect.stringContaining('explicit cwd'),
+    });
+  });
+
   it('upgrades repair persona resolution to best after the third failed retry', async () => {
     const resolverOptions: Array<Record<string, unknown>> = [];
     const resolver: WorkforcePersonaResolver = async (_intents, options) => {

--- a/src/product/generation/workforce-persona-repairer.ts
+++ b/src/product/generation/workforce-persona-repairer.ts
@@ -2,6 +2,7 @@ import { createHash } from 'node:crypto';
 
 import {
   defaultWorkforcePersonaResolver,
+  hasExplicitWorkflowRunCwd,
   parsePersonaWorkflowResponse,
   WORKFORCE_PERSONA_INTENT_CANDIDATES,
   WorkforcePersonaWriterError,
@@ -117,6 +118,9 @@ export async function repairWorkflowWithWorkforcePersona(
   const parsed = parsePersonaWorkflowResponse(result.output, options.artifactPath);
   if (parsed.clarification || !parsed.content) {
     throw new WorkforcePersonaWriterError('Workforce persona repair response must include a repaired workflow artifact.');
+  }
+  if (!hasExplicitWorkflowRunCwd(parsed.content)) {
+    throw new WorkforcePersonaWriterError('Workforce persona repair artifact must run with explicit cwd.');
   }
   const responseFormat = parsed.responseFormat as 'structured-json' | 'fenced-artifact';
   return {

--- a/src/product/generation/workforce-persona-writer.test.ts
+++ b/src/product/generation/workforce-persona-writer.test.ts
@@ -153,8 +153,8 @@ describe('workforce persona workflow writer', () => {
     expect(parsed.metadata).toMatchObject({ workflowName: 'persona' });
   });
 
-  it('still rejects persona artifacts that run without an explicit cwd', () => {
-    expect(() => parsePersonaWorkflowResponse(JSON.stringify({
+  it('parses persona artifacts without explicit cwd so pre-write validation can repair them', () => {
+    const parsed = parsePersonaWorkflowResponse(JSON.stringify({
       artifact: {
         path: 'workflows/generated/persona.ts',
         content: workflowSource().replace('.run({ cwd: process.cwd() });', '.run();'),
@@ -163,7 +163,10 @@ describe('workforce persona workflow writer', () => {
         workflowName: 'persona',
         agents: ['lead'],
       },
-    }), 'workflows/generated/persona.ts')).toThrow(/explicit cwd/);
+    }), 'workflows/generated/persona.ts');
+
+    expect(parsed.responseFormat).toBe('structured-json');
+    expect(parsed.content).toContain('.run();');
   });
 
   it('recovers expected artifact content from disk when structured output omits inline content', () => {
@@ -460,6 +463,60 @@ describe('workforce persona workflow writer', () => {
     expect(tasks[1]).toContain('Ricky pre-write validation failed');
     expect(tasks[1]).toContain('Rendered artifact has unbalanced braces');
     expect(tasks[1]).toContain('Previous rejected artifact');
+    expect(result.workforcePersona?.warnings).toContain(
+      'Ricky pre-write validation repaired the Workforce persona artifact before writing.',
+    );
+  });
+
+  it('runs pre-write validation and asks the persona to repair missing explicit cwd before writing', async () => {
+    const base = generate({
+      spec: spec({
+        description: 'Implement a strict Agent Relay workflow with tests and review.',
+        targetFiles: ['src/product/generation/pipeline.ts'],
+      }),
+      artifactPath: 'workflows/generated/prewrite-cwd-repair.ts',
+    });
+    expect(base.success).toBe(true);
+    const tasks: string[] = [];
+    const resolver: WorkforcePersonaResolver = async () => ({
+      source: 'package',
+      intent: 'agent-relay-workflow',
+      warnings: [],
+      context: {
+        selection: {
+          personaId: 'agent-relay-workflow',
+          tier: 'best',
+          runtime: { harness: 'codex', model: 'codex/test' },
+        },
+        sendMessage(task) {
+          tasks.push(task);
+          const content = tasks.length === 1
+            ? replaceLast(base.artifact!.content, '.run({ cwd: process.cwd() });', '.run();')
+            : base.artifact!.content;
+          return execution(personaResponse('workflows/generated/prewrite-cwd-repair.ts', content));
+        },
+      },
+    });
+
+    const result = await generateWithWorkforcePersona({
+      spec: spec({
+        description: 'Implement a strict Agent Relay workflow with tests and review.',
+        targetFiles: ['src/product/generation/pipeline.ts'],
+      }),
+      artifactPath: 'workflows/generated/prewrite-cwd-repair.ts',
+      workforcePersonaWriter: {
+        repoRoot: '/repo',
+        workflowName: 'prewrite-cwd-repair',
+        targetMode: 'local',
+        resolver,
+      },
+    });
+
+    expect(result.success).toBe(true);
+    expect(result.artifact?.content).toContain('.run({ cwd: process.cwd() })');
+    expect(tasks).toHaveLength(2);
+    expect(tasks[1]).toContain('Ricky pre-write validation failed');
+    expect(tasks[1]).toContain('Rendered workflow does not run with explicit cwd');
     expect(result.workforcePersona?.warnings).toContain(
       'Ricky pre-write validation repaired the Workforce persona artifact before writing.',
     );
@@ -864,6 +921,12 @@ function personaResponse(path: string, content: string): string {
     },
     metadata: { workflowName: path.split('/').pop()?.replace(/\.ts$/, '') },
   });
+}
+
+function replaceLast(value: string, search: string, replacement: string): string {
+  const index = value.lastIndexOf(search);
+  expect(index).toBeGreaterThanOrEqual(0);
+  return `${value.slice(0, index)}${replacement}${value.slice(index + search.length)}`;
 }
 
 function workflowSource(): string {

--- a/src/product/generation/workforce-persona-writer.ts
+++ b/src/product/generation/workforce-persona-writer.ts
@@ -817,13 +817,75 @@ function validateArtifactContent(content: string): void {
   if (!/\bworkflow\(/.test(content)) {
     throw new WorkforcePersonaWriterError('Workforce persona artifact does not call workflow().');
   }
-  if (!hasExplicitRunCwd(content)) {
-    throw new WorkforcePersonaWriterError('Workforce persona artifact must run with explicit cwd.');
-  }
 }
 
-function hasExplicitRunCwd(content: string): boolean {
-  return /\.run\s*\(\s*\{[\s\S]*?\bcwd\s*:\s*process\.cwd\s*\(\s*\)[\s\S]*?\}\s*\)/.test(content);
+export function hasExplicitWorkflowRunCwd(content: string): boolean {
+  const executableCode = maskTypeScriptStringsAndComments(content);
+  return /\.run\s*\(\s*\{[\s\S]*?\bcwd\s*:\s*process\.cwd\s*\(\s*\)[\s\S]*?\}\s*\)/.test(executableCode);
+}
+
+function maskTypeScriptStringsAndComments(content: string): string {
+  let masked = '';
+  let index = 0;
+
+  while (index < content.length) {
+    const char = content[index];
+    const next = content[index + 1];
+
+    if (char === '"' || char === "'" || char === '`') {
+      const quote = char;
+      masked += ' ';
+      index += 1;
+      let escaped = false;
+      while (index < content.length) {
+        const current = content[index];
+        masked += current === '\n' || current === '\r' ? current : ' ';
+        index += 1;
+        if (escaped) {
+          escaped = false;
+          continue;
+        }
+        if (current === '\\') {
+          escaped = true;
+          continue;
+        }
+        if (current === quote) break;
+      }
+      continue;
+    }
+
+    if (char === '/' && next === '/') {
+      masked += '  ';
+      index += 2;
+      while (index < content.length && content[index] !== '\n') {
+        masked += ' ';
+        index += 1;
+      }
+      continue;
+    }
+
+    if (char === '/' && next === '*') {
+      masked += '  ';
+      index += 2;
+      while (index < content.length) {
+        const current = content[index];
+        const following = content[index + 1];
+        masked += current === '\n' || current === '\r' ? current : ' ';
+        index += 1;
+        if (current === '*' && following === '/') {
+          masked += ' ';
+          index += 1;
+          break;
+        }
+      }
+      continue;
+    }
+
+    masked += char;
+    index += 1;
+  }
+
+  return masked;
 }
 
 function validateMetadata(metadata: Record<string, unknown>): void {


### PR DESCRIPTION
## Summary
- Let Workforce persona workflow artifacts that are missing explicit cwd reach pre-write validation so Ricky can repair them instead of hard-failing during response parsing.
- Validate the actual runtime .run(...) call with strings/comments masked, so embedded examples in generated context do not satisfy the cwd contract.
- Add regression tests for missing-cwd persona repair and embedded-example masking.

## Verification
- npm run typecheck
- npx vitest run src/product/generation/workforce-persona-writer.test.ts src/product/generation/pipeline.test.ts
- npm test