### PR TITLE
chore(ricky): bump DEFAULT_RUN_TIMEOUT_MS from 4h to 12h

### DIFF
--- a/src/shared/constants.ts
+++ b/src/shared/constants.ts
@@ -17,7 +17,7 @@ export const DEFAULT_MAX_CONCURRENCY = 4;
 // exceed the longest sequential path of per-step budgets below so that the
 // outer process killer never fires before per-step timeouts can do their job.
 // Per-step timeouts are the meaningful constraint; this is a safety net.
-export const DEFAULT_RUN_TIMEOUT_MS = 14_400_000; // 4 h
+export const DEFAULT_RUN_TIMEOUT_MS = 43_200_000; // 12 h
 
 export const DEFAULT_TIMEOUT_MS = DEFAULT_RUN_TIMEOUT_MS;
 


### PR DESCRIPTION
## Summary

Bumps the default outer wall-clock budget for an entire workflow run from 4h (`14_400_000` ms) to 12h (`43_200_000` ms).

## Why

Real multi-wave workflows (e.g. the relayfile mount-layout improvements workflow) have hit `STEP_TIMEOUT` at the 4h ceiling even though all implementation work had legitimately finished. Per-step timeouts are still the meaningful constraint here; the outer run timeout is a safety net that should not fire before the per-step timeouts can do their job. 12h gives realistic long-running workflows enough headroom.

Per-step constants (`DEFAULT_STEP_TIMEOUT_MS`, `DEFAULT_LEAD_PLAN_TIMEOUT_MS`, `DEFAULT_IMPLEMENT_TIMEOUT_MS`, `DEFAULT_REVIEW_TIMEOUT_MS`, `DEFAULT_FIX_LOOP_TIMEOUT_MS`) and per-workflow `.timeout(...)` overrides are intentionally untouched.

## Test plan

- [x] `npm test` (test counts unchanged vs. `origin/main`; the 3 pre-existing failures in `package-layout-proof` and `local-run-monitor` are unrelated to this change and reproduce on a clean checkout of `main`).
- [x] `git diff origin/main` is a single-line constant change in `src/shared/constants.ts`.