### PR TITLE
chore(deps): bump agent-relay SDK and workforce harness deps to latest

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,10 +10,10 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@agent-assistant/turn-context": "^0.4.31",
-        "@agent-relay/cloud": "^6.0.6",
-        "@agent-relay/sdk": "^6.0.6",
-        "@agentworkforce/harness-kit": "^0.6.1",
-        "@agentworkforce/workload-router": "^0.6.1",
+        "@agent-relay/cloud": "^6.0.13",
+        "@agent-relay/sdk": "^6.0.13",
+        "@agentworkforce/harness-kit": "^0.19.0",
+        "@agentworkforce/workload-router": "^0.19.0",
         "@inquirer/prompts": "^8.4.2",
         "ora": "^8.2.0",
         "ssh2": "^1.17.0"
@@ -751,9 +751,9 @@
       "license": "MIT"
     },
     "node_modules/@agent-relay/broker-darwin-arm64": {
-      "version": "6.0.6",
-      "resolved": "https://registry.npmjs.org/@agent-relay/broker-darwin-arm64/-/broker-darwin-arm64-6.0.6.tgz",
-      "integrity": "sha512-o3JdeDefhYcRmUSRE0BkOaaLuK+3nMwDJ6JBsJ92+2o9FHwyfXBezXFVtDaL956OdFGzxUilY/0cPxdGiWM52Q==",
+      "version": "6.0.13",
+      "resolved": "https://registry.npmjs.org/@agent-relay/broker-darwin-arm64/-/broker-darwin-arm64-6.0.13.tgz",
+      "integrity": "sha512-W/R3z/bmqups1/uYK9AlfM6TSrtfZLjE1N3GC586CteWVj0+5q9RGMRbrLDP3oJyjBPQANSyvIitzpiqmlniRQ==",
       "cpu": [
         "arm64"
       ],
@@ -764,9 +764,9 @@
       ]
     },
     "node_modules/@agent-relay/broker-darwin-x64": {
-      "version": "6.0.6",
-      "resolved": "https://registry.npmjs.org/@agent-relay/broker-darwin-x64/-/broker-darwin-x64-6.0.6.tgz",
-      "integrity": "sha512-opi0j+4tWpWUmgzGig4fwNU1cvUXP/Gru1NNKJYxUT8hr7MgWPenOsgpVzLgrtJFYDwLHgIWole4TVnVP9BinA==",
+      "version": "6.0.13",
+      "resolved": "https://registry.npmjs.org/@agent-relay/broker-darwin-x64/-/broker-darwin-x64-6.0.13.tgz",
+      "integrity": "sha512-Ty6rbja1l4jVSlG7aLNWYVx23CftsVZtm6t8pxkN7EzxK6uGLpGZNIUNlykp9BSA7GsaarnbIk2bxT9Csg0oNw==",
       "cpu": [
         "x64"
       ],
@@ -777,9 +777,9 @@
       ]
     },
     "node_modules/@agent-relay/broker-linux-arm64": {
-      "version": "6.0.6",
-      "resolved": "https://registry.npmjs.org/@agent-relay/broker-linux-arm64/-/broker-linux-arm64-6.0.6.tgz",
-      "integrity": "sha512-EtjW+4+bt+jdb6mNC6gHV0CWVe7euIAPTBiW+kCf2/Ilm9/8PQWJaJIydaAmhJTYDUsB5tp+Zali7Au0EfS+LA==",
+      "version": "6.0.13",
+      "resolved": "https://registry.npmjs.org/@agent-relay/broker-linux-arm64/-/broker-linux-arm64-6.0.13.tgz",
+      "integrity": "sha512-EMnokAS8rekBq58rEforPt3Jd1CGanDUJ5tfi0+auzOBtRt1U97HdkGC0FF+L3tSZyMXZqLSZInpxBbzuyn7rQ==",
       "cpu": [
         "arm64"
       ],
@@ -790,9 +790,9 @@
       ]
     },
     "node_modules/@agent-relay/broker-linux-x64": {
-      "version": "6.0.6",
-      "resolved": "https://registry.npmjs.org/@agent-relay/broker-linux-x64/-/broker-linux-x64-6.0.6.tgz",
-      "integrity": "sha512-XnGED/5MXeElW0VRFCFjBFHW7zPupTJ1uT0F69znbBzs9zHMYmMc3o+KYCCA4vQYYCaNDDBvpm+xEGt9P6WKAQ==",
+      "version": "6.0.13",
+      "resolved": "https://registry.npmjs.org/@agent-relay/broker-linux-x64/-/broker-linux-x64-6.0.13.tgz",
+      "integrity": "sha512-f9Yly4ixuoIVdG9IeMnCjzp6pvq9/jT4nhPJFgx6YPjCXsslNUzc4pbZmWvrKp+3FkNJGDXhF+h1aDZJTHC41w==",
       "cpu": [
         "x64"
       ],
@@ -803,9 +803,9 @@
       ]
     },
     "node_modules/@agent-relay/broker-win32-x64": {
-      "version": "6.0.6",
-      "resolved": "https://registry.npmjs.org/@agent-relay/broker-win32-x64/-/broker-win32-x64-6.0.6.tgz",
-      "integrity": "sha512-Lu4UZJTBMJz+1EhXxqn1RQU4Ta0i8u9Hcpwt0RzOLSh3Cc+QVyRrI93gbaTgrpMgDtjRBxJ66zRhvEjyNA8bow==",
+      "version": "6.0.13",
+      "resolved": "https://registry.npmjs.org/@agent-relay/broker-win32-x64/-/broker-win32-x64-6.0.13.tgz",
+      "integrity": "sha512-sDo5xHgWGnKo8bOUo1DGKGYErbxCd5+OWFmuDFhVjzAwMYgCKDH90G6RTrY19ZVWQXxHYtjtDEHhp5s/dzILXw==",
       "cpu": [
         "x64"
       ],
@@ -816,11 +816,11 @@
       ]
     },
     "node_modules/@agent-relay/cloud": {
-      "version": "6.0.6",
-      "resolved": "https://registry.npmjs.org/@agent-relay/cloud/-/cloud-6.0.6.tgz",
-      "integrity": "sha512-pZjzqukaAp5BCH6NxuICqfG5sH+F+kyEQym3ZA6LpUmwrV7HdLwoUSAh/iHcPFvO520JEA4UvCehWMCJJFpNgw==",
+      "version": "6.0.13",
+      "resolved": "https://registry.npmjs.org/@agent-relay/cloud/-/cloud-6.0.13.tgz",
+      "integrity": "sha512-kpp/F9WT8TxlSQETXcdX0q4aWLyxy7b+EbXcgBWIJE2SQbvkAX/FlafJe1BIJz4w1BFyzeJi+ykCu5QK/CBqqA==",
       "dependencies": {
-        "@agent-relay/config": "6.0.6",
+        "@agent-relay/config": "6.0.13",
         "@aws-sdk/client-s3": "3.1020.0",
         "ignore": "^7.0.5",
         "tar": "^7.5.10"
@@ -830,20 +830,20 @@
       }
     },
     "node_modules/@agent-relay/config": {
-      "version": "6.0.6",
-      "resolved": "https://registry.npmjs.org/@agent-relay/config/-/config-6.0.6.tgz",
-      "integrity": "sha512-gQe6eHGdh5lG3lCHEPUs2J9E5QUHy5O5CkXfSZgO0rAd2QWE55H0dRKwJ1CFnkYBcgYr4+3QtIPPZBKpkqnfGA==",
+      "version": "6.0.13",
+      "resolved": "https://registry.npmjs.org/@agent-relay/config/-/config-6.0.13.tgz",
+      "integrity": "sha512-4ycp7teSuoIG7Nh/hRHS1W1eiYUjl6tjwRWeCiyNKIJpnsclr/dXXMNpPrH4UJ5N4zeMmF5gpFDRbCz3V9xv5A==",
       "dependencies": {
         "zod": "^3.23.8",
         "zod-to-json-schema": "^3.23.1"
       }
     },
     "node_modules/@agent-relay/github-primitive": {
-      "version": "6.0.6",
-      "resolved": "https://registry.npmjs.org/@agent-relay/github-primitive/-/github-primitive-6.0.6.tgz",
-      "integrity": "sha512-2t5W3vdjsaIrKhxHN/ilQKtmQuE5sq8GnetquECJGbC9fxSVRYhwe2xCiDaYh1R0u7xCEFrcmFjEdLd8ju0mvA==",
+      "version": "6.0.13",
+      "resolved": "https://registry.npmjs.org/@agent-relay/github-primitive/-/github-primitive-6.0.13.tgz",
+      "integrity": "sha512-a41y2mzszBEI+ZUQWPTZAjZvAK+aReov2GBG6FUjKpCN2Fx5qhBD4Q+2Oikb7k05q9UGDqTrBFBqnXRE2F/WEg==",
       "dependencies": {
-        "@agent-relay/workflow-types": "6.0.6"
+        "@agent-relay/workflow-types": "6.0.13"
       }
     },
     "node_modules/@agent-relay/hooks": {
@@ -928,13 +928,16 @@
       }
     },
     "node_modules/@agent-relay/sdk": {
-      "version": "6.0.6",
-      "resolved": "https://registry.npmjs.org/@agent-relay/sdk/-/sdk-6.0.6.tgz",
-      "integrity": "sha512-B/FjRCDG/RBWeLZQmHYE2bcG7C4S9DJDnNTBfCAuzQiKbHBB4IebwvrOky0UIuSVjpGRVObAXf8KoiiYqbhBRg==",
+      "version": "6.0.13",
+      "resolved": "https://registry.npmjs.org/@agent-relay/sdk/-/sdk-6.0.13.tgz",
+      "integrity": "sha512-+9G4b9V/kuFzwDdcupcoYuXAjCK/wwI/Tn0mfqyFu4rYZj+K8Xan/xkY7psCVdKC2TPNNw31QZsPI4wAQD/rSQ==",
       "dependencies": {
-        "@agent-relay/config": "6.0.6",
-        "@agent-relay/github-primitive": "6.0.6",
-        "@agent-relay/workflow-types": "6.0.6",
+        "@agent-relay/config": "6.0.13",
+        "@agent-relay/github-primitive": "6.0.13",
+        "@agent-relay/slack-primitive": "6.0.13",
+        "@agent-relay/workflow-types": "6.0.13",
+        "@agentworkforce/harness-kit": "^0.11.0",
+        "@agentworkforce/workload-router": "^0.11.0",
         "@relaycast/sdk": "^1.1.0",
         "@relayfile/sdk": ">=0.1.2 <1",
         "@sinclair/typebox": "^0.34.48",
@@ -947,14 +950,14 @@
         "yaml": "^2.7.0"
       },
       "optionalDependencies": {
-        "@agent-relay/broker-darwin-arm64": "6.0.6",
-        "@agent-relay/broker-darwin-x64": "6.0.6",
-        "@agent-relay/broker-linux-arm64": "6.0.6",
-        "@agent-relay/broker-linux-x64": "6.0.6",
-        "@agent-relay/broker-win32-x64": "6.0.6"
+        "@agent-relay/broker-darwin-arm64": "6.0.13",
+        "@agent-relay/broker-darwin-x64": "6.0.13",
+        "@agent-relay/broker-linux-arm64": "6.0.13",
+        "@agent-relay/broker-linux-x64": "6.0.13",
+        "@agent-relay/broker-win32-x64": "6.0.13"
       },
       "peerDependencies": {
-        "@agent-relay/credential-proxy": "6.0.6",
+        "@agent-relay/credential-proxy": "6.0.13",
         "@anthropic-ai/claude-agent-sdk": ">=0.1.0",
         "@google/adk": ">=0.5.0",
         "@langchain/langgraph": ">=1.2.0",
@@ -990,6 +993,28 @@
         }
       }
     },
