### PR TITLE
Use stable Node register hook for SDK workflow loader

### DIFF
--- a/src/local/entrypoint.ts
+++ b/src/local/entrypoint.ts
@@ -923,7 +923,12 @@ async function workflowSdkLoaderNodeOption(cwd: string): Promise<string | undefi
   ].join('\n');
   await mkdir(dirname(loaderPath), { recursive: true });
   await writeFile(loaderPath, loaderSource, 'utf8');
-  return `--experimental-loader=${pathToFileURL(loaderPath).href}`;
+  const registerSource = [
+    'import{register}from"node:module";',
+    'import{pathToFileURL}from"node:url";',
+    `register(${JSON.stringify(pathToFileURL(loaderPath).href)},pathToFileURL("./"));`,
+  ].join('');
+  return `--import=data:text/javascript,${encodeURIComponent(registerSource)}`;
 }
 
 export function createLocalExecutor(options: LocalExecutorOptions = {}): LocalExecutor {


### PR DESCRIPTION
## Summary
- replace the SDK runtime NODE_OPTIONS hook from `--experimental-loader` to Node's stable `--import=data:...register(...)` form
- keeps the existing generated loader module and `@agent-relay/sdk/workflows` resolution behavior

## Verification
- npx vitest run src/local/entrypoint.test.ts

This removes the repeated ExperimentalWarning noise from Ricky workflow subprocesses on modern Node.