### PR TITLE
chore(deps): bump @agent-relay/sdk + @agent-relay/cloud to ^6.0.15

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,8 +10,8 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@agent-assistant/turn-context": "^0.4.31",
-        "@agent-relay/cloud": "^6.0.13",
-        "@agent-relay/sdk": "^6.0.13",
+        "@agent-relay/cloud": "^6.0.15",
+        "@agent-relay/sdk": "^6.0.15",
         "@agentworkforce/harness-kit": "^0.19.0",
         "@agentworkforce/workload-router": "^0.19.0",
         "@inquirer/prompts": "^8.4.2",
@@ -753,9 +753,9 @@
       "license": "MIT"
     },
     "node_modules/@agent-relay/broker-darwin-arm64": {
-      "version": "6.0.13",
-      "resolved": "https://registry.npmjs.org/@agent-relay/broker-darwin-arm64/-/broker-darwin-arm64-6.0.13.tgz",
-      "integrity": "sha512-W/R3z/bmqups1/uYK9AlfM6TSrtfZLjE1N3GC586CteWVj0+5q9RGMRbrLDP3oJyjBPQANSyvIitzpiqmlniRQ==",
+      "version": "6.0.15",
+      "resolved": "https://registry.npmjs.org/@agent-relay/broker-darwin-arm64/-/broker-darwin-arm64-6.0.15.tgz",
+      "integrity": "sha512-dlkh4DkUlJP65H9Xq1a43qdx8z2njqmujmFTtSbEG+iwKtDQ62kAboyBdpUFGQxUqv0CaRYtqK5Qc6erRR4lZA==",
       "cpu": [
         "arm64"
       ],
@@ -766,9 +766,9 @@
       ]
     },
     "node_modules/@agent-relay/broker-darwin-x64": {
-      "version": "6.0.13",
-      "resolved": "https://registry.npmjs.org/@agent-relay/broker-darwin-x64/-/broker-darwin-x64-6.0.13.tgz",
-      "integrity": "sha512-Ty6rbja1l4jVSlG7aLNWYVx23CftsVZtm6t8pxkN7EzxK6uGLpGZNIUNlykp9BSA7GsaarnbIk2bxT9Csg0oNw==",
+      "version": "6.0.15",
+      "resolved": "https://registry.npmjs.org/@agent-relay/broker-darwin-x64/-/broker-darwin-x64-6.0.15.tgz",
+      "integrity": "sha512-lAAosSd7lGhBdd+tQhCPAbjDCy/zxT2iPwxeKaLlE8iA1+EMcSt4W7jmxU1acn/ebqHiQuPdt+a+5x++UHuC3Q==",
       "cpu": [
         "x64"
       ],
@@ -779,9 +779,9 @@
       ]
     },
     "node_modules/@agent-relay/broker-linux-arm64": {
-      "version": "6.0.13",
-      "resolved": "https://registry.npmjs.org/@agent-relay/broker-linux-arm64/-/broker-linux-arm64-6.0.13.tgz",
-      "integrity": "sha512-EMnokAS8rekBq58rEforPt3Jd1CGanDUJ5tfi0+auzOBtRt1U97HdkGC0FF+L3tSZyMXZqLSZInpxBbzuyn7rQ==",
+      "version": "6.0.15",
+      "resolved": "https://registry.npmjs.org/@agent-relay/broker-linux-arm64/-/broker-linux-arm64-6.0.15.tgz",
+      "integrity": "sha512-xcnzupc7mj6a/cdgCW0nJMfYntNq6xPSdanaO/TRGHmpJYU+bvEdFn8x9wFDfaf45ZDVKEF5uCyWgiik9Wh63g==",
       "cpu": [
         "arm64"
       ],
@@ -792,9 +792,9 @@
       ]
     },
     "node_modules/@agent-relay/broker-linux-x64": {
-      "version": "6.0.13",
-      "resolved": "https://registry.npmjs.org/@agent-relay/broker-linux-x64/-/broker-linux-x64-6.0.13.tgz",
-      "integrity": "sha512-f9Yly4ixuoIVdG9IeMnCjzp6pvq9/jT4nhPJFgx6YPjCXsslNUzc4pbZmWvrKp+3FkNJGDXhF+h1aDZJTHC41w==",
+      "version": "6.0.15",
+      "resolved": "https://registry.npmjs.org/@agent-relay/broker-linux-x64/-/broker-linux-x64-6.0.15.tgz",
+      "integrity": "sha512-QqXWOtyyE090MExgYbqbhE1ddr1irEURwVgy/GlJZLConBW8D0/mLHyQK0F+nRJfNNXvuD3A4Pi/d4wA0v3lCg==",
       "cpu": [
         "x64"
       ],
@@ -805,9 +805,9 @@
       ]
     },
     "node_modules/@agent-relay/broker-win32-x64": {
-      "version": "6.0.13",
-      "resolved": "https://registry.npmjs.org/@agent-relay/broker-win32-x64/-/broker-win32-x64-6.0.13.tgz",
-      "integrity": "sha512-sDo5xHgWGnKo8bOUo1DGKGYErbxCd5+OWFmuDFhVjzAwMYgCKDH90G6RTrY19ZVWQXxHYtjtDEHhp5s/dzILXw==",
+      "version": "6.0.15",
+      "resolved": "https://registry.npmjs.org/@agent-relay/broker-win32-x64/-/broker-win32-x64-6.0.15.tgz",
+      "integrity": "sha512-6qcqPqfDiL/yt5gHIg9uOWCIR1vfgSATD16Bk/XnGsjC5IBHkeN7U38Sj2BHgrV5qxdHPTVikX62BDm2W9SKqQ==",
       "cpu": [
         "x64"
       ],
@@ -818,11 +818,11 @@
       ]
     },
     "node_modules/@agent-relay/cloud": {
-      "version": "6.0.13",
-      "resolved": "https://registry.npmjs.org/@agent-relay/cloud/-/cloud-6.0.13.tgz",
-      "integrity": "sha512-kpp/F9WT8TxlSQETXcdX0q4aWLyxy7b+EbXcgBWIJE2SQbvkAX/FlafJe1BIJz4w1BFyzeJi+ykCu5QK/CBqqA==",
+      "version": "6.0.15",
+      "resolved": "https://registry.npmjs.org/@agent-relay/cloud/-/cloud-6.0.15.tgz",
+      "integrity": "sha512-EeK/YN7oM15kzdF6vE/22WccuXCgmSA+0Nod3EiPo0vA8PH1rfY1oEWq4JphT5MFyHET3t5FPfmHM6uXVp1dow==",
       "dependencies": {
-        "@agent-relay/config": "6.0.13",
+        "@agent-relay/config": "6.0.15",
         "@aws-sdk/client-s3": "3.1020.0",
         "ignore": "^7.0.5",
         "tar": "^7.5.10"
@@ -832,20 +832,20 @@
       }
     },
     "node_modules/@agent-relay/config": {
-      "version": "6.0.13",
-      "resolved": "https://registry.npmjs.org/@agent-relay/config/-/config-6.0.13.tgz",
-      "integrity": "sha512-4ycp7teSuoIG7Nh/hRHS1W1eiYUjl6tjwRWeCiyNKIJpnsclr/dXXMNpPrH4UJ5N4zeMmF5gpFDRbCz3V9xv5A==",
+      "version": "6.0.15",
+      "resolved": "https://registry.npmjs.org/@agent-relay/config/-/config-6.0.15.tgz",
+      "integrity": "sha512-LRqCqAjJNU8kQ9PbcY+QTsluGlwFoCpk20bUFGgwyWo97vcXkVEsgt/6PY13j0yphOLfRj6s95GJ0OuxC6QTQw==",
       "dependencies": {
         "zod": "^3.23.8",
         "zod-to-json-schema": "^3.23.1"
       }
     },
     "node_modules/@agent-relay/github-primitive": {
-      "version": "6.0.13",
-      "resolved": "https://registry.npmjs.org/@agent-relay/github-primitive/-/github-primitive-6.0.13.tgz",
-      "integrity": "sha512-a41y2mzszBEI+ZUQWPTZAjZvAK+aReov2GBG6FUjKpCN2Fx5qhBD4Q+2Oikb7k05q9UGDqTrBFBqnXRE2F/WEg==",
+      "version": "6.0.15",
+      "resolved": "https://registry.npmjs.org/@agent-relay/github-primitive/-/github-primitive-6.0.15.tgz",
+      "integrity": "sha512-erW1uu1xNecv8Mie2dAgHpWFU39+3jVMWffgq2mgXUXkxdYyDZ1+nilmhCcnSHp8lJJjEu3a7F4Fwu6pwpF18A==",
       "dependencies": {
-        "@agent-relay/workflow-types": "6.0.13"
+        "@agent-relay/workflow-types": "6.0.15"
       }
     },
     "node_modules/@agent-relay/hooks": {
@@ -930,14 +930,15 @@
       }
     },
     "node_modules/@agent-relay/sdk": {
-      "version": "6.0.13",
-      "resolved": "https://registry.npmjs.org/@agent-relay/sdk/-/sdk-6.0.13.tgz",
-      "integrity": "sha512-+9G4b9V/kuFzwDdcupcoYuXAjCK/wwI/Tn0mfqyFu4rYZj+K8Xan/xkY7psCVdKC2TPNNw31QZsPI4wAQD/rSQ==",
+      "version": "6.0.15",
+      "resolved": "https://registry.npmjs.org/@agent-relay/sdk/-/sdk-6.0.15.tgz",
+      "integrity": "sha512-+CBEaA+r7I69Zh0L1s94NyKlRh+t4+mhCVxLsJWzTbgujMtp+yds6lr2KZZKoFPmXPXlD4y7nRkKwWDU1PA04A==",
       "dependencies": {
-        "@agent-relay/config": "6.0.13",
-        "@agent-relay/github-primitive": "6.0.13",
-        "@agent-relay/slack-primitive": "6.0.13",
-        "@agent-relay/workflow-types": "6.0.13",
+        "@agent-relay/cloud": "6.0.15",
+        "@agent-relay/config": "6.0.15",
+        "@agent-relay/github-primitive": "6.0.15",
+        "@agent-relay/slack-primitive": "6.0.15",
+        "@agent-relay/workflow-types": "6.0.15",
         "@agentworkforce/harness-kit": "^0.11.0",
         "@agentworkforce/workload-router": "^0.11.0",
         "@relaycast/sdk": "^1.1.0",
@@ -952,14 +953,14 @@
         "yaml": "^2.7.0"
       },
       "optionalDependencies": {
-        "@agent-relay/broker-darwin-arm64": "6.0.13",
-        "@agent-relay/broker-darwin-x64": "6.0.13",
-        "@agent-relay/broker-linux-arm64": "6.0.13",
-        "@agent-relay/broker-linux-x64": "6.0.13",
-        "@agent-relay/broker-win32-x64": "6.0.13"
+        "@agent-relay/broker-darwin-arm64": "6.0.15",
+        "@agent-relay/broker-darwin-x64": "6.0.15",
+        "@agent-relay/broker-linux-arm64": "6.0.15",
+        "@agent-relay/broker-linux-x64": "6.0.15",
+        "@agent-relay/broker-win32-x64": "6.0.15"
       },
       "peerDependencies": {
-        "@agent-relay/credential-proxy": "6.0.13",
+        "@agent-relay/credential-proxy": "6.0.15",
         "@anthropic-ai/claude-agent-sdk": ">=0.1.0",
         "@google/adk": ">=0.5.0",
         "@langchain/langgraph": ">=1.2.0",
@@ -1009,11 +1010,11 @@
       "integrity": "sha512-6Fn4oDsYeNRPe+k7hVfS3Ae3yIocNjuvscVvRswn74CzxSC1X9+1wDhQ5eCvE+S1m1ixAjYGFC9/MNwuhFwjHw=="
     },
     "node_modules/@agent-relay/slack-primitive": {
-      "version": "6.0.13",
-      "resolved": "https://registry.npmjs.org/@agent-relay/slack-primitive/-/slack-primitive-6.0.13.tgz",
-      "integrity": "sha512-eJs4UzDDTT84Gh65Wg+WkpAaPIWJcHHg4WBMfkqBWam98aFCZHdJZkxLGkvoHFuiF2b1EDTfhOrkU3+88oNsgw==",
+      "version": "6.0.15",
+      "resolved": "https://registry.npmjs.org/@agent-relay/slack-primitive/-/slack-primitive-6.0.15.tgz",
+      "integrity": "sha512-FrAond0P+mRpkcDqlsiMacySHbvjTVXqXxYMQSBKq/cmr9hwlKC9OqFbDAneYzKDpANcqPfup4siMNeesA8InA==",
       "dependencies": {
-        "@agent-relay/workflow-types": "6.0.13",
+        "@agent-relay/workflow-types": "6.0.15",
         "@slack/web-api": "^7.15.2"
       }
     },
@@ -1035,9 +1036,9 @@
       }
     },
     "node_modules/@agent-relay/workflow-types": {
-      "version": "6.0.13",
-      "resolved": "https://registry.npmjs.org/@agent-relay/workflow-types/-/workflow-types-6.0.13.tgz",
-      "integrity": "sha512-uOtCFDpRTZwhCM+KtcPZq/isiEIIrOO52BCsCU1Bh/XPbh7UjwT/pzp9OqypeDl8Q5cREooVo3NgV58BfrZawg=="
+      "version": "6.0.15",
+      "resolved": "https://registry.npmjs.org/@agent-relay/workflow-types/-/workflow-types-6.0.15.tgz",
+      "integrity": "sha512-CNNTb1rdFjOCBScxHe7S8fu/ifzBL/U+tcDFEs6jMC6TJpZ2ezJcrh3rOOY1pBScI/4/Fa6+OYVOH5Vt2OWNjQ=="
     },
     "node_modules/@agentworkforce/harness-kit": {
       "version": "0.19.0",
@@ -1933,7 +1934,6 @@
     },
     "node_modules/@clack/prompts/node_modules/is-unicode-supported": {
       "version": "1.3.0",
-      "extraneous": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {

--- a/package.json
+++ b/package.json
@@ -57,8 +57,8 @@
   },
   "dependencies": {
     "@agent-assistant/turn-context": "^0.4.31",
-    "@agent-relay/cloud": "^6.0.13",
-    "@agent-relay/sdk": "^6.0.13",
+    "@agent-relay/cloud": "^6.0.15",
+    "@agent-relay/sdk": "^6.0.15",
     "@agentworkforce/harness-kit": "^0.19.0",
     "@agentworkforce/workload-router": "^0.19.0",
     "@inquirer/prompts": "^8.4.2",


### PR DESCRIPTION
## Summary
Pulls in [agent-relay/relay#838](https://github.com/AgentWorkforce/relay/pull/838) (\"Drain broker stdout after SDK startup\") — the upstream/root fix for the broker pipe-buffer deadlock that's been wedging overnight runs of the proactive-runtime workflows.

## Why
Ricky 0.1.46 vendors `@agent-relay/sdk@6.0.14`, which still does **not** contain the drain fix (`grep drainBrokerStdoutAfterStartup dist/client.js` → 0 matches in 6.0.14, 2 matches in 6.0.15). Because Ricky's loader (#92) redirects every `@agent-relay/sdk*` import to its bundled copy, the SDK actually used at workflow runtime is Ricky's vendored version — so bumping the SDK in consumer repos alone has no effect.

## Reproducer symptom (without this bump)
After M1's `lead-coordinate` fans out to 9 PTY workers, every worker's log freezes within seconds of each other, broker process parks in `write()` (or `_pthread_cond_wait` once enough events queue waiting for backpressure to clear), and the workflow node's `step.run` awaits a drain signal that never arrives. Two diagnostic captures (`~/wedge-92b45d3e-diag/` and `~/wedge-c9600674-diag/`, ~14h apart on independent runs) showed the same freeze-at-fanout shape.

PR #94 shipped a loader-level unblocker; this bump brings in the proper upstream SDK fix so the runtime SDK that workflows execute against finally contains the drain.

## What changed
- `package.json`
  - `@agent-relay/cloud`: `^6.0.13` → `^6.0.15`
  - `@agent-relay/sdk`: `^6.0.13` → `^6.0.15`
- `package-lock.json` — regenerated via `npm install` (52 lines added / 52 removed; version bumps + integrity hashes for the relay packages, no transitive surface changes).

## Verification
- [x] `npm run typecheck` — clean
- [x] `npm run build` — externals unchanged
- [x] `npm test` — 1075 / 1075 pass, including the existing `\"drains broker stdout after SDK startup so event floods cannot wedge the workflow node\"` regression in `src/local/entrypoint.test.ts`