+    "node_modules/@agent-relay/sdk/node_modules/@agentworkforce/harness-kit": {
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/@agentworkforce/harness-kit/-/harness-kit-0.11.0.tgz",
+      "integrity": "sha512-CtW9P0pVm0j5R+kl7OaWMkPz7akYZqJNLmQ8k1m5Ony7NIfxJKuGiTBH9kcg+6vQ7fUtnfkoa34wt3y/pEh2QQ==",
+      "dependencies": {
+        "@agentworkforce/workload-router": "0.11.0"
+      }
+    },
+    "node_modules/@agent-relay/sdk/node_modules/@agentworkforce/workload-router": {
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/@agentworkforce/workload-router/-/workload-router-0.11.0.tgz",
+      "integrity": "sha512-6Fn4oDsYeNRPe+k7hVfS3Ae3yIocNjuvscVvRswn74CzxSC1X9+1wDhQ5eCvE+S1m1ixAjYGFC9/MNwuhFwjHw=="
+    },
+    "node_modules/@agent-relay/slack-primitive": {
+      "version": "6.0.13",
+      "resolved": "https://registry.npmjs.org/@agent-relay/slack-primitive/-/slack-primitive-6.0.13.tgz",
+      "integrity": "sha512-eJs4UzDDTT84Gh65Wg+WkpAaPIWJcHHg4WBMfkqBWam98aFCZHdJZkxLGkvoHFuiF2b1EDTfhOrkU3+88oNsgw==",
+      "dependencies": {
+        "@agent-relay/workflow-types": "6.0.13",
+        "@slack/web-api": "^7.15.2"
+      }
+    },
     "node_modules/@agent-relay/trajectory": {
       "version": "4.0.40",
       "resolved": "https://registry.npmjs.org/@agent-relay/trajectory/-/trajectory-4.0.40.tgz",
@@ -1008,22 +1033,22 @@
       }
     },
     "node_modules/@agent-relay/workflow-types": {
-      "version": "6.0.6",
-      "resolved": "https://registry.npmjs.org/@agent-relay/workflow-types/-/workflow-types-6.0.6.tgz",
-      "integrity": "sha512-Fu2GJWkIiSUxXawhk9SW+btDz5WDzI6RGKyugG12+wm4CDJ4rnDY9Xg8FGDugzOHL8EasWFvtF6pztZTzjJOSQ=="
+      "version": "6.0.13",
+      "resolved": "https://registry.npmjs.org/@agent-relay/workflow-types/-/workflow-types-6.0.13.tgz",
+      "integrity": "sha512-uOtCFDpRTZwhCM+KtcPZq/isiEIIrOO52BCsCU1Bh/XPbh7UjwT/pzp9OqypeDl8Q5cREooVo3NgV58BfrZawg=="
     },
     "node_modules/@agentworkforce/harness-kit": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/@agentworkforce/harness-kit/-/harness-kit-0.6.1.tgz",
