### PR TITLE
Honor Workforce workflow writer tier routing

### DIFF
--- a/src/product/generation/workforce-persona-writer.test.ts
+++ b/src/product/generation/workforce-persona-writer.test.ts
@@ -846,9 +846,10 @@ describe('workforce persona workflow writer', () => {
   });
 
   it('uses a runnable usePersona(...).sendMessage seam when harness-kit is unavailable', async () => {
+    const selectionOptionsCalls: unknown[] = [];
     const resolved = await resolveWorkforcePersonaContextWithModules(
       ['agent-relay-workflow'],
-      { tier: 'best' },
+      { tier: 'best', installRoot: '/state/ricky/persona-skills' },
       {
         source: 'package',
         warnings: ['harness-kit unavailable'],
@@ -859,6 +860,7 @@ describe('workforce persona workflow writer', () => {
         warnings: ['using packaged workload-router fallback'],
         module: {
           usePersona(intent, options) {
+            selectionOptionsCalls.push(options);
             return runnableContext({ personaId: intent, tier: options?.tier ?? 'minimum' });
           },
         },
@@ -871,12 +873,53 @@ describe('workforce persona workflow writer', () => {
       personaId: 'agent-relay-workflow',
       tier: 'best',
     });
+    expect(selectionOptionsCalls).toEqual([
+      { tier: 'best', installRoot: '/state/ricky/persona-skills' },
+    ]);
     expect(resolved.warnings).toEqual([
       'harness-kit unavailable',
       'using packaged workload-router fallback',
     ]);
     const result = await resolved.context.sendMessage('task');
     expect(result.status).toBe('completed');
+  });
+
+  it('retries the runnable usePersona fallback without installRoot when the selected harness rejects it', async () => {
+    const selectionOptionsCalls: unknown[] = [];
+    const resolved = await resolveWorkforcePersonaContextWithModules(
+      ['agent-relay-workflow'],
+      { installRoot: '/state/ricky/persona-skills' },
+      {
+        source: 'package',
+        warnings: ['harness-kit unavailable'],
+        module: {},
+      },
+      async () => ({
+        source: 'package',
+        warnings: [],
+        module: {
+          usePersona(intent, options) {
+            selectionOptionsCalls.push(options);
+            if (options?.installRoot) {
+              throw new Error('installRoot is only supported for the claude harness (got: opencode)');
+            }
+            return runnableContext({ personaId: intent, tier: 'best-value' });
+          },
+        },
+      }),
+    );
+
+    expect(resolved.context.selection).toMatchObject({
+      personaId: 'agent-relay-workflow',
+      tier: 'best-value',
+    });
+    expect(selectionOptionsCalls).toEqual([
+      { installRoot: '/state/ricky/persona-skills' },
+      undefined,
+    ]);
+    expect(resolved.warnings).toContain(
+      'Workforce persona selected a non-claude harness; retrying runnable context without installRoot.',
+    );
   });
 
   it('preserves npm load failure wording when harness-kit cannot be imported', async () => {

--- a/src/product/generation/workforce-persona-writer.test.ts
+++ b/src/product/generation/workforce-persona-writer.test.ts
@@ -665,6 +665,7 @@ describe('workforce persona workflow writer', () => {
 
   it('uses workload-router only for selection metadata when harness-kit needs useRunnableSelection', async () => {
     const selections: unknown[] = [];
+    const selectionOptionsCalls: unknown[] = [];
     const resolved = await resolveWorkforcePersonaContextWithModules(
       ['relay-orchestrator'],
       { installRoot: '/state/ricky/persona-skills' },
@@ -682,7 +683,8 @@ describe('workforce persona workflow writer', () => {
         source: 'package',
         warnings: [],
         module: {
-          usePersona(intent) {
+          usePersona(intent, options) {
+            selectionOptionsCalls.push(options);
             return {
               selection: {
                 personaId: intent,
@@ -698,6 +700,7 @@ describe('workforce persona workflow writer', () => {
     );
 
     expect(resolved.context.selection.personaId).toBe('relay-orchestrator');
+    expect(selectionOptionsCalls).toEqual([undefined]);
     expect(selections).toHaveLength(1);
     expect(selections[0]).toMatchObject({
       selection: { personaId: 'relay-orchestrator' },
@@ -782,6 +785,64 @@ describe('workforce persona workflow writer', () => {
     expect(result.workforcePersona?.promptDigest).toMatch(/^[a-f0-9]{64}$/);
     expect(result.workforcePersona?.warnings).toEqual(['resolver warning']);
     expect(result.artifact?.content).toBe(base.artifact!.content);
+  });
+
+  it('lets the Workforce router choose the default writer tier unless callers override it', async () => {
+    const base = generate({
+      spec: spec({
+        description: 'Implement a strict Agent Relay workflow with tests and review.',
+        targetFiles: ['src/product/generation/pipeline.ts'],
+      }),
+      artifactPath: 'workflows/generated/router-tier.ts',
+    });
+    expect(base.success).toBe(true);
+
+    const resolverOptions: Array<Record<string, unknown> | undefined> = [];
+    const resolver: WorkforcePersonaResolver = async (_intents, options) => {
+      resolverOptions.push(options);
+      return {
+        source: 'package',
+        intent: 'agent-relay-workflow',
+        warnings: [],
+        context: {
+          selection: {
+            personaId: 'agent-relay-workflow',
+            tier: 'best-value',
+            runtime: {
+              harness: 'opencode',
+              model: 'opencode/gpt-5-nano',
+              harnessSettings: { timeoutSeconds: 900, reasoning: 'medium' },
+            },
+          },
+          sendMessage() {
+            return execution(personaResponse('workflows/generated/router-tier.ts', base.artifact!.content));
+          },
+        },
+      };
+    };
+
+    const result = await generateWithWorkforcePersona({
+      spec: spec({
+        description: 'Implement a strict Agent Relay workflow with tests and review.',
+        targetFiles: ['src/product/generation/pipeline.ts'],
+      }),
+      artifactPath: 'workflows/generated/router-tier.ts',
+      workforcePersonaWriter: {
+        repoRoot: '/repo',
+        workflowName: 'router-tier',
+        targetMode: 'local',
+        resolver,
+      },
+    });
+
+    expect(result.success).toBe(true);
+    expect(resolverOptions).toEqual([{}]);
+    expect(result.workforcePersona).toMatchObject({
+      personaId: 'agent-relay-workflow',
+      tier: 'best-value',
+      harness: 'opencode',
+      model: 'opencode/gpt-5-nano',
+    });
   });
 
   it('uses a runnable usePersona(...).sendMessage seam when harness-kit is unavailable', async () => {

--- a/src/product/generation/workforce-persona-writer.ts
+++ b/src/product/generation/workforce-persona-writer.ts
@@ -14,7 +14,6 @@ export const WORKFORCE_PERSONA_INTENT_CANDIDATES = [
   'architecture-plan',
   'documentation',
 ] as const;
-export const DEFAULT_WORKFORCE_PERSONA_TIER = 'best';
 
 export interface WorkforcePersonaRuntime {
   harness: string;
@@ -983,7 +982,6 @@ function selectionOptions(
 ): WorkforceSelectionOptions | undefined {
   const resolved: WorkforceSelectionOptions = {};
   if (options.tier) resolved.tier = options.tier;
-  if (options.installRoot) resolved.installRoot = options.installRoot;
   return Object.keys(resolved).length > 0 ? resolved : undefined;
 }
 
@@ -993,7 +991,8 @@ function selectionFromPersonaResult(value: unknown): unknown {
 }
 
 function personaResolverOptions(options: { tier?: string; installRoot?: string }): { tier?: string; installRoot?: string } {
-  const resolved: { tier?: string; installRoot?: string } = { tier: options.tier ?? DEFAULT_WORKFORCE_PERSONA_TIER };
+  const resolved: { tier?: string; installRoot?: string } = {};
+  if (options.tier) resolved.tier = options.tier;
   if (options.installRoot) resolved.installRoot = options.installRoot;
   return resolved;
 }

--- a/src/product/generation/workforce-persona-writer.ts
+++ b/src/product/generation/workforce-persona-writer.ts
@@ -337,7 +337,7 @@ export async function resolveWorkforcePersonaContextWithModules(
       const selectionModule = await loadSelectionModule();
       warnings.push(...selectionModule.warnings);
       try {
-        const selected = selectionModule.module.usePersona(intent, selectionOptions(options));
+        const selected = selectionModule.module.usePersona(intent, metadataSelectionOptions(options));
         if (isUsablePersonaContext(selected)) {
           return {
             source: 'package',
@@ -400,7 +400,7 @@ export async function resolveWorkforcePersonaContextWithModules(
     try {
       const selectionModule = await loadSelectionModule();
       warnings.push(...selectionModule.warnings);
-      const context = selectionModule.module.usePersona(intent, selectionOptions(options));
+      const context = selectionModule.module.usePersona(intent, runnableSelectionFallbackOptions(options));
       if (isUsablePersonaContext(context)) {
         return {
           source: selectionModule.source,
@@ -415,7 +415,32 @@ export async function resolveWorkforcePersonaContextWithModules(
       }
       warnings.push(`Workforce usePersona(${intent}) returned unusable selection metadata.`);
     } catch (error) {
-      warnings.push(`Workforce selection metadata for ${intent} failed: ${errorMessage(error)}`);
+      const retry = retryWithoutInstallRoot(error, options);
+      if (retry) {
+        warnings.push(retry.warning);
+        try {
+          const selectionModule = await loadSelectionModule();
+          warnings.push(...selectionModule.warnings);
+          const context = selectionModule.module.usePersona(intent, metadataSelectionOptions(options));
+          if (isUsablePersonaContext(context)) {
+            return {
+              source: selectionModule.source,
+              intent,
+              context,
+              warnings,
+            };
+          }
+          if (selectionFromPersonaResult(context)) {
+            warnings.push(`Workforce usePersona(${intent}) without installRoot resolved metadata but did not provide a runnable sendMessage API.`);
+            continue;
+          }
+          warnings.push(`Workforce usePersona(${intent}) without installRoot returned unusable selection metadata.`);
+        } catch (retryError) {
+          warnings.push(`Workforce usePersona(${intent}) without installRoot failed: ${errorMessage(retryError)}`);
+        }
+      } else {
+        warnings.push(`Workforce selection metadata for ${intent} failed: ${errorMessage(error)}`);
+      }
     }
   }
 
@@ -977,11 +1002,20 @@ function runnableSelectionOptions(
     : undefined;
 }
 
-function selectionOptions(
+function metadataSelectionOptions(
   options: { tier?: string; installRoot?: string },
 ): WorkforceSelectionOptions | undefined {
   const resolved: WorkforceSelectionOptions = {};
   if (options.tier) resolved.tier = options.tier;
+  return Object.keys(resolved).length > 0 ? resolved : undefined;
+}
+
+function runnableSelectionFallbackOptions(
+  options: { tier?: string; installRoot?: string },
+): WorkforceSelectionOptions | undefined {
+  const resolved: WorkforceSelectionOptions = {};
+  if (options.tier) resolved.tier = options.tier;
+  if (options.installRoot) resolved.installRoot = options.installRoot;
   return Object.keys(resolved).length > 0 ? resolved : undefined;
 }
 


### PR DESCRIPTION
## Summary
- stop forcing Workforce workflow authoring to the best tier so router defaults can choose the faster best-value persona
- avoid passing installRoot into metadata-only selection, while preserving runnable Claude installRoot handling
- add regression coverage for router-selected writer tier and selection options

## Tests
- npm test -- --run src/product/generation/workforce-persona-writer.test.ts
- npm run typecheck