### PR TITLE
fix(cli): stop spinner before clarification prompt

### DIFF
--- a/src/surfaces/cli/commands/cli-main.ts
+++ b/src/surfaces/cli/commands/cli-main.ts
@@ -1674,6 +1674,7 @@ export async function cliMain(deps: CliMainDeps = {}): Promise<CliMainResult> {
     ...(cliHandoff ? { handoff: cliHandoff } : {}),
     ...(cloudRequest ? { cloudRequest } : {}),
     ...(localProgress ? { localProgress } : {}),
+    ...(progressReporter ? { localProgressStop: progressReporter.stop } : {}),
     ...(localRuntimeOutput ? { localRuntimeOutput } : {}),
     allowClarificationPrompts: cliHandoff !== undefined && !parsed.json && !parsed.quiet,
     ...cloudRecoveryDeps,

--- a/src/surfaces/cli/entrypoint/interactive-cli.test.ts
+++ b/src/surfaces/cli/entrypoint/interactive-cli.test.ts
@@ -136,6 +136,54 @@ describe('runInteractiveCli', () => {
     expect(execute.mock.calls[1][0].spec).toContain('Package B.');
   });
 
+  it('stops the foreground progress spinner before prompting for clarification answers', async () => {
+    const clarification = {
+      id: 'open-question-1',
+      question: 'Pick package A or B?',
+      reason: 'unresolved',
+      blocking: true,
+    };
+    const blockedResponse: LocalResponse = {
+      ok: false,
+      exitCode: 1,
+      artifacts: [],
+      logs: [],
+      warnings: [],
+      nextActions: [],
+      clarificationQuestions: [clarification],
+      generation: {
+        stage: 'generate',
+        status: 'needs_clarification',
+        decisions: { clarification_questions: [clarification] },
+      },
+    };
+    const successResponse: LocalResponse = {
+      ok: true, artifacts: [], logs: [], warnings: [], nextActions: [],
+    };
+    const execute = vi.fn()
+      .mockResolvedValueOnce(blockedResponse)
+      .mockResolvedValueOnce(successResponse);
+
+    const events: string[] = [];
+    const localProgressStop = vi.fn(() => { events.push('stop'); });
+    const inputClarificationAnswer = vi.fn(async () => {
+      events.push('prompt');
+      return 'Package B.';
+    });
+
+    await runInteractiveCli({
+      onboard: vi.fn().mockResolvedValue(onboarding('local')),
+      handoff: { source: 'cli', spec: 'Generate.', mode: 'local' },
+      localExecutor: { execute },
+      localProgress: vi.fn(),
+      localProgressStop,
+      inputClarificationAnswer,
+    });
+
+    expect(localProgressStop).toHaveBeenCalled();
+    expect(events).toEqual(['stop', 'prompt']);
+  });
+
   it('passes deps.cwd as invocationRoot to an injected local executor when the handoff omits it', async () => {
     const localResponse: LocalResponse = {
       ok: true,

--- a/src/surfaces/cli/entrypoint/interactive-cli.ts
+++ b/src/surfaces/cli/entrypoint/interactive-cli.ts
@@ -212,6 +212,13 @@ export interface InteractiveCliDeps extends CloudWorkflowFlowDeps {
   /** Concise local-run progress updates for foreground CLI execution. */
   localProgress?: (message: string) => void;
 
+  /**
+   * Stop any active local-progress indicator (spinner) — called before
+   * interactive prompts so they don't render underneath a still-spinning
+   * spinner. Safe to call when no spinner is active.
+   */
+  localProgressStop?: () => void;
+
   /** Foreground local workflow stdout/stderr passthrough. */
   localRuntimeOutput?: (stream: 'stdout' | 'stderr', line: string) => void;
 }
@@ -365,6 +372,10 @@ async function collectClarificationAnswers(
   deps: InteractiveCliDeps,
   questions: ClarificationQuestion[],
 ): Promise<ClarificationAnswer[]> {
+  // Stop the foreground spinner before prompting — otherwise ora keeps
+  // overdrawing the inquirer prompt line and the user sees a frozen
+  // "Spec intake routed to clarify..." with no visible question.
+  deps.localProgressStop?.();
   const answers: ClarificationAnswer[] = [];
   for (const [index, question] of questions.entries()) {
     const answer = deps.inputClarificationAnswer


### PR DESCRIPTION
## Summary
- When spec intake routed to `clarify`, the `ora` spinner stayed active and overdrew the inquirer clarification prompt, so the CLI looked frozen at `⠋ Spec intake routed to clarify...` and Ctrl-C surfaced as `Cancelled. Nothing was generated or executed.`
- Wired `progressReporter.stop` through `InteractiveCliDeps` as `localProgressStop` and call it at the top of `collectClarificationAnswers` so the prompt renders cleanly.
- Spinner restarts naturally on the post-clarification `runLocal` via the existing `onProgress` callbacks.

## Repro
`ricky --mode local --spec-file <spec-with-an-Open-questions-heading>` — intake routes to clarify, spinner masks the inquirer prompt.

## Test plan
- [x] Added a regression test in `interactive-cli.test.ts` asserting `localProgressStop` fires before the first clarification prompt.
- [x] `npx vitest run src/surfaces/cli/entrypoint/interactive-cli.test.ts src/surfaces/cli/commands/cli-main.test.ts` — 178 passed.
- [x] `npm run typecheck` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)