-      "integrity": "sha512-Lcoj/9ZrmOenJowhAM0gUWWtnfcHgP/cwPnkiiXi1cQN0O69BD7v6EqiHWLerebqlLTwTOG0JWzerOj7Nlwgcw==",
+      "version": "0.19.0",
+      "resolved": "https://registry.npmjs.org/@agentworkforce/harness-kit/-/harness-kit-0.19.0.tgz",
+      "integrity": "sha512-5QuZ7XzzFDImibL7Pad7avnJCKygkoIoJHZN7OezeUK9xBLbm8jlEIOFPcumrqY+x3IJ2vM2KpX8Qvhti19Gtg==",
       "dependencies": {
-        "@agentworkforce/workload-router": "0.6.1"
+        "@agentworkforce/workload-router": "0.19.0"
       }
     },
     "node_modules/@agentworkforce/workload-router": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/@agentworkforce/workload-router/-/workload-router-0.6.1.tgz",
-      "integrity": "sha512-9IziwGVleJwDfL2Z2LlvtN61RaxnGaCZhUVfbxSPS/U5xNDY1S2iC/VKnlasmhYBBW5iy8nsO/755pT19+8O0Q=="
+      "version": "0.19.0",
+      "resolved": "https://registry.npmjs.org/@agentworkforce/workload-router/-/workload-router-0.19.0.tgz",
+      "integrity": "sha512-nch4WYp+xeT0lbLd3HUWOUZE/MH1q0eHkaRbmkh8C1ag7RtFsOviRCjJMCWPAonT9QqZA71PlfO4ywhahdJSDQ=="
     },
     "node_modules/@aws-crypto/crc32": {
       "version": "5.2.0",
@@ -1906,6 +1931,7 @@
     },
     "node_modules/@clack/prompts/node_modules/is-unicode-supported": {
       "version": "1.3.0",
+      "extraneous": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -3128,6 +3154,53 @@
       "integrity": "sha512-brySQQs7Jtn0joV8Xh9ZV/hZb9Ozb0pmazDIASBkYKCjXrXU3mpcFahmK/z4YDhGkQvP9mWJbVyahdtU5wQA+A==",
       "license": "MIT"
     },
