### PR TITLE
fix(loader): drain broker stdout on spawn (was wired to 'pause' which never fires)

### DIFF
--- a/src/local/entrypoint.ts
+++ b/src/local/entrypoint.ts
@@ -979,9 +979,15 @@ async function workflowSdkLoaderNodeOption(cwd: string): Promise<string | undefi
   await mkdir(dirname(loaderPath), { recursive: true });
   await writeFile(loaderPath, loaderSource, 'utf8');
   // The SDK reads broker stdout just long enough to parse the startup URL.
-  // Once readline closes, the stream can pause and a chatty broker can block
-  // writing events into the full pipe. Patch spawn in the workflow process so
-  // only managed agent-relay-broker init children are resumed after that pause.
+  // Once readline detaches its 'data' listener, the stream falls back to
+  // paused mode and libuv stops draining the kernel pipe; a chatty broker
+  // then blocks in write() once the OS pipe buffer fills. Patch spawn in the
+  // workflow process so every managed agent-relay-broker child (init AND
+  // pty workers) has a no-op data listener attached and is resumed
+  // immediately, keeping the stream in flowing mode for the lifetime of the
+  // broker. Prior versions hooked the 'pause' event instead, which Node's
+  // Readable never emits for internal buffer fills — only when something
+  // explicitly calls .pause() — so the workaround never fired.
   const registerSource = [
     'import{createRequire,register,syncBuiltinESMExports}from"node:module";',
     'import{pathToFileURL}from"node:url";',
@@ -994,13 +1000,15 @@ async function workflowSdkLoaderNodeOption(cwd: string): Promise<string | undefi
     'const child=originalSpawn.apply(this,arguments);',
     'const argv=Array.isArray(args)?args.map(String):[];',
     'const executable=String(command??"");',
-    'if(argv[0]==="init"&&/(?:^|[/\\\\])agent-relay-broker(?:\\.exe)?$/u.test(executable)&&child.stdout){',
-    'const drainBrokerStdout=()=>{',
-    'child.stdout?.off("pause",drainBrokerStdout);',
-    'child.stdout?.on("data",()=>{});',
-    'child.stdout?.resume();',
-    '};',
-    'child.stdout.on("pause",drainBrokerStdout);',
+    'if((argv[0]==="init"||argv[0]==="pty")&&/(?:^|[/\\\\])agent-relay-broker(?:\\.exe)?$/u.test(executable)&&child.stdout){',
+    // Attach the data listener immediately so the stream enters flowing mode
+    // and libuv keeps draining the kernel pipe. The previous `on("pause", ...)`
+    // hook never fired — Node `Readable` only emits `'pause'` when something
+    // explicitly calls `.pause()`, which nothing does in this code path, so the
+    // stream stayed in paused mode and the broker eventually blocked in
+    // `write()` when the OS pipe buffer filled.
+    'child.stdout.on("data",()=>{});',
+    'child.stdout.resume();',
     '}',
     'return child;',
     '};',


### PR DESCRIPTION
## Summary
The loader's `NODE_OPTIONS` register script monkeypatches `child_process.spawn` so that `agent-relay-broker` children have their stdout drained — preventing the broker from blocking in `write()` once the OS pipe buffer fills. **The previous wiring was a no-op:** it hooked the stream's `'pause'` event, which Node's `Readable` streams **never emit on internal buffer fill** — `'pause'` only fires when something explicitly calls `.pause()`, which nothing in this code path does. The stream stayed in paused mode, libuv stopped draining the kernel pipe at the high-water mark, and a chatty broker would block in `write()` once ~64KB queued up.

## Symptom
Overnight `proactive-runtime-m1` runs (Ricky-driven, M1 fans out to 9 PTY workers) froze within seconds of fanout with every worker log stuck at the same mtime, broker process parked in `write()` or `_pthread_cond_wait`, M1's `step.run` awaiting a never-arriving drain signal. Reproduced **twice ~14 hours apart on independent runs**, with diagnostic bundles capturing the same freeze-at-fanout shape both times.

## Root cause (decoded from the running NODE_OPTIONS)
```js
// Previous (broken):
const drainBrokerStdout = () => {
  child.stdout?.off(\"pause\", drainBrokerStdout);
  child.stdout?.on(\"data\", () => {});
  child.stdout?.resume();
};
child.stdout.on(\"pause\", drainBrokerStdout);   // ← never fires
```

vs. what SDK 6.0.15's `drainBrokerStdoutAfterStartup` (relay#838) does for direct SDK consumers:
```js
child.stdout.on('data', () => {});
child.stdout.resume();
```

## What changed (\`src/local/entrypoint.ts\`)
1. **Attach `data` listener and `resume()` synchronously at spawn time.** No more waiting on `'pause'`. Stream goes into flowing mode at birth and stays there for the lifetime of the broker.
2. **Expand argv guard from `argv[0]===\"init\"` to also include `\"pty\"`.** M1 spawns one `init` broker (channel multiplexer) plus one `pty` broker per worker (1 lead + 9 impl-* workers). All of them write events back through stdout. Covering only `init` left the PTY brokers vulnerable.
3. **Updated the comment block** above `registerSource` to capture the new semantics and the prior bug.

## Verification
- [x] `npm run typecheck` — clean
- [x] `npm test` — **1077 / 1077 pass**, including the existing `\"drains broker stdout after SDK startup so event floods cannot wedge the workflow node\"` regression at `entrypoint.test.ts:3122` (which previously passed only because the bundled SDK 6.0.15 has its own drain — this fix makes the loader-level protection actually do what it advertises for consumers still on older SDKs).

## Related
- relay#838 — upstream/root drain in `@agent-relay/sdk@6.0.15`
- ricky#94 — original loader-level unblocker (introduced the broken `'pause'` wiring)
- ricky#96 — earlier bump to bundle SDK `^6.0.15` (necessary but not sufficient when consumers have their own local SDK pin)