### PR TITLE
test: surface package proof failure details

### DIFF
--- a/test/package-proof/package-layout-proof.test.ts
+++ b/test/package-proof/package-layout-proof.test.ts
@@ -12,7 +12,7 @@ describe('Ricky package layout and npm-default proof', () => {
   it('all cases pass', () => {
     const summary = summarizePackageLayoutProof();
 
-    expect(summary.passed).toBe(true);
+    expect(summary.passed, formatPackageProofSummaryFailure(summary)).toBe(true);
     expect(summary.failures).toEqual([]);
   });
 
@@ -124,7 +124,7 @@ describe('Ricky package layout and npm-default proof', () => {
       const proofResult = evaluatePackageLayoutProofCase(name);
       const evidence = proofResult.evidence.join('\n');
 
-      expect(proofResult.passed).toBe(true);
+      expect(proofResult.passed, formatPackageProofCaseFailure(proofResult)).toBe(true);
       for (const expected of expectedEvidence) {
         expect(evidence).toContain(expected);
       }
@@ -146,3 +146,15 @@ describe('Ricky package layout and npm-default proof', () => {
     expect(elapsed).toBeLessThan(2000);
   });
 });
+
+function formatPackageProofSummaryFailure(summary: ReturnType<typeof summarizePackageLayoutProof>): string {
+  const failures = summary.failures.length > 0 ? summary.failures.join('\n') : '(none)';
+  const gaps = summary.gaps.length > 0 ? summary.gaps.join('\n') : '(none)';
+  return `Package layout proof failed.\nFailures:\n${failures}\nGaps:\n${gaps}`;
+}
+
+function formatPackageProofCaseFailure(proofResult: ReturnType<typeof evaluatePackageLayoutProofCase>): string {
+  const failures = proofResult.failures.length > 0 ? proofResult.failures.join('\n') : '(none)';
+  const evidence = proofResult.evidence.length > 0 ? proofResult.evidence.join('\n') : '(none)';
+  return `Package layout proof case failed: ${proofResult.name}\nFailures:\n${failures}\nEvidence:\n${evidence}`;
+}


### PR DESCRIPTION
## Summary
- Add assertion messages that include package proof summary failures and gaps.
- Add per-case package proof failure messages with failures and evidence.
- Keep the publish package proof actionable if future manifest/docs drift reaches CI.

## Context
The publish failure shown in the workflow log came from the package-script allowlist rejecting `evals:provider`. Latest `main` already contains the direct fix in `d76a9b4 fix(proofs): include provider eval script in package parity`; this PR is the follow-up diagnostic hardening so future publish proof failures name the exact failure instead of only reporting `expected false to be true`.

## Verification
- `npx vitest run test/package-proof/package-layout-proof.test.ts --reporter=verbose`
- `npm test`
- `npm run typecheck`