+    "node_modules/@slack/logger": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@slack/logger/-/logger-4.0.1.tgz",
+      "integrity": "sha512-6cmdPrV/RYfd2U0mDGiMK8S7OJqpCTm7enMLRR3edccsPX8j7zXTLnaEF4fhxxJJTAIOil6+qZrnUPTuaLvwrQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": ">=18"
+      },
+      "engines": {
+        "node": ">= 18",
+        "npm": ">= 8.6.0"
+      }
+    },
+    "node_modules/@slack/types": {
+      "version": "2.21.1",
+      "resolved": "https://registry.npmjs.org/@slack/types/-/types-2.21.1.tgz",
+      "integrity": "sha512-I8vmSjNYWsaxuWPx6dz4yeh0h7vRBWbgAMK14LEmblbZ404BtrPbXs6jDPx4cYgGf8msDGF4A9opLZBu21FViQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12.13.0",
+        "npm": ">= 6.12.0"
+      }
+    },
+    "node_modules/@slack/web-api": {
+      "version": "7.15.2",
+      "resolved": "https://registry.npmjs.org/@slack/web-api/-/web-api-7.15.2.tgz",
+      "integrity": "sha512-/m9qVFkiq85Oa/FSQwYIRDa/AO4qNYkDh4sRBK1WqEc2+RyG7w4tbU6rBIwUOcc/TmWOIr24Nraquxg7um5mYw==",
+      "license": "MIT",
+      "dependencies": {
+        "@slack/logger": "^4.0.1",
+        "@slack/types": "^2.21.0",
+        "@types/node": ">=18",
+        "@types/retry": "0.12.0",
+        "axios": "^1.15.0",
+        "eventemitter3": "^5.0.1",
+        "form-data": "^4.0.4",
+        "is-electron": "2.2.2",
+        "is-stream": "^2",
+        "p-queue": "^6",
+        "p-retry": "^4",
+        "retry": "^0.13.1"
+      },
+      "engines": {
+        "node": ">= 18",
+        "npm": ">= 8.6.0"
+      }
+    },
     "node_modules/@smithy/chunked-blob-reader": {
       "version": "5.2.2",
       "resolved": "https://registry.npmjs.org/@smithy/chunked-blob-reader/-/chunked-blob-reader-5.2.2.tgz",
@@ -3876,11 +3949,16 @@
       "version": "24.12.2",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-24.12.2.tgz",
       "integrity": "sha512-A1sre26ke7HDIuY/M23nd9gfB+nrmhtYyMINbjI1zHJxYteKR6qSMX56FsmjMcDb3SMcjJg5BiRRgOCC/yBD0g==",
-      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "undici-types": "~7.16.0"
       }
+    },
+    "node_modules/@types/retry": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/@types/retry/-/retry-0.12.0.tgz",
+      "integrity": "sha512-wWKOClTTiizcZhXnPY4wikVAwmdYHp8q6DmC+EJUzAMsycb7HB32Kh9RN4+0gExjmPmZSAQjgURXIGATPegAvA==",
+      "license": "MIT"
     },
     "node_modules/@vitest/expect": {
       "version": "3.2.4",
@@ -4075,6 +4153,23 @@
         "node": ">=12"
       }
     },
+    "node_modules/asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
+      "license": "MIT"
+    },
+    "node_modules/axios": {
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.16.0.tgz",
+      "integrity": "sha512-6hp5CwvTPlN2A31g5dxnwAX0orzM7pmCRDLnZSX772mv8WDqICwFjowHuPs04Mc8deIld1+ejhtaMn5vp6b+1w==",
+      "license": "MIT",
+      "dependencies": {
+        "follow-redirects": "^1.16.0",
+        "form-data": "^4.0.5",
+        "proxy-from-env": "^2.1.0"
+      }
+    },
     "node_modules/bcrypt-pbkdf": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz",
@@ -4107,6 +4202,19 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/chai": {
@@ -4237,6 +4345,18 @@
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
       "license": "MIT"
     },
+    "node_modules/combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "license": "MIT",
+      "dependencies": {
+        "delayed-stream": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/commander": {
       "version": "12.1.0",
       "resolved": "https://registry.npmjs.org/commander/-/commander-12.1.0.tgz",
@@ -4288,6 +4408,29 @@
         "node": ">=6"
       }
     },
+    "node_modules/delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/emoji-regex": {
       "version": "10.6.0",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.6.0.tgz",
@@ -4306,12 +4449,57 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/es-module-lexer": {
       "version": "1.7.0",
       "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz",
       "integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
+      "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-set-tostringtag": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
+      "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.6",
+        "has-tostringtag": "^1.0.2",
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
     },
     "node_modules/esbuild": {
       "version": "0.28.0",
@@ -4459,6 +4647,42 @@
         }
       }
     },
+    "node_modules/follow-redirects": {
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.16.0.tgz",
+      "integrity": "sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/RubenVerborgh"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.0"
+      },
+      "peerDependenciesMeta": {
+        "debug": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/form-data": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.5.tgz",
+      "integrity": "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==",
+      "license": "MIT",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "es-set-tostringtag": "^2.1.0",
+        "hasown": "^2.0.2",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/fsevents": {
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
@@ -4474,6 +4698,15 @@
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/get-east-asian-width": {
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/get-east-asian-width/-/get-east-asian-width-1.5.0.tgz",
@@ -4484,6 +4717,43 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/get-tsconfig": {
@@ -4499,6 +4769,18 @@
         "url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
       }
     },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/has-flag": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
@@ -4506,6 +4788,45 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-tostringtag": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
+      "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
+      "license": "MIT",
+      "dependencies": {
+        "has-symbols": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.3.tgz",
+      "integrity": "sha512-ej4AhfhfL2Q2zpMmLo7U1Uv9+PyhIZpgQLGT1F9miIGmiCJIoCgSmczFdrc97mWT4kVY72KA+WnnhJ5pghSvSg==",
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/iconv-lite": {
@@ -4533,6 +4854,12 @@
         "node": ">= 4"
       }
     },
+    "node_modules/is-electron": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/is-electron/-/is-electron-2.2.2.tgz",
+      "integrity": "sha512-FO/Rhvz5tuw4MCWkpMzHFKWD2LsfHzIb7i6MdPYZ/KW7AlxawyLkqdy+jPZP1WubqEADE3O4FUENlJHDfQASRg==",
+      "license": "MIT"
+    },
     "node_modules/is-fullwidth-code-point": {
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-5.1.0.tgz",
@@ -4555,6 +4882,18 @@
       "license": "MIT",
       "engines": {
         "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/is-stream": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
+      "integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
@@ -4733,6 +5072,36 @@
         "@jridgewell/sourcemap-codec": "^1.5.5"
       }
     },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/mimic-function": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/mimic-function/-/mimic-function-5.0.1.tgz",
@@ -4875,6 +5244,62 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/p-finally": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz",
+      "integrity": "sha512-LICb2p9CB7FS+0eR1oqWnHhp0FljGLZCWBE9aix0Uye9W8LTQPwMTYVGWQWIw9RdQiDg4+epXQODwIYJtSJaow==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/p-queue": {
+      "version": "6.6.2",
+      "resolved": "https://registry.npmjs.org/p-queue/-/p-queue-6.6.2.tgz",
+      "integrity": "sha512-RwFpb72c/BhQLEXIZ5K2e+AhgNVmIejGlTgiB9MzZ0e93GRvqZ7uSi0dvRF7/XIXDeNkra2fNHBxTyPDGySpjQ==",
+      "license": "MIT",
+      "dependencies": {
+        "eventemitter3": "^4.0.4",
+        "p-timeout": "^3.2.0"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-queue/node_modules/eventemitter3": {
+      "version": "4.0.7",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.7.tgz",
+      "integrity": "sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw==",
+      "license": "MIT"
+    },
+    "node_modules/p-retry": {
+      "version": "4.6.2",
+      "resolved": "https://registry.npmjs.org/p-retry/-/p-retry-4.6.2.tgz",
+      "integrity": "sha512-312Id396EbJdvRONlngUx0NydfrIQ5lsYu0znKVUzVvArzEIt08V1qhtyESbGVd1FGX7UKtiFp5uwKZdM8wIuQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/retry": "0.12.0",
+        "retry": "^0.13.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/p-timeout": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/p-timeout/-/p-timeout-3.2.0.tgz",
+      "integrity": "sha512-rhIwUycgwwKcP9yTOOFK/AKsAopjjCakVqLHePO3CC6Mir1Z99xT+R63jZxAT5lFZLa2inS5h+ZS2GvR99/FBg==",
+      "license": "MIT",
+      "dependencies": {
+        "p-finally": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/path-expression-matcher": {
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/path-expression-matcher/-/path-expression-matcher-1.5.0.tgz",
@@ -4955,6 +5380,15 @@
         "node": "^10 || ^12 || >=14"
       }
     },
+    "node_modules/proxy-from-env": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-2.1.0.tgz",
+      "integrity": "sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/resolve-pkg-maps": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/resolve-pkg-maps/-/resolve-pkg-maps-1.0.0.tgz",
@@ -4979,6 +5413,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/retry": {
+      "version": "0.13.1",
+      "resolved": "https://registry.npmjs.org/retry/-/retry-0.13.1.tgz",
+      "integrity": "sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
       }
     },
     "node_modules/rfdc": {
@@ -5833,7 +6276,6 @@
       "version": "7.16.0",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.16.0.tgz",
       "integrity": "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==",
-      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/vite": {

--- a/package.json
+++ b/package.json
@@ -57,10 +57,10 @@
   },
   "dependencies": {
     "@agent-assistant/turn-context": "^0.4.31",
-    "@agent-relay/cloud": "^6.0.6",
-    "@agent-relay/sdk": "^6.0.6",
-    "@agentworkforce/harness-kit": "^0.6.1",
-    "@agentworkforce/workload-router": "^0.6.1",
+    "@agent-relay/cloud": "^6.0.13",
+    "@agent-relay/sdk": "^6.0.13",
+    "@agentworkforce/harness-kit": "^0.19.0",
+    "@agentworkforce/workload-router": "^0.19.0",
     "@inquirer/prompts": "^8.4.2",
     "ora": "^8.2.0",
     "ssh2": "^1.17.0"


### PR DESCRIPTION
## Summary
- Bumps `@agent-relay/sdk` and `@agent-relay/cloud` from `^6.0.6` → `^6.0.13` to pick up the latest SDK exports/properties.
- Bumps `@agentworkforce/harness-kit` and `@agentworkforce/workload-router` from `^0.6.1` → `^0.19.0` (the persona APIs Ricky consumes are unchanged).
- `@agent-assistant/turn-context` and `@agent-assistant/telemetry` already on the latest `^0.4.31`.

## Test plan
- [x] `npm install`
- [x] `npm run typecheck`
- [x] `npm run bundle`
- [x] `npx vitest run` — 1021 pass; 2 pre-existing `test/package-proof/package-layout-proof.test.ts` failures reproduce on `main` and are unrelated to this bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)