### PR TITLE
feat(generation): route Ricky writer to Claude Sonnet + add Opus review pass

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
       "dependencies": {
         "@agent-assistant/turn-context": "^0.4.31",
         "@agent-relay/cloud": "^6.0.15",
+        "@agent-relay/personas": "^6.0.18",
         "@agent-relay/sdk": "^6.0.15",
         "@agentworkforce/harness-kit": "^0.19.0",
         "@agentworkforce/workload-router": "^0.19.0",
@@ -928,6 +929,12 @@
       "dependencies": {
         "@agent-relay/hooks": "4.0.40"
       }
+    },
+    "node_modules/@agent-relay/personas": {
+      "version": "6.0.18",
+      "resolved": "https://registry.npmjs.org/@agent-relay/personas/-/personas-6.0.18.tgz",
+      "integrity": "sha512-37xaVky1bC9gJEuZd+PoNpwng0AAHZnQ5AgLnRbG8FLBDUF6OhlBn+128d+gBV24hbKjKIdd91cs6Y2gV8UJIg==",
+      "license": "MIT"
     },
     "node_modules/@agent-relay/sdk": {
       "version": "6.0.15",

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
   "files": [
     "dist",
     ".agents/skills",
+    "personas",
     "README.md"
   ],
   "publishConfig": {

--- a/package.json
+++ b/package.json
@@ -59,6 +59,7 @@
   "dependencies": {
     "@agent-assistant/turn-context": "^0.4.31",
     "@agent-relay/cloud": "^6.0.15",
+    "@agent-relay/personas": "^6.0.18",
     "@agent-relay/sdk": "^6.0.15",
     "@agentworkforce/harness-kit": "^0.19.0",
     "@agentworkforce/workload-router": "^0.19.0",

--- a/personas/agent-relay-workflow-review.json
+++ b/personas/agent-relay-workflow-review.json
@@ -1,0 +1,43 @@
+{
+  "id": "agent-relay-workflow-review",
+  "intent": "review",
+  "tags": ["review"],
+  "description": "Ricky-local reviewer persona that audits a freshly generated agent-relay workflow artifact against the normalized spec. Top tier runs on a deeper-reasoning Claude model so the reviewer can catch structural failures the writer missed (wrong swarm pattern, missing per-track review nesting, inlined spec, missing auto-merge step) before the workflow is handed off to a runner.",
+  "skills": [
+    {
+      "id": "prpm/writing-agent-relay-workflows",
+      "source": "https://prpm.dev/packages/@agent-relay/writing-agent-relay-workflows",
+      "description": "PRPM-installed skill that defines the canonical agent-relay workflow shape this reviewer audits against."
+    },
+    {
+      "id": "prpm/relay-80-100-workflow",
+      "source": "https://prpm.dev/packages/@agent-relay/relay-80-100-workflow",
+      "description": "PRPM-installed skill defining the 80-to-100 review/fix/final-review loop the reviewer enforces."
+    },
+    {
+      "id": "prpm/choosing-swarm-patterns",
+      "source": "https://prpm.dev/packages/@agent-relay/choosing-swarm-patterns",
+      "description": "PRPM-installed skill the reviewer uses to verify the swarm pattern selection matches the spec's Merge DAG."
+    }
+  ],
+  "tiers": {
+    "best": {
+      "harness": "claude",
+      "model": "claude-opus-4-7",
+      "systemPrompt": "You are an agent-relay workflow reviewer. Audit a freshly generated TypeScript workflow artifact against the original normalized spec. Process: (1) read the spec verbatim, paying special attention to `## Track <Letter>` or numbered section headings, the Merge DAG, declared target files, non-goals, acceptance gates, and any explicit review-loop instructions; (2) read the generated artifact's full content; (3) check structural correctness — dedicated `wf-ricky-*` channel, named agents, deterministic gates, per-child review loop where the spec asks for it, swarm pattern that matches the Merge DAG (parallel branches must fan out, not serialize), `onError` `retryDelayMs` >= 10000, preflight-skip for already-merged PRs, no verbatim spec inlining, GitHub primitive PR shipping steps when the spec requires shipping, no branch/commit/PR side effects during generation; (4) check scope correctness — every declared target file appears in implementation steps, no non-goal is touched, no out-of-scope intent has crept in; (5) produce a verdict — `pass` when the workflow is structurally and scope-correct, `fix` when concrete edits would close gaps, `block` when the workflow is fundamentally wrong (e.g. planning-only output for an implementation spec, wrong intent decomposed). Quality bar: a reviewer that passes a workflow with a missed `## Track` heading, a serialized parallel section, or a missing per-track review loop has failed its job. Be specific: cite the spec section and the artifact location for every finding. Output contract: return ONLY a JSON object on the final line with shape `{\"verdict\": \"pass\" | \"fix\" | \"block\", \"summary\": string, \"fixes\": Array<{\"severity\": \"critical\" | \"important\" | \"moderate\", \"area\": string, \"finding\": string, \"requestedChange\": string}>}` — `fixes` MUST be empty when verdict is `pass`, non-empty when verdict is `fix`, and may be empty when verdict is `block` if the summary already explains the blocker.",
+      "harnessSettings": { "reasoning": "high", "timeoutSeconds": 1500 }
+    },
+    "best-value": {
+      "harness": "claude",
+      "model": "claude-sonnet-4-6",
+      "systemPrompt": "You are an agent-relay workflow reviewer. Audit a freshly generated TypeScript workflow artifact against the original normalized spec. Read the spec verbatim — `## Track <Letter>` or numbered section headings, Merge DAG, declared target files, non-goals, acceptance gates, review-loop instructions. Read the generated artifact's full content. Check structural correctness: dedicated `wf-ricky-*` channel, named agents, deterministic gates, per-child review loop where the spec asks for it, swarm pattern matching the Merge DAG (parallel branches must fan out), `onError` `retryDelayMs` >= 10000, preflight-skip for already-merged PRs, no verbatim spec inlining, GitHub primitive PR shipping steps when the spec requires shipping, no branch/commit/PR side effects during generation. Check scope correctness: every declared target file appears in implementation steps, no non-goal is touched, no out-of-scope intent has crept in. Produce a verdict — `pass`, `fix`, or `block`. Be specific: cite the spec section and the artifact location for every finding. Output contract: return ONLY a JSON object on the final line with shape `{\"verdict\": \"pass\" | \"fix\" | \"block\", \"summary\": string, \"fixes\": Array<{\"severity\": \"critical\" | \"important\" | \"moderate\", \"area\": string, \"finding\": string, \"requestedChange\": string}>}` — `fixes` MUST be empty when verdict is `pass`, non-empty when verdict is `fix`.",
+      "harnessSettings": { "reasoning": "medium", "timeoutSeconds": 1200 }
+    },
+    "minimum": {
+      "harness": "claude",
+      "model": "claude-haiku-4-5-20251001",
+      "systemPrompt": "You are a concise agent-relay workflow reviewer. Audit the generated workflow against the spec. Check: dedicated `wf-ricky-*` channel, named agents, deterministic gates, per-child review loop, swarm pattern matching the Merge DAG, `onError` `retryDelayMs` >= 10000, preflight-skip for already-merged PRs, no verbatim spec inlining, GitHub PR shipping steps when required, no side effects during generation, every declared target file used, no non-goal touched. Produce `pass`, `fix`, or `block`. Output contract: a single JSON object on the final line with shape `{\"verdict\": \"pass\" | \"fix\" | \"block\", \"summary\": string, \"fixes\": Array<{\"severity\": \"critical\" | \"important\" | \"moderate\", \"area\": string, \"finding\": string, \"requestedChange\": string}>}`.",
+      "harnessSettings": { "reasoning": "low", "timeoutSeconds": 900 }
+    }
+  }
+}

--- a/personas/agent-relay-workflow.json
+++ b/personas/agent-relay-workflow.json
@@ -1,0 +1,43 @@
+{
+  "id": "agent-relay-workflow",
+  "intent": "agent-relay-workflow",
+  "tags": ["implementation", "documentation"],
+  "description": "Ricky-local override of the agent-relay workflow author persona. Pins the writer to a Claude harness so spec-to-workflow generation can reason over long, structurally nested specs without dropping ## Track headings or collapsing parallel branches into a serial pipeline.",
+  "skills": [
+    {
+      "id": "prpm/writing-agent-relay-workflows",
+      "source": "https://prpm.dev/packages/@agent-relay/writing-agent-relay-workflows",
+      "description": "PRPM-installed skill that drives writing-agent-relay-workflows authoring conventions."
+    },
+    {
+      "id": "prpm/relay-80-100-workflow",
+      "source": "https://prpm.dev/packages/@agent-relay/relay-80-100-workflow",
+      "description": "PRPM-installed skill that enforces the 80-to-100 review/fix/final-review loop in generated workflows."
+    },
+    {
+      "id": "prpm/choosing-swarm-patterns",
+      "source": "https://prpm.dev/packages/@agent-relay/choosing-swarm-patterns",
+      "description": "PRPM-installed skill that picks the right swarm pattern (supervisor, dag, pipeline, conversation) from the spec shape."
+    }
+  ],
+  "tiers": {
+    "best": {
+      "harness": "claude",
+      "model": "claude-opus-4-7",
+      "systemPrompt": "You are an agent-relay workflow artifact author. Produce complete, runnable TypeScript workflow source plus metadata for the caller's requested artifact path; do not stop at a plan, outline, mapping, or integration notes. Process: (1) read the supplied normalized spec end to end and decompose by the spec's explicit `## Track <Letter>` or numbered section headings rather than by inferred subtopics; (2) read the matched skill context, relevant files, target mode, and response schema; (3) choose the coordination pattern from the spec's Merge DAG or workflow shape — when the spec lists independent tracks or parallel branches, generate parallel forEach / fan-out child invocations rather than a serial pipeline; (4) write a workflow that imports the Agent Relay workflow builder, uses a dedicated `wf-ricky-*` channel, declares explicit named agents, includes deterministic preflight/context, bounded implementation steps, a per-child review + fix loop, final review, hard validation, regression evidence, and final signoff — nest the structured review loop inside each child workflow when the spec asks for per-track review; (5) preserve declared target files, non-goals, acceptance gates, environment preflights, and tool fallbacks exactly enough for deterministic validation to prove them; (6) reference the spec by path rather than inlining it verbatim when the spec is long; (7) when the workflow can change repository files or must ship a bug fix/feature, include GitHub primitive shipping steps in the generated workflow: import `GitHubStepExecutor` and `createGitHubStep` from `@agent-relay/github-primitive`, create or update a branch, commit the changed files, open a pull request, and capture the PR URL; only omit these steps when the normalized spec explicitly says planning-only, no PR, or PR creation is out of scope; (8) never create branches, commits, or pull requests during persona generation itself; generate workflow source that does those side effects later when executed; (9) keep all runtime-agent prompts model-agnostic; (10) set `onError` `retryDelayMs` to at least 10000 for retried steps; (11) preflight-skip any PRs the spec marks as already merged. Quality bar: generated workflows must be locally dry-runnable, structurally valid, evidence-driven, and safe to hand to local or cloud runners. Output contract: return only the requested structured JSON or fenced TypeScript artifact plus metadata; `artifact.content` must contain the complete workflow source.",
+      "harnessSettings": { "reasoning": "high", "timeoutSeconds": 1500 }
+    },
+    "best-value": {
+      "harness": "claude",
+      "model": "claude-sonnet-4-6",
+      "systemPrompt": "You are an agent-relay workflow artifact author. Produce complete, runnable TypeScript workflow source plus metadata for the caller's requested artifact path; do not stop at a plan or outline. Read the normalized spec, matched skill context, target mode, and response schema. Decompose by the spec's explicit `## Track <Letter>` or numbered section headings rather than by inferred subtopics. Pick the coordination pattern from the spec's Merge DAG or workflow shape: when the spec lists independent tracks or parallel branches, generate parallel forEach / fan-out child invocations rather than a serial pipeline. Write a workflow that imports the Agent Relay workflow builder, uses a dedicated `wf-ricky-*` channel, declares explicit named agents, includes deterministic preflight/context, bounded implementation steps, a per-child review + fix loop, final review, hard validation, regression evidence, and final signoff — nest the structured review loop inside each child workflow when the spec asks for per-track review. Preserve declared target files, non-goals, acceptance gates, environment preflights, and tool fallbacks. Reference the spec by path rather than inlining it verbatim. When the workflow can change repository files or must ship a bug fix/feature, include GitHub primitive shipping steps in the generated workflow: import `GitHubStepExecutor` and `createGitHubStep` from `@agent-relay/github-primitive`, create or update a branch, commit changed files, open a pull request, and capture the PR URL. Omit PR steps only when the spec explicitly says planning-only, no PR, or PR creation is out of scope. Never perform branch, commit, or pull-request side effects during persona generation itself; generate workflow source that does them later when executed. Keep runtime-agent prompts model-agnostic. Set `onError` `retryDelayMs` to at least 10000 for retried steps. Preflight-skip any PRs the spec marks as already merged. Quality bar: generated workflows must be locally dry-runnable, structurally valid, evidence-driven, and safe to hand to local or cloud runners. Output contract: return only the requested structured JSON or fenced TypeScript artifact plus metadata, with `artifact.content` containing the complete workflow source.",
+      "harnessSettings": { "reasoning": "medium", "timeoutSeconds": 1200 }
+    },
+    "minimum": {
+      "harness": "claude",
+      "model": "claude-haiku-4-5-20251001",
+      "systemPrompt": "You are a concise agent-relay workflow artifact author. Return complete, runnable TypeScript workflow source plus metadata for the requested artifact path; do not return a plan. Read the normalized spec and matched skill context. Decompose by the spec's explicit `## Track <Letter>` or numbered section headings rather than by inferred subtopics. Choose the coordination pattern from the spec's Merge DAG: parallel branches map to fan-out child invocations, not serial steps. Declare a dedicated `wf-ricky-*` channel, explicit named agents, deterministic gates, review, fix loop, final hard validation, regression evidence, and final signoff. Nest the structured review loop inside each child workflow when the spec asks for per-track review. Preserve declared targets, non-goals, acceptance gates, environment preflights, and command fallbacks. Reference the spec by path rather than inlining it verbatim. For implementation workflows that can change repository files, include GitHub primitive PR shipping steps in the generated workflow: `GitHubStepExecutor`, `createGitHubStep`, branch, commit, open pull request, and PR URL capture. Omit PR steps only when the spec explicitly says planning-only, no PR, or PR creation is out of scope. Do not create branches, commits, or pull requests during persona generation. Keep runtime-agent prompts model-agnostic. Set `onError` `retryDelayMs` to at least 10000. Preflight-skip already-merged PRs. Output contract: structured JSON or fenced TypeScript artifact plus metadata with complete workflow source.",
+      "harnessSettings": { "reasoning": "low", "timeoutSeconds": 900 }
+    }
+  }
+}

--- a/src/local/entrypoint.ts
+++ b/src/local/entrypoint.ts
@@ -1664,11 +1664,18 @@ function resolveWorkforcePersonaWriterOptions(
   const requestedByMetadata = request.metadata.workflowWriter === 'workforce' || request.metadata.workflow_writer === 'workforce';
   if (!options.workforcePersonaWriter && !requestedByMetadata) return undefined;
 
+  // Thread the original spec file path (when --spec-file was used and the
+  // path is not an executable workflow) so the persona writer can reference
+  // the spec by path instead of inlining the full text into the prompt.
+  const specPath =
+    request.specPath && !isExecutableWorkflowPath(request.specPath) ? request.specPath : undefined;
+
   return {
     ...(options.workforcePersonaWriter || {}),
     repoRoot: cwd,
     targetMode: executionPreference === 'cloud' ? 'cloud' : 'local',
     installRoot: join(localRunStateRoot(cwd), 'workforce-persona-skills'),
+    ...(specPath ? { specPath } : {}),
   };
 }
 

--- a/src/product/generation/pipeline.ts
+++ b/src/product/generation/pipeline.ts
@@ -113,6 +113,7 @@ export async function generateWithWorkforcePersona(input: GenerationInput): Prom
       installSkills: input.workforcePersonaWriter?.installSkills,
       installRoot: input.workforcePersonaWriter?.installRoot,
       tier: input.workforcePersonaWriter?.tier,
+      ...(input.workforcePersonaWriter?.specPath ? { specPath: input.workforcePersonaWriter.specPath } : {}),
       personaIntentCandidates: input.workforcePersonaWriter?.personaIntentCandidates,
       resolver,
       skillContext: baseResult.skillContext,

--- a/src/product/generation/pipeline.ts
+++ b/src/product/generation/pipeline.ts
@@ -10,6 +10,7 @@ import type {
   RenderedArtifact,
   SkillContext,
   WorkflowExecutionRoute,
+  WorkforcePersonaGenerationMetadata,
 } from './types.js';
 import { selectPattern } from './pattern-selector.js';
 import { refineWithLlm } from './refine-with-llm.js';
@@ -23,7 +24,15 @@ import {
   WorkforcePersonaClarificationError,
   WorkforcePersonaWriterError,
   type WorkforcePersonaPrewriteRepairAttempt,
+  type WorkforcePersonaResolver,
 } from './workforce-persona-writer.js';
+import { createRickyLocalPersonaResolver } from './ricky-local-persona-resolver.js';
+import {
+  renderReviewFixesForWriter,
+  reviewWorkflowWithWorkforcePersona,
+  type WorkforcePersonaReviewResult,
+} from './workforce-persona-reviewer.js';
+import type { WorkforcePersonaReviewSummary } from './types.js';
 
 const DEFAULT_WORKFORCE_PERSONA_PREWRITE_REPAIR_ATTEMPTS = 4;
 const MAX_WORKFORCE_PERSONA_PREWRITE_REPAIR_ATTEMPTS = 8;
@@ -93,6 +102,7 @@ export async function generateWithWorkforcePersona(input: GenerationInput): Prom
     (input.spec.executionPreference === 'cloud' ? 'cloud' : 'local');
 
   try {
+    const resolver: WorkforcePersonaResolver = input.workforcePersonaWriter?.resolver ?? createRickyLocalPersonaResolver();
     const writerOptions = {
       repoRoot: input.workforcePersonaWriter?.repoRoot ?? process.cwd(),
       workflowName: input.workforcePersonaWriter?.workflowName ?? artifact.workflowId,
@@ -104,7 +114,7 @@ export async function generateWithWorkforcePersona(input: GenerationInput): Prom
       installRoot: input.workforcePersonaWriter?.installRoot,
       tier: input.workforcePersonaWriter?.tier,
       personaIntentCandidates: input.workforcePersonaWriter?.personaIntentCandidates,
-      resolver: input.workforcePersonaWriter?.resolver,
+      resolver,
       skillContext: baseResult.skillContext,
     };
     const personaResult = await writeWorkflowWithWorkforcePersona(input.spec, writerOptions);
@@ -165,6 +175,27 @@ export async function generateWithWorkforcePersona(input: GenerationInput): Prom
       };
     }
 
+    let reviewSummary: WorkforcePersonaReviewSummary | undefined;
+    if (workforcePersonaReviewEnabled(input)) {
+      const reviewOutcome = await runWorkforcePersonaReviewPass(input, {
+        baseWriterOptions: writerOptions,
+        baseArtifact: artifact,
+        baseSkillContext: baseResult.skillContext,
+        basePatternDecision: baseResult.patternDecision,
+        normalizedSpec: input.spec,
+        previousRepairAttempts,
+        currentArtifact: finalArtifact,
+        currentValidation: validation,
+        currentPersonaMetadata: finalPersonaMetadata,
+      });
+      if (reviewOutcome) {
+        finalArtifact = reviewOutcome.finalArtifact;
+        validation = reviewOutcome.validation;
+        finalPersonaMetadata = reviewOutcome.personaMetadata;
+        reviewSummary = reviewOutcome.reviewSummary;
+      }
+    }
+
     const plannedChecks = buildPlannedChecks(finalArtifact, input.dryRunEnabled !== false);
 
     return {
@@ -177,7 +208,9 @@ export async function generateWithWorkforcePersona(input: GenerationInput): Prom
         .filter((check) => check.stage !== 'dry_run')
         .map((check) => check.command),
       executionRoute: resolveExecutionRoute(input.spec, finalArtifact),
-      workforcePersona: finalPersonaMetadata,
+      workforcePersona: reviewSummary
+        ? { ...finalPersonaMetadata, review: reviewSummary }
+        : finalPersonaMetadata,
     };
   } catch (error) {
     if (error instanceof WorkforcePersonaClarificationError) {
@@ -251,6 +284,178 @@ function resolvePrewriteRepairAttempts(value: number | undefined): number {
   if (value === undefined) return DEFAULT_WORKFORCE_PERSONA_PREWRITE_REPAIR_ATTEMPTS;
   if (!Number.isFinite(value)) return DEFAULT_WORKFORCE_PERSONA_PREWRITE_REPAIR_ATTEMPTS;
   return Math.max(0, Math.min(MAX_WORKFORCE_PERSONA_PREWRITE_REPAIR_ATTEMPTS, Math.floor(value)));
+}
+
+function workforcePersonaReviewEnabled(input: GenerationInput): boolean {
+  const writerOptions = input.workforcePersonaWriter;
+  if (writerOptions === false || writerOptions == null) return false;
+  if (writerOptions.review === false) return false;
+  const envFlag = process.env.RICKY_PERSONA_REVIEW;
+  if (envFlag !== undefined) {
+    const normalized = envFlag.trim().toLowerCase();
+    if (['0', 'false', 'no', 'off'].includes(normalized)) return false;
+  }
+  return true;
+}
+
+interface WorkforcePersonaReviewPassInputs {
+  baseWriterOptions: Parameters<typeof writeWorkflowWithWorkforcePersona>[1];
+  baseArtifact: RenderedArtifact;
+  baseSkillContext: SkillContext;
+  basePatternDecision: PatternDecision;
+  normalizedSpec: GenerationInput['spec'];
+  previousRepairAttempts: WorkforcePersonaPrewriteRepairAttempt[];
+  currentArtifact: RenderedArtifact;
+  currentValidation: GenerationValidationResult;
+  currentPersonaMetadata: WorkforcePersonaGenerationMetadata;
+}
+
+interface WorkforcePersonaReviewPassResult {
+  finalArtifact: RenderedArtifact;
+  validation: GenerationValidationResult;
+  personaMetadata: WorkforcePersonaGenerationMetadata;
+  reviewSummary: WorkforcePersonaReviewSummary;
+}
+
+async function runWorkforcePersonaReviewPass(
+  input: GenerationInput,
+  inputs: WorkforcePersonaReviewPassInputs,
+): Promise<WorkforcePersonaReviewPassResult | null> {
+  const writerOptions = input.workforcePersonaWriter;
+  if (writerOptions === false || writerOptions == null) return null;
+  const reviewOptions = writerOptions.review === undefined ? {} : writerOptions.review;
+  if (reviewOptions === false) return null;
+
+  // Reviewer resolver precedence: explicit `review.resolver` overrides
+  // everything; otherwise reuse the writer's custom resolver when the
+  // caller provided one (so tests and integration callers do not need to
+  // wire two parallel resolver mocks). Falls back to the Ricky-local
+  // Claude resolver when neither is supplied.
+  const reviewResolver = reviewOptions.resolver ?? inputs.baseWriterOptions.resolver;
+
+  let review: WorkforcePersonaReviewResult;
+  try {
+    review = await reviewWorkflowWithWorkforcePersona(inputs.normalizedSpec, {
+      repoRoot: inputs.baseWriterOptions.repoRoot,
+      outputPath: inputs.baseArtifact.artifactPath,
+      artifactContent: inputs.currentArtifact.content,
+      workflowName: inputs.baseWriterOptions.workflowName ?? inputs.baseArtifact.workflowId,
+      ...(reviewOptions.tier !== undefined ? { tier: reviewOptions.tier } : {}),
+      ...(reviewOptions.timeoutSeconds !== undefined ? { timeoutSeconds: reviewOptions.timeoutSeconds } : {}),
+      ...(reviewOptions.personaIntentCandidates ? { personaIntentCandidates: reviewOptions.personaIntentCandidates } : {}),
+      ...(reviewResolver ? { resolver: reviewResolver } : {}),
+      ...(writerOptions.installRoot !== undefined ? { installRoot: writerOptions.installRoot } : {}),
+    });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    return {
+      finalArtifact: inputs.currentArtifact,
+      validation: inputs.currentValidation,
+      personaMetadata: appendPersonaWarning(
+        inputs.currentPersonaMetadata,
+        `Workforce persona review pass skipped: ${message}`,
+      ),
+      reviewSummary: {
+        verdict: 'pass',
+        summary: `Reviewer pass was skipped after error: ${message}`,
+        personaId: 'unresolved',
+        tier: 'unknown',
+        harness: 'unknown',
+        model: 'unknown',
+        selectedIntent: 'review',
+        runId: null,
+        fixes: [],
+        appliedFix: false,
+        warnings: [message],
+      },
+    };
+  }
+
+  const reviewSummary: WorkforcePersonaReviewSummary = {
+    verdict: review.verdict,
+    summary: review.summary,
+    personaId: review.metadata.personaId,
+    tier: review.metadata.tier,
+    harness: review.metadata.harness,
+    model: review.metadata.model,
+    selectedIntent: review.metadata.selectedIntent,
+    runId: review.metadata.runId,
+    fixes: review.fixes,
+    appliedFix: false,
+    warnings: review.metadata.warnings,
+  };
+
+  if (review.verdict === 'pass' || review.fixes.length === 0) {
+    return {
+      finalArtifact: inputs.currentArtifact,
+      validation: inputs.currentValidation,
+      personaMetadata: inputs.currentPersonaMetadata,
+      reviewSummary,
+    };
+  }
+
+  // Verdict is `fix` (or `block` with fixes): feed the structured fix list
+  // back into a single writer repair attempt.
+  const fixErrors = renderReviewFixesForWriter(review);
+  let appliedArtifact = inputs.currentArtifact;
+  let appliedValidation = inputs.currentValidation;
+  let appliedMetadata = inputs.currentPersonaMetadata;
+
+  try {
+    const repairResult = await writeWorkflowWithWorkforcePersona(inputs.normalizedSpec, {
+      ...inputs.baseWriterOptions,
+      validationFeedback: {
+        errors: fixErrors,
+        previousContent: appliedArtifact.content,
+        previousAttempts: inputs.previousRepairAttempts,
+      },
+    });
+    const repairedArtifact = applyPersonaArtifactToRenderedArtifact(inputs.baseArtifact, repairResult);
+    const repairedValidation = validateGeneratedArtifact(
+      repairedArtifact,
+      inputs.basePatternDecision,
+      inputs.baseSkillContext,
+      inputs.normalizedSpec,
+    );
+
+    if (repairedValidation.valid) {
+      appliedArtifact = repairedArtifact;
+      appliedValidation = repairedValidation;
+      appliedMetadata = {
+        ...repairResult.metadata,
+        warnings: [
+          ...repairResult.metadata.warnings,
+          `Workforce persona reviewer (${review.metadata.model}) returned ${review.fixes.length} fix(es); writer repair attempt applied them.`,
+        ],
+      };
+      reviewSummary.appliedFix = true;
+    } else {
+      appliedMetadata = appendPersonaWarning(
+        inputs.currentPersonaMetadata,
+        `Workforce persona reviewer fix attempt did not satisfy deterministic validation; kept the original writer artifact.`,
+      );
+    }
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    appliedMetadata = appendPersonaWarning(
+      inputs.currentPersonaMetadata,
+      `Workforce persona reviewer fix attempt failed: ${message}.`,
+    );
+  }
+
+  return {
+    finalArtifact: appliedArtifact,
+    validation: appliedValidation,
+    personaMetadata: appliedMetadata,
+    reviewSummary,
+  };
+}
+
+function appendPersonaWarning(
+  metadata: WorkforcePersonaGenerationMetadata,
+  warning: string,
+): WorkforcePersonaGenerationMetadata {
+  return { ...metadata, warnings: [...metadata.warnings, warning] };
 }
 
 function workforcePersonaTierForRepairAttempt(tier: string | undefined, repairAttempt: number): string | undefined {

--- a/src/product/generation/pipeline.ts
+++ b/src/product/generation/pipeline.ts
@@ -357,7 +357,11 @@ async function runWorkforcePersonaReviewPass(
         `Workforce persona review pass skipped: ${message}`,
       ),
       reviewSummary: {
-        verdict: 'pass',
+        // Reviewer pass crashed — surface as `error` so downstream
+        // automation (and humans reading the JSON) can tell "the reviewer
+        // never ran" from "the reviewer ran and approved." Synthesizing
+        // `pass` here would be a false approval signal.
+        verdict: 'error',
         summary: `Reviewer pass was skipped after error: ${message}`,
         personaId: 'unresolved',
         tier: 'unknown',
@@ -386,7 +390,15 @@ async function runWorkforcePersonaReviewPass(
     warnings: review.metadata.warnings,
   };
 
-  if (review.verdict === 'pass' || review.fixes.length === 0) {
+  // Skip the repair attempt when:
+  //   - verdict is `pass` (no fixes requested),
+  //   - verdict is `block` (the reviewer rejected the artifact outright; per
+  //     the contract documented on `WorkforcePersonaReviewSummary`, Ricky
+  //     keeps the writer artifact and records the verdict rather than trying
+  //     to repair what the reviewer called fundamentally wrong), or
+  //   - `fixes` is empty (a `fix` verdict without actionable items has
+  //     nothing the writer can act on).
+  if (review.verdict === 'pass' || review.verdict === 'block' || review.fixes.length === 0) {
     return {
       finalArtifact: inputs.currentArtifact,
       validation: inputs.currentValidation,
@@ -395,8 +407,8 @@ async function runWorkforcePersonaReviewPass(
     };
   }
 
-  // Verdict is `fix` (or `block` with fixes): feed the structured fix list
-  // back into a single writer repair attempt.
+  // Verdict is `fix` with a non-empty fix list: feed the structured fix
+  // list back into a single writer repair attempt.
   const fixErrors = renderReviewFixesForWriter(review);
   let appliedArtifact = inputs.currentArtifact;
   let appliedValidation = inputs.currentValidation;

--- a/src/product/generation/ricky-local-persona-resolver.ts
+++ b/src/product/generation/ricky-local-persona-resolver.ts
@@ -1,3 +1,4 @@
+import { existsSync } from 'node:fs';
 import { readFile, readdir } from 'node:fs/promises';
 import { dirname, join, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
@@ -46,9 +47,31 @@ export interface RickyLocalPersonaRuntime {
   agentsMd?: string;
 }
 
-/** Absolute path to the Ricky-local persona directory inside the repo. */
+const PERSONA_SENTINEL = join('personas', 'agent-relay-workflow.json');
+
+/**
+ * Absolute path to the Ricky-local persona directory. Walks up from this
+ * module's URL looking for a directory that contains the sentinel persona
+ * file. Works under all the layouts Ricky ships in:
+ * - source via tsx (`src/product/generation/...`)
+ * - bundled CLI (`dist/ricky.js` adjacent to `personas/`)
+ * - npm install (`node_modules/@agentworkforce/ricky/dist/ricky.js`)
+ * Falls back to the legacy three-up resolution so tests that mock
+ * `import.meta.url` still get a deterministic path.
+ */
 export function rickyLocalPersonaDir(): string {
   const here = dirname(fileURLToPath(import.meta.url));
+  let current = here;
+  // Probe up to 8 parents — covers `dist/ricky.js`, `src/<a>/<b>/<c>.ts`,
+  // and `node_modules/@scope/pkg/dist/<file>`.
+  for (let i = 0; i < 8; i += 1) {
+    if (existsSync(join(current, PERSONA_SENTINEL))) {
+      return join(current, 'personas');
+    }
+    const parent = dirname(current);
+    if (parent === current) break;
+    current = parent;
+  }
   return resolve(here, '..', '..', '..', 'personas');
 }
 

--- a/src/product/generation/ricky-local-persona-resolver.ts
+++ b/src/product/generation/ricky-local-persona-resolver.ts
@@ -1,0 +1,281 @@
+import { readFile, readdir } from 'node:fs/promises';
+import { dirname, join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import {
+  defaultWorkforcePersonaResolver as packageWorkforcePersonaResolver,
+  WorkforcePersonaWriterError,
+  type ResolvedWorkforcePersonaContext,
+  type WorkforcePersonaContext,
+  type WorkforcePersonaResolver,
+  type WorkforcePersonaModule,
+} from './workforce-persona-writer.js';
+
+/**
+ * Tiers accepted by Ricky-local persona specs. Mirrors the workload-router
+ * 0.19 `PersonaTier` tuple. We hardcode it instead of importing because the
+ * Ricky-local resolver must keep loading even when `@agentworkforce/workload-router`
+ * is unavailable (the test path stubs the package out).
+ */
+export const RICKY_LOCAL_PERSONA_TIERS = ['best', 'best-value', 'minimum'] as const;
+export type RickyLocalPersonaTier = (typeof RICKY_LOCAL_PERSONA_TIERS)[number];
+
+const DEFAULT_RICKY_LOCAL_TIER: RickyLocalPersonaTier = 'best-value';
+
+export interface RickyLocalPersonaSpec {
+  id: string;
+  intent: string;
+  tags: string[];
+  description: string;
+  skills: Array<{ id: string; source: string; description: string }>;
+  inputs?: Record<string, { description?: string; default?: string; optional?: boolean }>;
+  tiers: Record<RickyLocalPersonaTier, RickyLocalPersonaRuntime>;
+  defaultTier?: RickyLocalPersonaTier;
+  env?: Record<string, string>;
+}
+
+export interface RickyLocalPersonaRuntime {
+  harness: 'claude' | 'codex' | 'opencode';
+  model: string;
+  systemPrompt: string;
+  harnessSettings: {
+    reasoning?: string;
+    timeoutSeconds?: number;
+  };
+  claudeMd?: string;
+  agentsMd?: string;
+}
+
+/** Absolute path to the Ricky-local persona directory inside the repo. */
+export function rickyLocalPersonaDir(): string {
+  const here = dirname(fileURLToPath(import.meta.url));
+  return resolve(here, '..', '..', '..', 'personas');
+}
+
+interface LoadedPersonaCache {
+  byIntent: Map<string, RickyLocalPersonaSpec>;
+}
+
+let cachedPersonas: Promise<LoadedPersonaCache> | undefined;
+
+/**
+ * Returns the Ricky-local persona for `intent`, or `null` when no Ricky-local
+ * override exists. Reads `personas/*.json` lazily on first call and memoizes
+ * across the process lifetime.
+ */
+export async function loadRickyLocalPersona(intent: string): Promise<RickyLocalPersonaSpec | null> {
+  const cache = await (cachedPersonas ??= loadAllRickyLocalPersonas(rickyLocalPersonaDir()));
+  return cache.byIntent.get(intent) ?? null;
+}
+
+/** Test seam: forget any cached Ricky-local persona specs so subsequent loads re-read from disk. */
+export function resetRickyLocalPersonaCacheForTests(): void {
+  cachedPersonas = undefined;
+}
+
+/**
+ * Loads every `personas/*.json` Ricky-local spec from `dir`. Files that fail
+ * to parse are skipped with a warning rather than throwing; the resolver
+ * should treat a missing or malformed override as "fall through to the
+ * package resolver" rather than hard-failing the writer.
+ */
+export async function loadAllRickyLocalPersonas(dir: string): Promise<LoadedPersonaCache> {
+  const byIntent = new Map<string, RickyLocalPersonaSpec>();
+  let entries: string[];
+  try {
+    entries = await readdir(dir);
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === 'ENOENT') {
+      return { byIntent };
+    }
+    throw error;
+  }
+  for (const entry of entries) {
+    if (!entry.endsWith('.json')) continue;
+    const path = join(dir, entry);
+    try {
+      const text = await readFile(path, 'utf8');
+      const spec = JSON.parse(text) as RickyLocalPersonaSpec;
+      if (!isRickyLocalPersonaSpec(spec)) {
+        continue;
+      }
+      byIntent.set(spec.intent, spec);
+    } catch {
+      // Skip unreadable or invalid persona JSONs; the resolver falls through.
+    }
+  }
+  return { byIntent };
+}
+
+function isRickyLocalPersonaSpec(value: unknown): value is RickyLocalPersonaSpec {
+  if (!value || typeof value !== 'object') return false;
+  const spec = value as Partial<RickyLocalPersonaSpec>;
+  if (typeof spec.id !== 'string' || typeof spec.intent !== 'string') return false;
+  if (!spec.tiers || typeof spec.tiers !== 'object') return false;
+  return RICKY_LOCAL_PERSONA_TIERS.every((tier) => {
+    const runtime = spec.tiers?.[tier];
+    return (
+      runtime !== undefined &&
+      typeof runtime.harness === 'string' &&
+      typeof runtime.model === 'string' &&
+      typeof runtime.systemPrompt === 'string'
+    );
+  });
+}
+
+/**
+ * Resolves the tier to use for a given Ricky-local persona. Honors
+ * `options.tier` first, then the persona's own `defaultTier`, then
+ * `'best-value'` (the system-wide default). Falls back to `'best-value'`
+ * when the requested tier isn't declared on the spec.
+ */
+export function resolveRickyLocalPersonaTier(
+  spec: RickyLocalPersonaSpec,
+  options: { tier?: string } = {},
+): RickyLocalPersonaTier {
+  const requested = options.tier && isLocalTier(options.tier) ? options.tier : undefined;
+  const declared = requested ?? spec.defaultTier ?? DEFAULT_RICKY_LOCAL_TIER;
+  return spec.tiers[declared] ? declared : DEFAULT_RICKY_LOCAL_TIER;
+}
+
+function isLocalTier(value: string): value is RickyLocalPersonaTier {
+  return (RICKY_LOCAL_PERSONA_TIERS as readonly string[]).includes(value);
+}
+
+/**
+ * Builds a workload-router-compatible `PersonaSelection` object from a
+ * Ricky-local persona spec. The output is typed loosely because workload-router
+ * does not export its `PersonaSelection` parser, and Ricky-local personas are
+ * hand-validated at load time.
+ */
+export function buildPersonaSelectionFromRickyLocalSpec(
+  spec: RickyLocalPersonaSpec,
+  tier: RickyLocalPersonaTier,
+): {
+  personaId: string;
+  tier: RickyLocalPersonaTier;
+  runtime: RickyLocalPersonaRuntime;
+  skills: RickyLocalPersonaSpec['skills'];
+  rationale: string;
+  inputs?: RickyLocalPersonaSpec['inputs'];
+  env?: RickyLocalPersonaSpec['env'];
+} {
+  const runtime = spec.tiers[tier];
+  return {
+    personaId: spec.id,
+    tier,
+    runtime,
+    skills: spec.skills,
+    rationale: `Ricky-local Claude persona override for intent "${spec.intent}" (tier ${tier})`,
+    ...(spec.inputs ? { inputs: spec.inputs } : {}),
+    ...(spec.env ? { env: spec.env } : {}),
+  };
+}
+
+interface HarnessKitRunnableSelectionModule {
+  useRunnableSelection?: WorkforcePersonaModule['useRunnableSelection'];
+}
+
+type RunnableSelectionLoader = () => Promise<HarnessKitRunnableSelectionModule>;
+
+async function defaultLoadRunnableSelectionModule(): Promise<HarnessKitRunnableSelectionModule> {
+  return (await import('@agentworkforce/harness-kit')) as HarnessKitRunnableSelectionModule;
+}
+
+/**
+ * Creates a `WorkforcePersonaResolver` that prefers Ricky-local Claude
+ * persona overrides (`personas/*.json`) over the package resolver. For any
+ * intent that has no Ricky-local override, the resolver falls back to the
+ * supplied `fallback` (defaults to {@link packageWorkforcePersonaResolver}),
+ * preserving the prior workforce-package behavior end-to-end.
+ *
+ * The Ricky-local path constructs a `PersonaSelection` by hand and hands
+ * it to `@agentworkforce/harness-kit`'s `useRunnableSelection` to obtain a
+ * runnable `WorkforcePersonaContext`. This avoids depending on the v3
+ * persona-kit shape (which dropped tiers) and stays compatible with the
+ * 0.19 router/harness-kit pair pinned by Ricky today.
+ */
+export function createRickyLocalPersonaResolver(
+  options: {
+    fallback?: WorkforcePersonaResolver;
+    loadRunnableSelectionModule?: RunnableSelectionLoader;
+  } = {},
+): WorkforcePersonaResolver {
+  const fallback = options.fallback ?? packageWorkforcePersonaResolver;
+  const load = options.loadRunnableSelectionModule ?? defaultLoadRunnableSelectionModule;
+
+  return async (intents, resolverOptions) => {
+    const localWarnings: string[] = [];
+
+    for (const intent of intents) {
+      const spec = await loadRickyLocalPersona(intent);
+      if (!spec) continue;
+
+      const tier = resolveRickyLocalPersonaTier(spec, resolverOptions);
+      const selection = buildPersonaSelectionFromRickyLocalSpec(spec, tier);
+
+      let runnableModule: HarnessKitRunnableSelectionModule;
+      try {
+        runnableModule = await load();
+      } catch (error) {
+        localWarnings.push(
+          `Ricky-local persona override for "${intent}" could not load @agentworkforce/harness-kit: ${errorMessage(error)}.`,
+        );
+        break;
+      }
+      if (typeof runnableModule.useRunnableSelection !== 'function') {
+        localWarnings.push(
+          `Ricky-local persona override for "${intent}" skipped: @agentworkforce/harness-kit did not export useRunnableSelection().`,
+        );
+        break;
+      }
+
+      try {
+        const installRootOption = resolverOptions.installRoot !== undefined ? { installRoot: resolverOptions.installRoot } : {};
+        const context = runnableModule.useRunnableSelection(selection, installRootOption);
+        if (isUsableContext(context)) {
+          return {
+            source: 'package',
+            intent,
+            context,
+            warnings: [
+              ...localWarnings,
+              `Ricky-local Claude persona override resolved for intent "${intent}" at tier "${tier}".`,
+            ],
+          } satisfies ResolvedWorkforcePersonaContext;
+        }
+        localWarnings.push(
+          `Ricky-local persona override for "${intent}" produced an unusable runnable context; falling through.`,
+        );
+      } catch (error) {
+        localWarnings.push(
+          `Ricky-local persona override for "${intent}" failed to build a runnable context: ${errorMessage(error)}.`,
+        );
+      }
+    }
+
+    try {
+      const downstream = await fallback(intents, resolverOptions);
+      return {
+        ...downstream,
+        warnings: [...localWarnings, ...downstream.warnings],
+      };
+    } catch (error) {
+      if (error instanceof WorkforcePersonaWriterError) {
+        throw new WorkforcePersonaWriterError(error.message, [...localWarnings, ...error.warnings]);
+      }
+      throw error;
+    }
+  };
+}
+
+function isUsableContext(value: unknown): value is WorkforcePersonaContext {
+  if (!value || typeof value !== 'object') return false;
+  const candidate = value as { selection?: unknown; sendMessage?: unknown };
+  return typeof candidate.sendMessage === 'function' && candidate.selection !== undefined;
+}
+
+function errorMessage(error: unknown): string {
+  if (error instanceof Error) return error.message;
+  return String(error);
+}

--- a/src/product/generation/types.ts
+++ b/src/product/generation/types.ts
@@ -228,16 +228,28 @@ export interface WorkforcePersonaGenerationMetadata {
   };
   /**
    * Verdict from the post-write Opus reviewer pass, when the reviewer ran.
-   * `pass` means the reviewer approved the artifact as-is. `fix` means the
-   * writer accepted a structured fix list from the reviewer and ran one
-   * repair attempt against it. `block` means the reviewer rejected the
-   * artifact and Ricky fell back to the deterministic renderer.
+   *
+   * - `pass`: the reviewer approved the artifact; Ricky shipped the
+   *   writer's output as-is.
+   * - `fix`: the reviewer returned a structured fix list; Ricky ran one
+   *   writer repair attempt against it. `appliedFix` records whether the
+   *   repair actually passed deterministic validation.
+   * - `block`: the reviewer rejected the artifact as fundamentally wrong.
+   *   Ricky kept the writer's output and recorded the verdict in metadata
+   *   for the operator — it does NOT fall back to the deterministic
+   *   renderer (that fallback only triggers when deterministic pre-write
+   *   validation cannot be repaired).
+   * - `error`: the reviewer pass itself failed (resolver error, harness
+   *   timeout, parser exception). Distinct from `block` so downstream
+   *   automation does not misread "reviewer crashed" as "reviewer
+   *   approved." The writer artifact is kept and the failure is surfaced
+   *   via `warnings`.
    */
   review?: WorkforcePersonaReviewSummary;
 }
 
 export type WorkforcePersonaReviewSummary = {
-  verdict: 'pass' | 'fix' | 'block';
+  verdict: 'pass' | 'fix' | 'block' | 'error';
   summary: string;
   personaId: string;
   tier: string;

--- a/src/product/generation/types.ts
+++ b/src/product/generation/types.ts
@@ -56,6 +56,17 @@ export interface GenerationInput {
     repairAttempts?: number;
     personaIntentCandidates?: readonly string[];
     resolver?: import('./workforce-persona-writer.js').WorkforcePersonaResolver;
+    /**
+     * Post-write Opus reviewer pass control. `false` disables the pass.
+     * Defaults to enabled when omitted; can also be disabled via the
+     * `RICKY_PERSONA_REVIEW=0` env var.
+     */
+    review?: false | {
+      tier?: string;
+      timeoutSeconds?: number;
+      personaIntentCandidates?: readonly string[];
+      resolver?: import('./workforce-persona-writer.js').WorkforcePersonaResolver;
+    };
   };
 }
 
@@ -213,7 +224,34 @@ export interface WorkforcePersonaGenerationMetadata {
     repoRoot: string;
     relevantFileCount: number;
   };
+  /**
+   * Verdict from the post-write Opus reviewer pass, when the reviewer ran.
+   * `pass` means the reviewer approved the artifact as-is. `fix` means the
+   * writer accepted a structured fix list from the reviewer and ran one
+   * repair attempt against it. `block` means the reviewer rejected the
+   * artifact and Ricky fell back to the deterministic renderer.
+   */
+  review?: WorkforcePersonaReviewSummary;
 }
+
+export type WorkforcePersonaReviewSummary = {
+  verdict: 'pass' | 'fix' | 'block';
+  summary: string;
+  personaId: string;
+  tier: string;
+  harness: string;
+  model: string;
+  selectedIntent: string;
+  runId: string | null;
+  fixes: Array<{
+    severity: 'critical' | 'important' | 'moderate';
+    area: string;
+    finding: string;
+    requestedChange: string;
+  }>;
+  appliedFix: boolean;
+  warnings: string[];
+};
 
 export interface GenerationValidationResult {
   valid: boolean;

--- a/src/product/generation/types.ts
+++ b/src/product/generation/types.ts
@@ -52,6 +52,8 @@ export interface GenerationInput {
     installSkills?: boolean;
     installRoot?: string;
     tier?: string;
+    /** Absolute path to the original spec file, when --spec-file was used. Lets the writer reference the spec by path instead of inlining it. */
+    specPath?: string;
     /** Maximum pre-write validation repair attempts before falling back to deterministic rendering. */
     repairAttempts?: number;
     personaIntentCandidates?: readonly string[];

--- a/src/product/generation/workforce-persona-reviewer.ts
+++ b/src/product/generation/workforce-persona-reviewer.ts
@@ -1,5 +1,8 @@
 import { createHash } from 'node:crypto';
 
+import { fromMarkdown } from 'mdast-util-from-markdown';
+import type { Code, Node, Parent, Root } from 'mdast';
+
 import type { NormalizedWorkflowSpec } from '../spec-intake/types.js';
 import {
   dumpPersonaDebug,
@@ -11,7 +14,21 @@ import { createRickyLocalPersonaResolver } from './ricky-local-persona-resolver.
 
 const DEFAULT_REVIEW_INTENT_CANDIDATES = ['review'] as const;
 
-export type WorkforcePersonaReviewVerdict = 'pass' | 'fix' | 'block';
+/**
+ * Reviewer verdict values.
+ *
+ * - `pass`: artifact approved; pipeline ships the writer's output as-is.
+ * - `fix`: artifact has actionable fixes; pipeline feeds them back into one
+ *   writer repair attempt.
+ * - `block`: artifact is fundamentally wrong; pipeline keeps the writer's
+ *   output and records the verdict in metadata for the operator.
+ * - `error`: the reviewer pass itself failed (resolver error, harness
+ *   timeout, parser exception). Distinct from `block` so downstream
+ *   automation does not misread "the reviewer crashed" as "the reviewer
+ *   reviewed and approved." Only ever produced by the pipeline catch path,
+ *   never emitted by the reviewer persona itself.
+ */
+export type WorkforcePersonaReviewVerdict = 'pass' | 'fix' | 'block' | 'error';
 
 export type WorkforcePersonaReviewSeverity = 'critical' | 'important' | 'moderate';
 
@@ -193,32 +210,52 @@ function buildReviewerTask(spec: NormalizedWorkflowSpec, options: WorkforcePerso
 }
 
 /**
- * Extracts the reviewer verdict from the persona response. Accepts the
- * verdict JSON either on its own (the response is a JSON object) or as
- * the last fenced ` ```json ` block, or as the last balanced JSON object
- * in the response. Falls back to `block` with a synthetic summary when no
- * verdict can be parsed.
+ * Extracts the reviewer verdict from the persona response.
+ *
+ * Resolution order, picked to favor the model's final-line answer over any
+ * earlier draft work:
+ * 1. Walk the response as Markdown via `mdast-util-from-markdown` and collect
+ *    every fenced ` ```json ` code block. Try the LAST block first, then
+ *    earlier blocks — Sonnet has been observed to emit one or more draft
+ *    verdict JSONs followed by its final verdict, and the final block is
+ *    what the persona system prompt says is authoritative.
+ * 2. If no fenced block carried a valid verdict, scan the raw text from the
+ *    end looking for the last balanced `{ ... }` object. This catches
+ *    "prose plus unfenced JSON on the final line."
+ * 3. Direct-parse the entire trimmed output as a JSON object. This catches
+ *    the strict-contract case where the model returned only `{ ... }`.
+ *
+ * Falls back to `verdict: 'block'` with a canned summary when no candidate
+ * carries a recognized verdict so the pipeline can record an auditable
+ * failure rather than crashing or silently approving.
+ *
+ * Why mdast rather than a regex over raw text: `output.match(/```json[…]```/)`
+ * picks the first match and can match across nested fences inside the
+ * inlined workflow source the reviewer is auditing. The CLAUDE.md
+ * "grammar-aware parsers, not regex" rule applies directly here — see the
+ * `markdown-target-files.ts` precedent for the same pattern.
  */
 export function parseReviewerVerdict(output: string): {
   verdict: WorkforcePersonaReviewVerdict;
   summary: string;
   fixes: WorkforcePersonaReviewFix[];
 } {
-  const candidates = [
-    extractFencedJson(output),
-    extractTrailingJsonObject(output),
-    safeParse(output.trim()),
-  ];
+  const fencedCandidates = extractFencedJsonBlocksLastFirst(output);
+  for (const candidate of fencedCandidates) {
+    const verdict = toVerdict(candidate);
+    if (verdict) return verdict;
+  }
 
-  for (const candidate of candidates) {
-    if (!candidate) continue;
-    const verdict = candidate.verdict;
-    if (verdict !== 'pass' && verdict !== 'fix' && verdict !== 'block') continue;
-    const summary = typeof candidate.summary === 'string' ? candidate.summary : '';
-    const fixes = Array.isArray(candidate.fixes)
-      ? candidate.fixes.flatMap((entry: unknown) => normalizeFix(entry))
-      : [];
-    return { verdict, summary, fixes };
+  const trailing = extractTrailingJsonObject(output);
+  if (trailing) {
+    const verdict = toVerdict(trailing);
+    if (verdict) return verdict;
+  }
+
+  const direct = safeParse(output.trim());
+  if (direct) {
+    const verdict = toVerdict(direct);
+    if (verdict) return verdict;
   }
 
   return {
@@ -228,15 +265,61 @@ export function parseReviewerVerdict(output: string): {
   };
 }
 
-function extractFencedJson(output: string): Record<string, unknown> | null {
-  const match = output.match(/```json\s*([\s\S]*?)```/i);
-  if (!match) return null;
-  return safeParse(match[1].trim());
+function toVerdict(
+  candidate: Record<string, unknown>,
+): { verdict: WorkforcePersonaReviewVerdict; summary: string; fixes: WorkforcePersonaReviewFix[] } | null {
+  const verdict = candidate.verdict;
+  // Reviewer-persona vocabulary only — `'error'` is reserved for the
+  // pipeline catch path on the reviewer-pass-itself-crashed channel.
+  if (verdict !== 'pass' && verdict !== 'fix' && verdict !== 'block') return null;
+  const summary = typeof candidate.summary === 'string' ? candidate.summary : '';
+  const fixes = Array.isArray(candidate.fixes)
+    ? candidate.fixes.flatMap((entry: unknown) => normalizeFix(entry))
+    : [];
+  return { verdict, summary, fixes };
+}
+
+/**
+ * Returns the parsed contents of every fenced ` ```json ` block in the
+ * response, ordered LAST-block-first so callers can prefer the model's
+ * final answer over earlier drafts. Walks the mdast tree rather than
+ * regex-matching raw text so fenced blocks nested inside the workflow
+ * source the reviewer is auditing do not get confused with verdict
+ * blocks.
+ */
+export function extractFencedJsonBlocksLastFirst(output: string): Record<string, unknown>[] {
+  let tree: Root;
+  try {
+    tree = fromMarkdown(output);
+  } catch {
+    return [];
+  }
+  const blocks: Record<string, unknown>[] = [];
+  walkMdast(tree, (node) => {
+    if (node.type !== 'code') return;
+    const code = node as Code;
+    if (typeof code.lang !== 'string') return;
+    if (code.lang.toLowerCase() !== 'json') return;
+    const parsed = safeParse(code.value);
+    if (parsed) blocks.push(parsed);
+  });
+  return blocks.reverse();
+}
+
+function walkMdast(node: Node, visit: (node: Node) => void): void {
+  visit(node);
+  const parent = node as Partial<Parent>;
+  if (!Array.isArray(parent.children)) return;
+  for (const child of parent.children) walkMdast(child, visit);
 }
 
 function extractTrailingJsonObject(output: string): Record<string, unknown> | null {
   const trimmed = output.trim();
-  // Walk back from the end looking for a balanced object.
+  // Walk back from the end looking for a balanced object so we honor the
+  // reviewer's "JSON on the final line" contract even when there are no
+  // fences at all (e.g. when the model returned the verdict as raw JSON
+  // appended after prose, or when fences were unbalanced and so missed
+  // by the mdast parser).
   let depth = 0;
   let endIndex = -1;
   for (let i = trimmed.length - 1; i >= 0; i -= 1) {

--- a/src/product/generation/workforce-persona-reviewer.ts
+++ b/src/product/generation/workforce-persona-reviewer.ts
@@ -2,6 +2,7 @@ import { createHash } from 'node:crypto';
 
 import type { NormalizedWorkflowSpec } from '../spec-intake/types.js';
 import {
+  dumpPersonaDebug,
   WorkforcePersonaWriterError,
   type WorkforcePersonaResolver,
   type WorkforcePersonaSendOptions,
@@ -101,7 +102,21 @@ export async function reviewWorkflowWithWorkforcePersona(
   });
 
   const [result, runId] = await Promise.all([run, run.runId.catch(() => null)]);
+  const dumpDebug = (reason: 'noncompletion' | 'parse-error' | 'no-content' | 'success') =>
+    dumpPersonaDebug({
+      kind: 'reviewer',
+      reason,
+      repoRoot: options.repoRoot,
+      promptDigest,
+      task,
+      result,
+      selection,
+      resolved,
+      outputPath: options.outputPath,
+    });
+
   if (result.status !== 'completed') {
+    await dumpDebug('noncompletion');
     throw new WorkforcePersonaWriterError(
       `Workforce persona reviewer did not complete: ${result.status}.`,
       [...resolved.warnings, result.stderr].filter(Boolean),
@@ -109,6 +124,13 @@ export async function reviewWorkflowWithWorkforcePersona(
   }
 
   const verdict = parseReviewerVerdict(result.output);
+  // Reviewer's parser never throws — an unparseable response degrades to a
+  // `block` verdict with the canned summary below. Detect that exact
+  // synthetic case so dumps land in the parse-error directory only when
+  // the parser actually fell through (not for a legitimate `block` from
+  // the model).
+  const synthesizedBlockSummary = 'Reviewer response did not contain a parseable verdict JSON; treating as block.';
+  await dumpDebug(verdict.summary === synthesizedBlockSummary ? 'parse-error' : 'success');
   return {
     ...verdict,
     raw: result.output,

--- a/src/product/generation/workforce-persona-reviewer.ts
+++ b/src/product/generation/workforce-persona-reviewer.ts
@@ -1,0 +1,274 @@
+import { createHash } from 'node:crypto';
+
+import type { NormalizedWorkflowSpec } from '../spec-intake/types.js';
+import {
+  WorkforcePersonaWriterError,
+  type WorkforcePersonaResolver,
+  type WorkforcePersonaSendOptions,
+} from './workforce-persona-writer.js';
+import { createRickyLocalPersonaResolver } from './ricky-local-persona-resolver.js';
+
+const DEFAULT_REVIEW_INTENT_CANDIDATES = ['review'] as const;
+
+export type WorkforcePersonaReviewVerdict = 'pass' | 'fix' | 'block';
+
+export type WorkforcePersonaReviewSeverity = 'critical' | 'important' | 'moderate';
+
+export interface WorkforcePersonaReviewFix {
+  severity: WorkforcePersonaReviewSeverity;
+  area: string;
+  finding: string;
+  requestedChange: string;
+}
+
+export interface WorkforcePersonaReviewMetadata {
+  personaId: string;
+  tier: string;
+  harness: string;
+  model: string;
+  selectedIntent: string;
+  runId: string | null;
+  warnings: string[];
+  promptDigest: string;
+}
+
+export interface WorkforcePersonaReviewResult {
+  verdict: WorkforcePersonaReviewVerdict;
+  summary: string;
+  fixes: WorkforcePersonaReviewFix[];
+  raw: string;
+  metadata: WorkforcePersonaReviewMetadata;
+}
+
+export interface WorkforcePersonaReviewOptions {
+  repoRoot: string;
+  outputPath: string;
+  artifactContent: string;
+  workflowName: string;
+  tier?: string;
+  timeoutSeconds?: number;
+  installSkills?: boolean;
+  installRoot?: string;
+  env?: NodeJS.ProcessEnv;
+  signal?: AbortSignal;
+  onProgress?: WorkforcePersonaSendOptions['onProgress'];
+  resolver?: WorkforcePersonaResolver;
+  personaIntentCandidates?: readonly string[];
+}
+
+/**
+ * Runs a Workforce persona reviewer over a freshly generated workflow
+ * artifact. The reviewer resolves through the same `agent-relay-workflow`
+ * intent path as the writer, but targets the `review` intent at tier
+ * `best` by default so the audit pass uses the deepest-reasoning Claude
+ * persona available. The reviewer returns a structured verdict the
+ * pipeline can act on (pass through, feed fixes back to the writer, or
+ * block).
+ */
+export async function reviewWorkflowWithWorkforcePersona(
+  spec: NormalizedWorkflowSpec,
+  options: WorkforcePersonaReviewOptions,
+): Promise<WorkforcePersonaReviewResult> {
+  const resolver = options.resolver ?? createRickyLocalPersonaResolver();
+  const intents = options.personaIntentCandidates ?? DEFAULT_REVIEW_INTENT_CANDIDATES;
+  const tier = options.tier ?? 'best';
+
+  const resolved = await resolver(intents, {
+    tier,
+    ...(options.installRoot !== undefined ? { installRoot: options.installRoot } : {}),
+  });
+
+  const task = buildReviewerTask(spec, options);
+  const promptDigest = digest(task);
+  const selection = resolved.context.selection;
+
+  const run = resolved.context.sendMessage(task, {
+    workingDirectory: options.repoRoot,
+    name: `ricky-workflow-reviewer-${promptDigest.slice(0, 12)}`,
+    timeoutSeconds: options.timeoutSeconds ?? selection.runtime.harnessSettings?.timeoutSeconds,
+    installSkills: options.installSkills,
+    mode: 'one-shot',
+    responseFormat: 'structured-json-or-fenced-artifact',
+    env: options.env,
+    signal: options.signal,
+    onProgress: options.onProgress,
+    inputs: {
+      outputPath: options.outputPath,
+      workflowName: options.workflowName,
+      promptDigest,
+      mode: 'one-shot',
+    },
+  });
+
+  const [result, runId] = await Promise.all([run, run.runId.catch(() => null)]);
+  if (result.status !== 'completed') {
+    throw new WorkforcePersonaWriterError(
+      `Workforce persona reviewer did not complete: ${result.status}.`,
+      [...resolved.warnings, result.stderr].filter(Boolean),
+    );
+  }
+
+  const verdict = parseReviewerVerdict(result.output);
+  return {
+    ...verdict,
+    raw: result.output,
+    metadata: {
+      personaId: selection.personaId,
+      tier: selection.tier,
+      harness: selection.runtime.harness,
+      model: selection.runtime.model,
+      selectedIntent: resolved.intent,
+      runId: result.workflowRunId ?? runId,
+      warnings: [...resolved.warnings],
+      promptDigest,
+    },
+  };
+}
+
+function buildReviewerTask(spec: NormalizedWorkflowSpec, options: WorkforcePersonaReviewOptions): string {
+  const verdictContract = {
+    response: {
+      preferred: 'JSON object on the final line of the response',
+      schema: {
+        verdict: '"pass" | "fix" | "block"',
+        summary: 'One-paragraph verdict rationale.',
+        fixes:
+          'Array of { severity: "critical" | "important" | "moderate", area: string, finding: string, requestedChange: string }. Empty when verdict is "pass".',
+      },
+    },
+  };
+
+  return [
+    'Audit the freshly generated Agent Relay workflow artifact below against the original normalized spec.',
+    'Run as a non-interactive one-shot persona invocation. Return only the response contract.',
+    '',
+    'Normalized spec JSON:',
+    JSON.stringify(spec, null, 2),
+    '',
+    `Generated workflow artifact path: ${options.outputPath}`,
+    `Generated workflow name: ${options.workflowName}`,
+    '',
+    'Generated workflow source:',
+    '```ts',
+    options.artifactContent,
+    '```',
+    '',
+    'Audit checklist:',
+    '- Decompose by the spec\'s explicit `## Track <Letter>` or numbered section headings rather than inferred subtopics.',
+    '- Swarm pattern must match the spec\'s Merge DAG. Parallel branches must fan out, not serialize.',
+    '- Per-child review/fix loop must be nested inside each child workflow when the spec asks for it.',
+    '- Dedicated `wf-ricky-*` channel, named agents, deterministic gates, file_exists gate, typecheck/test gates, git diff gate.',
+    '- `onError` `retryDelayMs` must be >= 10000 for retried steps.',
+    '- Preflight-skip any PRs the spec marks as already merged.',
+    '- Spec must be referenced by path, not inlined verbatim into `.description()`.',
+    '- GitHub primitive PR shipping steps included when the spec requires shipping; omitted when planning-only.',
+    '- No branch/commit/PR side effects during persona generation itself.',
+    '- Every declared target file appears in implementation steps. No non-goal is touched.',
+    '',
+    'Response contract:',
+    JSON.stringify(verdictContract, null, 2),
+  ].join('\n');
+}
+
+/**
+ * Extracts the reviewer verdict from the persona response. Accepts the
+ * verdict JSON either on its own (the response is a JSON object) or as
+ * the last fenced ` ```json ` block, or as the last balanced JSON object
+ * in the response. Falls back to `block` with a synthetic summary when no
+ * verdict can be parsed.
+ */
+export function parseReviewerVerdict(output: string): {
+  verdict: WorkforcePersonaReviewVerdict;
+  summary: string;
+  fixes: WorkforcePersonaReviewFix[];
+} {
+  const candidates = [
+    extractFencedJson(output),
+    extractTrailingJsonObject(output),
+    safeParse(output.trim()),
+  ];
+
+  for (const candidate of candidates) {
+    if (!candidate) continue;
+    const verdict = candidate.verdict;
+    if (verdict !== 'pass' && verdict !== 'fix' && verdict !== 'block') continue;
+    const summary = typeof candidate.summary === 'string' ? candidate.summary : '';
+    const fixes = Array.isArray(candidate.fixes)
+      ? candidate.fixes.flatMap((entry: unknown) => normalizeFix(entry))
+      : [];
+    return { verdict, summary, fixes };
+  }
+
+  return {
+    verdict: 'block',
+    summary: 'Reviewer response did not contain a parseable verdict JSON; treating as block.',
+    fixes: [],
+  };
+}
+
+function extractFencedJson(output: string): Record<string, unknown> | null {
+  const match = output.match(/```json\s*([\s\S]*?)```/i);
+  if (!match) return null;
+  return safeParse(match[1].trim());
+}
+
+function extractTrailingJsonObject(output: string): Record<string, unknown> | null {
+  const trimmed = output.trim();
+  // Walk back from the end looking for a balanced object.
+  let depth = 0;
+  let endIndex = -1;
+  for (let i = trimmed.length - 1; i >= 0; i -= 1) {
+    const ch = trimmed[i];
+    if (ch === '}') {
+      if (endIndex === -1) endIndex = i;
+      depth += 1;
+    } else if (ch === '{') {
+      depth -= 1;
+      if (depth === 0 && endIndex !== -1) {
+        const slice = trimmed.slice(i, endIndex + 1);
+        return safeParse(slice);
+      }
+    }
+  }
+  return null;
+}
+
+function safeParse(value: string): Record<string, unknown> | null {
+  try {
+    const parsed = JSON.parse(value);
+    return parsed && typeof parsed === 'object' && !Array.isArray(parsed) ? (parsed as Record<string, unknown>) : null;
+  } catch {
+    return null;
+  }
+}
+
+function normalizeFix(entry: unknown): WorkforcePersonaReviewFix[] {
+  if (!entry || typeof entry !== 'object') return [];
+  const record = entry as Partial<Record<keyof WorkforcePersonaReviewFix, unknown>>;
+  const severity = record.severity;
+  if (severity !== 'critical' && severity !== 'important' && severity !== 'moderate') return [];
+  if (typeof record.area !== 'string' || typeof record.finding !== 'string' || typeof record.requestedChange !== 'string') {
+    return [];
+  }
+  return [{
+    severity,
+    area: record.area,
+    finding: record.finding,
+    requestedChange: record.requestedChange,
+  }];
+}
+
+function digest(value: string): string {
+  return createHash('sha256').update(value).digest('hex');
+}
+
+/**
+ * Renders a flat list of fix strings suitable for feeding back into the
+ * writer's `validationFeedback.errors` channel. Each line carries the
+ * severity prefix so the writer can prioritise inside the repair attempt.
+ */
+export function renderReviewFixesForWriter(review: WorkforcePersonaReviewResult): string[] {
+  return review.fixes.map(
+    (fix) => `[${fix.severity}] ${fix.area}: ${fix.finding} — ${fix.requestedChange}`,
+  );
+}

--- a/src/product/generation/workforce-persona-writer.test.ts
+++ b/src/product/generation/workforce-persona-writer.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from 'vitest';
+import { afterEach, describe, expect, it } from 'vitest';
 import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
@@ -8,6 +8,7 @@ import { generate, generateWithWorkforcePersona } from './pipeline.js';
 import type { WorkforcePersonaExecution, WorkforcePersonaResolver } from './workforce-persona-writer.js';
 import {
   buildWorkflowPersonaTask,
+  dumpPersonaDebug,
   loadWorkforcePersonaModule,
   loadWorkforceSelectionModule,
   parsePersonaWorkflowResponse,
@@ -16,6 +17,8 @@ import {
   summarizeSpecForPersona,
   WORKFORCE_PERSONA_INTENT_CANDIDATES,
 } from './workforce-persona-writer.js';
+import { readFile } from 'node:fs/promises';
+import { existsSync } from 'node:fs';
 
 const RECEIVED_AT = '2026-04-30T00:00:00.000Z';
 
@@ -1349,6 +1352,118 @@ describe('workforce persona reviewer pass', () => {
     expect(result.success).toBe(true);
     expect(intentCalls).not.toContain('review');
     expect(result.workforcePersona?.review).toBeUndefined();
+  });
+});
+
+describe('persona debug dump', () => {
+  function dumpInputs(repoRoot: string, overrides: Partial<{ reason: 'noncompletion' | 'parse-error' | 'no-content' | 'success'; output: string; promptDigest: string }> = {}) {
+    return {
+      kind: 'writer' as const,
+      reason: overrides.reason ?? 'parse-error',
+      repoRoot,
+      promptDigest: overrides.promptDigest ?? 'a'.repeat(64),
+      task: 'task body',
+      result: {
+        status: 'completed' as const,
+        output: overrides.output ?? 'free-form sonnet prose',
+        stderr: '',
+        exitCode: 0,
+        durationMs: 4242,
+        workflowRunId: 'debug-dump-run',
+        stepName: 'agent-relay-workflow',
+      },
+      selection: {
+        personaId: 'agent-relay-workflow',
+        tier: 'best-value',
+        runtime: { harness: 'claude' as const, model: 'claude-sonnet-4-6' },
+      },
+      resolved: {
+        source: 'package' as const,
+        intent: 'agent-relay-workflow',
+        warnings: ['Ricky-local Claude persona override resolved for intent "agent-relay-workflow" at tier "best-value".'],
+        context: {
+          selection: {
+            personaId: 'agent-relay-workflow',
+            tier: 'best-value',
+            runtime: { harness: 'claude' as const, model: 'claude-sonnet-4-6' },
+          },
+          sendMessage() {
+            throw new Error('not invoked in debug-dump tests');
+          },
+        },
+      },
+      outputPath: 'workflows/generated/dump.ts',
+    };
+  }
+
+  let repoRoot: string | undefined;
+  afterEach(async () => {
+    if (repoRoot) {
+      await import('node:fs/promises').then(({ rm }) => rm(repoRoot!, { recursive: true, force: true }));
+      repoRoot = undefined;
+    }
+  });
+
+  it('writes output.raw.txt, task.prompt.txt, and meta.json on the parse-error path', async () => {
+    repoRoot = mkdtempSync(join(tmpdir(), 'ricky-persona-dump-'));
+    await dumpPersonaDebug(dumpInputs(repoRoot, { reason: 'parse-error', output: 'verbatim sonnet output' }));
+
+    const dir = join(repoRoot, '.workflow-artifacts', 'ricky-persona-debug', 'writer', `${'a'.repeat(16)}-parse-error`);
+    expect(existsSync(dir)).toBe(true);
+    const raw = await readFile(join(dir, 'output.raw.txt'), 'utf8');
+    const task = await readFile(join(dir, 'task.prompt.txt'), 'utf8');
+    const meta = JSON.parse(await readFile(join(dir, 'meta.json'), 'utf8')) as Record<string, unknown>;
+
+    expect(raw).toBe('verbatim sonnet output');
+    expect(task).toBe('task body');
+    expect(meta).toMatchObject({
+      kind: 'writer',
+      reason: 'parse-error',
+      outputPath: 'workflows/generated/dump.ts',
+      selection: { personaId: 'agent-relay-workflow', tier: 'best-value', harness: 'claude', model: 'claude-sonnet-4-6' },
+      result: { status: 'completed', exitCode: 0, durationMs: 4242 },
+      resolverIntent: 'agent-relay-workflow',
+    });
+  });
+
+  it('skips the success-path dump unless RICKY_PERSONA_DEBUG=1', async () => {
+    repoRoot = mkdtempSync(join(tmpdir(), 'ricky-persona-dump-'));
+    const originalFlag = process.env.RICKY_PERSONA_DEBUG;
+    delete process.env.RICKY_PERSONA_DEBUG;
+    try {
+      await dumpPersonaDebug(dumpInputs(repoRoot, { reason: 'success' }));
+      const dir = join(repoRoot, '.workflow-artifacts', 'ricky-persona-debug', 'writer', `${'a'.repeat(16)}-success`);
+      expect(existsSync(dir)).toBe(false);
+    } finally {
+      if (originalFlag !== undefined) process.env.RICKY_PERSONA_DEBUG = originalFlag;
+    }
+  });
+
+  it('records the success-path dump when RICKY_PERSONA_DEBUG=1', async () => {
+    repoRoot = mkdtempSync(join(tmpdir(), 'ricky-persona-dump-'));
+    const originalFlag = process.env.RICKY_PERSONA_DEBUG;
+    process.env.RICKY_PERSONA_DEBUG = '1';
+    try {
+      await dumpPersonaDebug(dumpInputs(repoRoot, { reason: 'success' }));
+      const dir = join(repoRoot, '.workflow-artifacts', 'ricky-persona-debug', 'writer', `${'a'.repeat(16)}-success`);
+      expect(existsSync(dir)).toBe(true);
+    } finally {
+      if (originalFlag === undefined) {
+        delete process.env.RICKY_PERSONA_DEBUG;
+      } else {
+        process.env.RICKY_PERSONA_DEBUG = originalFlag;
+      }
+    }
+  });
+
+  it('silently swallows dump errors when the repo root is unwritable', async () => {
+    // /nonexistent-ricky-test-root cannot be created without root; the helper
+    // must not throw or noisily log to stderr by default.
+    await expect(
+      dumpPersonaDebug({
+        ...dumpInputs('/nonexistent-ricky-test-root-' + Date.now(), { reason: 'parse-error' }),
+      }),
+    ).resolves.toBeUndefined();
   });
 });
 

--- a/src/product/generation/workforce-persona-writer.test.ts
+++ b/src/product/generation/workforce-persona-writer.test.ts
@@ -243,6 +243,7 @@ describe('workforce persona workflow writer', () => {
         targetMode: 'local',
         installSkills: false,
         resolver,
+        review: false,
       },
     });
 
@@ -311,6 +312,7 @@ describe('workforce persona workflow writer', () => {
         workflowName: 'runtime-master',
         targetMode: 'local',
         resolver,
+        review: false,
       },
     });
 
@@ -360,6 +362,7 @@ describe('workforce persona workflow writer', () => {
         workflowName: 'malformed',
         targetMode: 'local',
         resolver,
+        review: false,
       },
     });
 
@@ -414,6 +417,7 @@ describe('workforce persona workflow writer', () => {
         workflowName: 'clarify',
         targetMode: 'local',
         resolver,
+        review: false,
       },
     });
 
@@ -470,6 +474,7 @@ describe('workforce persona workflow writer', () => {
         workflowName: 'prewrite-repair',
         targetMode: 'local',
         resolver,
+        review: false,
       },
     });
 
@@ -525,6 +530,7 @@ describe('workforce persona workflow writer', () => {
         workflowName: 'prewrite-cwd-repair',
         targetMode: 'local',
         resolver,
+        review: false,
       },
     });
 
@@ -585,6 +591,7 @@ describe('workforce persona workflow writer', () => {
         tier: 'minimum',
         repairAttempts: 4,
         resolver,
+        review: false,
       },
     });
 
@@ -641,6 +648,7 @@ describe('workforce persona workflow writer', () => {
         workflowName: 'prewrite-fallback',
         targetMode: 'local',
         resolver,
+        review: false,
       },
     });
 
@@ -776,6 +784,9 @@ describe('workforce persona workflow writer', () => {
         workflowName: 'workforce-writer',
         targetMode: 'local',
         resolver,
+        // Writer-in-isolation test: the post-write reviewer pass is exercised
+        // separately in pipeline-review.test.ts.
+        review: false,
       },
     });
 
@@ -848,6 +859,7 @@ describe('workforce persona workflow writer', () => {
         workflowName: 'router-tier',
         targetMode: 'local',
         resolver,
+        review: false,
       },
     });
 
@@ -988,6 +1000,257 @@ describe('workforce persona workflow writer', () => {
       message: expect.stringContaining('does not expose the persona selection API'),
       warnings: [expect.stringContaining('exports: resolvePersona')],
     });
+  });
+});
+
+describe('workforce persona reviewer pass', () => {
+  it('passes the writer artifact through when the reviewer returns verdict=pass', async () => {
+    const baseGen = generate({
+      spec: spec({
+        description: 'Implement a strict Agent Relay workflow with tests and review.',
+        targetFiles: ['src/product/generation/pipeline.ts'],
+      }),
+      artifactPath: 'workflows/generated/reviewer-pass.ts',
+    });
+    expect(baseGen.success).toBe(true);
+    const writerArtifact = baseGen.artifact!.content;
+
+    const intentCalls: string[] = [];
+    const resolver: WorkforcePersonaResolver = async (intents) => {
+      const intent = intents[0];
+      intentCalls.push(intent);
+      return {
+        source: 'package',
+        intent,
+        warnings: [],
+        context: {
+          selection: {
+            personaId: intent,
+            tier: intent === 'review' ? 'best' : 'best-value',
+            runtime: { harness: 'claude', model: intent === 'review' ? 'claude-opus-4-7' : 'claude-sonnet-4-6' },
+          },
+          sendMessage() {
+            if (intent === 'review') {
+              return execution(JSON.stringify({ verdict: 'pass', summary: 'All checks green.', fixes: [] }));
+            }
+            return execution(personaResponse('workflows/generated/reviewer-pass.ts', writerArtifact));
+          },
+        },
+      };
+    };
+
+    const result = await generateWithWorkforcePersona({
+      spec: spec({
+        description: 'Implement a strict Agent Relay workflow with tests and review.',
+        targetFiles: ['src/product/generation/pipeline.ts'],
+      }),
+      artifactPath: 'workflows/generated/reviewer-pass.ts',
+      workforcePersonaWriter: {
+        repoRoot: '/repo',
+        workflowName: 'reviewer-pass',
+        targetMode: 'local',
+        resolver,
+        review: { personaIntentCandidates: ['review'] },
+      },
+    });
+
+    expect(result.success).toBe(true);
+    expect(intentCalls).toContain('review');
+    expect(result.workforcePersona?.review).toMatchObject({
+      verdict: 'pass',
+      personaId: 'review',
+      tier: 'best',
+      model: 'claude-opus-4-7',
+      selectedIntent: 'review',
+      appliedFix: false,
+    });
+    expect(result.artifact?.content).toBe(writerArtifact);
+  });
+
+  it('feeds reviewer fixes back to the writer for a single repair attempt when verdict=fix', async () => {
+    const baseGen = generate({
+      spec: spec({
+        description: 'Implement a strict Agent Relay workflow with tests and review.',
+        targetFiles: ['src/product/generation/pipeline.ts'],
+      }),
+      artifactPath: 'workflows/generated/reviewer-fix.ts',
+    });
+    expect(baseGen.success).toBe(true);
+    const writerFirstArtifact = baseGen.artifact!.content;
+    const writerRepairArtifact = baseGen.artifact!.content.replace(/Persona generated workflow/g, 'Repaired by reviewer feedback');
+    const writerCalls: string[] = [];
+    let reviewerInvocations = 0;
+
+    const resolver: WorkforcePersonaResolver = async (intents) => {
+      const intent = intents[0];
+      return {
+        source: 'package',
+        intent,
+        warnings: [],
+        context: {
+          selection: {
+            personaId: intent,
+            tier: intent === 'review' ? 'best' : 'best-value',
+            runtime: { harness: 'claude', model: intent === 'review' ? 'claude-opus-4-7' : 'claude-sonnet-4-6' },
+          },
+          sendMessage(task) {
+            if (intent === 'review') {
+              reviewerInvocations += 1;
+              return execution(JSON.stringify({
+                verdict: 'fix',
+                summary: 'Swarm pattern does not match the spec Merge DAG.',
+                fixes: [{
+                  severity: 'critical',
+                  area: 'swarm-pattern',
+                  finding: 'Pipeline serializes parallel tracks.',
+                  requestedChange: 'Switch to a dag pattern with parallel child invocations per Track.',
+                }],
+              }));
+            }
+            const isRepair = task.includes('Ricky pre-write validation failed on your previous artifact.');
+            writerCalls.push(isRepair ? 'writer-repair' : 'writer-first');
+            return execution(personaResponse(
+              'workflows/generated/reviewer-fix.ts',
+              isRepair ? writerRepairArtifact : writerFirstArtifact,
+            ));
+          },
+        },
+      };
+    };
+
+    const result = await generateWithWorkforcePersona({
+      spec: spec({
+        description: 'Implement a strict Agent Relay workflow with tests and review.',
+        targetFiles: ['src/product/generation/pipeline.ts'],
+      }),
+      artifactPath: 'workflows/generated/reviewer-fix.ts',
+      workforcePersonaWriter: {
+        repoRoot: '/repo',
+        workflowName: 'reviewer-fix',
+        targetMode: 'local',
+        resolver,
+        review: { personaIntentCandidates: ['review'] },
+      },
+    });
+
+    expect(result.success).toBe(true);
+    expect(reviewerInvocations).toBe(1);
+    expect(writerCalls).toEqual(['writer-first', 'writer-repair']);
+    expect(result.workforcePersona?.review).toMatchObject({
+      verdict: 'fix',
+      appliedFix: true,
+      fixes: [{ severity: 'critical', area: 'swarm-pattern' }],
+    });
+    expect(result.artifact?.content).toBe(writerRepairArtifact);
+  });
+
+  it('returns verdict=block with no fixes and keeps the writer artifact when reviewer output is unparseable', async () => {
+    const baseGen = generate({
+      spec: spec({
+        description: 'Implement a strict Agent Relay workflow with tests and review.',
+        targetFiles: ['src/product/generation/pipeline.ts'],
+      }),
+      artifactPath: 'workflows/generated/reviewer-block.ts',
+    });
+    expect(baseGen.success).toBe(true);
+    const writerArtifact = baseGen.artifact!.content;
+    const resolver: WorkforcePersonaResolver = async (intents) => {
+      const intent = intents[0];
+      return {
+        source: 'package',
+        intent,
+        warnings: [],
+        context: {
+          selection: {
+            personaId: intent,
+            tier: intent === 'review' ? 'best' : 'best-value',
+            runtime: { harness: 'claude', model: intent === 'review' ? 'claude-opus-4-7' : 'claude-sonnet-4-6' },
+          },
+          sendMessage() {
+            if (intent === 'review') {
+              // Reviewer emitted prose with no JSON verdict; pipeline should treat as block.
+              return execution('I looked at the workflow and have concerns but no parseable verdict block.');
+            }
+            return execution(personaResponse('workflows/generated/reviewer-block.ts', writerArtifact));
+          },
+        },
+      };
+    };
+
+    const result = await generateWithWorkforcePersona({
+      spec: spec({
+        description: 'Implement a strict Agent Relay workflow with tests and review.',
+        targetFiles: ['src/product/generation/pipeline.ts'],
+      }),
+      artifactPath: 'workflows/generated/reviewer-block.ts',
+      workforcePersonaWriter: {
+        repoRoot: '/repo',
+        workflowName: 'reviewer-block',
+        targetMode: 'local',
+        resolver,
+        review: { personaIntentCandidates: ['review'] },
+      },
+    });
+
+    expect(result.success).toBe(true);
+    expect(result.workforcePersona?.review).toMatchObject({
+      verdict: 'block',
+      appliedFix: false,
+      fixes: [],
+    });
+    // Block-with-no-fixes path leaves the writer artifact intact.
+    expect(result.artifact?.content).toBe(writerArtifact);
+  });
+
+  it('skips the review pass when workforcePersonaWriter.review is false', async () => {
+    const baseGen = generate({
+      spec: spec({
+        description: 'Implement a strict Agent Relay workflow with tests and review.',
+        targetFiles: ['src/product/generation/pipeline.ts'],
+      }),
+      artifactPath: 'workflows/generated/reviewer-off.ts',
+    });
+    expect(baseGen.success).toBe(true);
+    const writerArtifact = baseGen.artifact!.content;
+    const intentCalls: string[] = [];
+    const resolver: WorkforcePersonaResolver = async (intents) => {
+      const intent = intents[0];
+      intentCalls.push(intent);
+      return {
+        source: 'package',
+        intent,
+        warnings: [],
+        context: {
+          selection: {
+            personaId: intent,
+            tier: 'best-value',
+            runtime: { harness: 'claude', model: 'claude-sonnet-4-6' },
+          },
+          sendMessage() {
+            return execution(personaResponse('workflows/generated/reviewer-off.ts', writerArtifact));
+          },
+        },
+      };
+    };
+
+    const result = await generateWithWorkforcePersona({
+      spec: spec({
+        description: 'Implement a strict Agent Relay workflow with tests and review.',
+        targetFiles: ['src/product/generation/pipeline.ts'],
+      }),
+      artifactPath: 'workflows/generated/reviewer-off.ts',
+      workforcePersonaWriter: {
+        repoRoot: '/repo',
+        workflowName: 'reviewer-off',
+        targetMode: 'local',
+        resolver,
+        review: false,
+      },
+    });
+
+    expect(result.success).toBe(true);
+    expect(intentCalls).not.toContain('review');
+    expect(result.workforcePersona?.review).toBeUndefined();
   });
 });
 

--- a/src/product/generation/workforce-persona-writer.test.ts
+++ b/src/product/generation/workforce-persona-writer.test.ts
@@ -12,6 +12,8 @@ import {
   loadWorkforceSelectionModule,
   parsePersonaWorkflowResponse,
   resolveWorkforcePersonaContextWithModules,
+  summarizeRelevantFilesForPersona,
+  summarizeSpecForPersona,
   WORKFORCE_PERSONA_INTENT_CANDIDATES,
 } from './workforce-persona-writer.js';
 
@@ -1000,6 +1002,102 @@ describe('workforce persona workflow writer', () => {
       message: expect.stringContaining('does not expose the persona selection API'),
       warnings: [expect.stringContaining('exports: resolvePersona')],
     });
+  });
+});
+
+describe('workforce persona writer task summarization', () => {
+  it('elides the raw spec payload text on every summarization', () => {
+    const longDescription = 'A'.repeat(50);
+    const summarized = summarizeSpecForPersona(spec({ description: longDescription }));
+    const rawPayload = summarized.spec.sourceSpec.rawPayload;
+    expect(rawPayload.kind).toBe('natural_language');
+    if (rawPayload.kind === 'natural_language') {
+      expect(rawPayload.text).toContain('<<elided');
+      expect(rawPayload.text).not.toContain(longDescription);
+    }
+    expect(summarized.spec.sourceSpec.description).toBe('<<elided: see top-level description field>>');
+  });
+
+  it('preserves description when it fits under the cap and reports truncated=false', () => {
+    const summarized = summarizeSpecForPersona(spec({ description: 'small description body' }));
+    expect(summarized.spec.description).toBe('small description body');
+    expect(summarized.descriptionTruncated).toBe(false);
+  });
+
+  it('truncates oversized descriptions with a head + tail elision marker', () => {
+    const huge = `${'X'.repeat(40_000)}\n--- middle landmark ---\n${'Y'.repeat(40_000)}`;
+    const summarized = summarizeSpecForPersona(spec({ description: huge }));
+    expect(summarized.descriptionTruncated).toBe(true);
+    expect(summarized.spec.description).toContain('<<truncated');
+    // Head from the start AND tail from the end both survive.
+    expect(summarized.spec.description.startsWith('XXXX')).toBe(true);
+    expect(summarized.spec.description.endsWith('YYYY')).toBe(true);
+    // Whole summarized spec must fit under ~64KB even though input was 80KB.
+    const serialized = JSON.stringify(summarized.spec);
+    expect(serialized.length).toBeLessThan(64 * 1024);
+  });
+
+  it('caps relevant file contents per-file and reports per-file omission counts', () => {
+    const big = 'A'.repeat(20_000);
+    const result = summarizeRelevantFilesForPersona([
+      { path: 'a.ts', content: big },
+      { path: 'b.ts', content: 'tiny' },
+    ]);
+    expect(result.includedCount).toBe(2);
+    expect(result.files[0].content).toContain('<<truncated');
+    expect(result.files[0].bytesOmitted).toBeGreaterThan(0);
+    expect(result.files[1].content).toBe('tiny');
+    expect(result.files[1].bytesOmitted).toBeUndefined();
+  });
+
+  it('drops file contents past the total relevant-file budget but keeps the path entry', () => {
+    const big = 'A'.repeat(8 * 1024);
+    const files = Array.from({ length: 30 }, (_, idx) => ({ path: `file-${idx}.ts`, content: big }));
+    const result = summarizeRelevantFilesForPersona(files);
+    expect(result.files).toHaveLength(30);
+    const omitted = result.files.filter((file) => file.omitted === true);
+    expect(omitted.length).toBeGreaterThan(0);
+    omitted.forEach((entry) => expect(entry.content).toBeNull());
+  });
+
+  it('references the spec file by path and notes truncation when description is oversized', () => {
+    const huge = 'A'.repeat(60_000);
+    const task = buildWorkflowPersonaTask(spec({ description: huge }), {
+      workflowName: 'reference-spec-by-path',
+      targetMode: 'local',
+      repoRoot: '/repo',
+      outputPath: 'workflows/generated/reference-spec.ts',
+      relevantFiles: [],
+      specPath: '/repo/docs/plans/big-spec.md',
+    });
+    expect(task).toContain('Spec source file');
+    expect(task).toContain('/repo/docs/plans/big-spec.md');
+    expect(task).toContain('Read the spec file for full content');
+    expect(task).toContain('<<truncated');
+    // Top-level "Normalized spec JSON" wording should reflect the truncation note.
+    expect(task).toContain('description/targetContext truncated when oversized; raw spec payload elided');
+    // Total task body must be well under 200 KB regardless of input size.
+    expect(task.length).toBeLessThan(200 * 1024);
+  });
+
+  it('keeps the original raw spec text out of the writer task body', () => {
+    // Place the sentinel in the middle of an oversized description so that
+    // head/tail truncation excludes it from the inlined description AND so
+    // that raw-payload elision is the only path that could surface it.
+    const sentinel = 'SECRET-RAW-SPEC-SENTINEL';
+    const description = `${'A'.repeat(80_000)}${sentinel}${'B'.repeat(80_000)}`;
+    const task = buildWorkflowPersonaTask(spec({ description }), {
+      workflowName: 'elision',
+      targetMode: 'local',
+      repoRoot: '/repo',
+      outputPath: 'workflows/generated/elision.ts',
+      relevantFiles: [],
+      specPath: '/repo/docs/plans/big-spec.md',
+    });
+    // The unique sentinel must not appear verbatim because both description
+    // and rawPayload.text are summarized/elided.
+    expect(task).not.toContain(sentinel);
+    expect(task).toContain('<<elided');
   });
 });
 

--- a/src/product/generation/workforce-persona-writer.test.ts
+++ b/src/product/generation/workforce-persona-writer.test.ts
@@ -126,6 +126,35 @@ describe('workforce persona workflow writer', () => {
     });
   });
 
+  it('parses Sonnet output with prose preamble + unclosed ```json fence', () => {
+    // Empirical regression: Claude Sonnet running the agent-relay-workflow
+    // persona emits a one-line preamble plus an opening ```json fence with
+    // no matching closing fence; the JSON payload is otherwise valid.
+    // Captured via the persona-debug dump from the deploy-v1 smoke run.
+    const payload = JSON.stringify({
+      artifact: { path: 'workflows/generated/persona.ts', content: workflowSource() },
+      metadata: { workflowName: 'persona', summary: 'tiny' },
+    });
+    const sonnetShaped = `Now I have enough context. I'll generate the workflow artifact.\n\n\`\`\`json\n${payload}`;
+    const parsed = parsePersonaWorkflowResponse(sonnetShaped, 'workflows/generated/persona.ts');
+    expect(parsed.responseFormat).toBe('structured-json');
+    expect(parsed.content).toContain('.run({ cwd: process.cwd() })');
+    expect(parsed.metadata).toMatchObject({ workflowName: 'persona' });
+  });
+
+  it('parses persona output with prose preamble and no fences at all', () => {
+    const payload = JSON.stringify({
+      artifact: { path: 'workflows/generated/persona.ts', content: workflowSource() },
+      metadata: { workflowName: 'persona' },
+    });
+    const parsed = parsePersonaWorkflowResponse(
+      `Here is the workflow you asked for:\n\n${payload}\n\nLet me know if you want me to adjust anything.`,
+      'workflows/generated/persona.ts',
+    );
+    expect(parsed.responseFormat).toBe('structured-json');
+    expect(parsed.content).toContain('.run({ cwd: process.cwd() })');
+  });
+
   it('parses fenced TypeScript artifact plus JSON metadata fallback', () => {
     const parsed = parsePersonaWorkflowResponse([
       '```ts',

--- a/src/product/generation/workforce-persona-writer.test.ts
+++ b/src/product/generation/workforce-persona-writer.test.ts
@@ -1133,6 +1133,66 @@ describe('workforce persona writer task summarization', () => {
   });
 });
 
+describe('workforce persona reviewer verdict parsing', () => {
+  it('prefers the LAST ```json fenced verdict over an earlier draft block', async () => {
+    const { parseReviewerVerdict } = await import('./workforce-persona-reviewer.js');
+    const output = [
+      'First, a draft assessment:',
+      '```json',
+      JSON.stringify({ verdict: 'fix', summary: 'draft', fixes: [{ severity: 'critical', area: 'x', finding: 'y', requestedChange: 'z' }] }),
+      '```',
+      '',
+      'After reviewing more carefully, my final verdict:',
+      '```json',
+      JSON.stringify({ verdict: 'pass', summary: 'final approval', fixes: [] }),
+      '```',
+    ].join('\n');
+    const result = parseReviewerVerdict(output);
+    expect(result.verdict).toBe('pass');
+    expect(result.summary).toBe('final approval');
+    expect(result.fixes).toEqual([]);
+  });
+
+  it('ignores ```json blocks that nest inside an audited workflow source', async () => {
+    const { parseReviewerVerdict } = await import('./workforce-persona-reviewer.js');
+    // A reviewer audit response that includes the workflow source the
+    // reviewer is auditing (inside ```ts) MUST NOT pick up any nested
+    // json-looking content from the workflow body. The mdast walker only
+    // returns top-level fenced code blocks with lang=json, so the inner
+    // workflow source is invisible.
+    const output = [
+      'Audit of the generated workflow:',
+      '```ts',
+      'const example = { "verdict": "fix", "summary": "this is INSIDE the workflow source, not a verdict" };',
+      '```',
+      '',
+      'My verdict:',
+      '```json',
+      JSON.stringify({ verdict: 'pass', summary: 'all good', fixes: [] }),
+      '```',
+    ].join('\n');
+    const result = parseReviewerVerdict(output);
+    expect(result.verdict).toBe('pass');
+    expect(result.summary).toBe('all good');
+  });
+
+  it('falls through to trailing balanced-JSON when no fenced block carries a verdict', async () => {
+    const { parseReviewerVerdict } = await import('./workforce-persona-reviewer.js');
+    const output = `I reviewed the workflow and here is my verdict:\n\n${JSON.stringify({ verdict: 'fix', summary: 's', fixes: [{ severity: 'important', area: 'a', finding: 'f', requestedChange: 'r' }] })}`;
+    const result = parseReviewerVerdict(output);
+    expect(result.verdict).toBe('fix');
+    expect(result.fixes).toHaveLength(1);
+  });
+
+  it('synthesizes block verdict when no candidate parses', async () => {
+    const { parseReviewerVerdict } = await import('./workforce-persona-reviewer.js');
+    const result = parseReviewerVerdict('I have opinions but no JSON to share today.');
+    expect(result.verdict).toBe('block');
+    expect(result.summary).toMatch(/Reviewer response did not contain a parseable verdict JSON/);
+    expect(result.fixes).toEqual([]);
+  });
+});
+
 describe('workforce persona reviewer pass', () => {
   it('passes the writer artifact through when the reviewer returns verdict=pass', async () => {
     const baseGen = generate({
@@ -1381,6 +1441,137 @@ describe('workforce persona reviewer pass', () => {
     expect(result.success).toBe(true);
     expect(intentCalls).not.toContain('review');
     expect(result.workforcePersona?.review).toBeUndefined();
+  });
+
+  it('records verdict=block + non-empty fixes WITHOUT triggering a writer repair', async () => {
+    const baseGen = generate({
+      spec: spec({
+        description: 'Implement a strict Agent Relay workflow with tests and review.',
+        targetFiles: ['src/product/generation/pipeline.ts'],
+      }),
+      artifactPath: 'workflows/generated/reviewer-block-with-fixes.ts',
+    });
+    expect(baseGen.success).toBe(true);
+    const writerArtifact = baseGen.artifact!.content;
+    const writerCalls: string[] = [];
+
+    const resolver: WorkforcePersonaResolver = async (intents) => {
+      const intent = intents[0];
+      return {
+        source: 'package',
+        intent,
+        warnings: [],
+        context: {
+          selection: {
+            personaId: intent,
+            tier: intent === 'review' ? 'best' : 'best-value',
+            runtime: { harness: 'claude', model: intent === 'review' ? 'claude-opus-4-7' : 'claude-sonnet-4-6' },
+          },
+          sendMessage(task) {
+            if (intent === 'review') {
+              // `block` + non-empty fixes: pipeline must record the verdict
+              // but not feed the fixes back into a writer repair attempt.
+              return execution(JSON.stringify({
+                verdict: 'block',
+                summary: 'Spec is planning-only but writer produced implementation work.',
+                fixes: [{ severity: 'critical', area: 'scope', finding: 'Spec drift', requestedChange: 'Stop and re-scope.' }],
+              }));
+            }
+            const isRepair = task.includes('Ricky pre-write validation failed on your previous artifact.');
+            writerCalls.push(isRepair ? 'writer-repair' : 'writer-first');
+            return execution(personaResponse('workflows/generated/reviewer-block-with-fixes.ts', writerArtifact));
+          },
+        },
+      };
+    };
+
+    const result = await generateWithWorkforcePersona({
+      spec: spec({
+        description: 'Implement a strict Agent Relay workflow with tests and review.',
+        targetFiles: ['src/product/generation/pipeline.ts'],
+      }),
+      artifactPath: 'workflows/generated/reviewer-block-with-fixes.ts',
+      workforcePersonaWriter: {
+        repoRoot: '/repo',
+        workflowName: 'reviewer-block-with-fixes',
+        targetMode: 'local',
+        resolver,
+        review: { personaIntentCandidates: ['review'] },
+      },
+    });
+
+    expect(result.success).toBe(true);
+    // Writer must have been called exactly once — `block` short-circuits
+    // the repair attempt.
+    expect(writerCalls).toEqual(['writer-first']);
+    expect(result.workforcePersona?.review).toMatchObject({
+      verdict: 'block',
+      appliedFix: false,
+      fixes: [{ severity: 'critical', area: 'scope' }],
+    });
+    expect(result.artifact?.content).toBe(writerArtifact);
+  });
+
+  it('records verdict=error when the reviewer pass itself throws', async () => {
+    const baseGen = generate({
+      spec: spec({
+        description: 'Implement a strict Agent Relay workflow with tests and review.',
+        targetFiles: ['src/product/generation/pipeline.ts'],
+      }),
+      artifactPath: 'workflows/generated/reviewer-crashed.ts',
+    });
+    expect(baseGen.success).toBe(true);
+    const writerArtifact = baseGen.artifact!.content;
+
+    const resolver: WorkforcePersonaResolver = async (intents) => {
+      const intent = intents[0];
+      if (intent === 'review') {
+        // Simulate a reviewer-side crash (e.g. resolver/harness failure).
+        // The pipeline catch block must mark the verdict as `error`, not
+        // `pass` — otherwise downstream automation misreads "reviewer
+        // crashed" as "reviewer approved."
+        throw new Error('synthetic reviewer harness failure');
+      }
+      return {
+        source: 'package',
+        intent,
+        warnings: [],
+        context: {
+          selection: {
+            personaId: intent,
+            tier: 'best-value',
+            runtime: { harness: 'claude', model: 'claude-sonnet-4-6' },
+          },
+          sendMessage() {
+            return execution(personaResponse('workflows/generated/reviewer-crashed.ts', writerArtifact));
+          },
+        },
+      };
+    };
+
+    const result = await generateWithWorkforcePersona({
+      spec: spec({
+        description: 'Implement a strict Agent Relay workflow with tests and review.',
+        targetFiles: ['src/product/generation/pipeline.ts'],
+      }),
+      artifactPath: 'workflows/generated/reviewer-crashed.ts',
+      workforcePersonaWriter: {
+        repoRoot: '/repo',
+        workflowName: 'reviewer-crashed',
+        targetMode: 'local',
+        resolver,
+        review: { personaIntentCandidates: ['review'] },
+      },
+    });
+
+    expect(result.success).toBe(true);
+    expect(result.workforcePersona?.review).toMatchObject({
+      verdict: 'error',
+      appliedFix: false,
+      fixes: [],
+    });
+    expect(result.workforcePersona?.review?.summary).toContain('synthetic reviewer harness failure');
+    expect(result.artifact?.content).toBe(writerArtifact);
   });
 });
 

--- a/src/product/generation/workforce-persona-writer.ts
+++ b/src/product/generation/workforce-persona-writer.ts
@@ -911,9 +911,70 @@ export function parsePersonaWorkflowResponse(
     return validateFencedResponse(tsFence, metadata, expectedPath);
   }
 
+  // Tolerant fallback: Claude Sonnet has been observed to emit a prose
+  // preamble plus a ```json opening fence without a matching closing fence,
+  // which defeats both the direct-JSON and fenced-block matchers above. As
+  // a last resort, walk the response looking for the first balanced JSON
+  // object and treat that as the structured response. Picks up:
+  //   - "preamble text\n```json\n{ ... }"   (unclosed fence)
+  //   - "preamble text\n{ ... }"            (no fence at all)
+  //   - "{ ... }\ntrailing prose"           (trailing prose after JSON)
+  const embedded = extractFirstBalancedJsonObject(output);
+  if (embedded) {
+    const clarification = parseClarificationResponse(embedded);
+    if (clarification) return { metadata: {}, responseFormat: 'needs-clarification', clarification };
+    return validateStructuredResponse(embedded, expectedPath, 'structured-json', options);
+  }
+
   throw new WorkforcePersonaWriterError(
     'Workforce persona response must be structured JSON or include fenced TypeScript artifact and JSON metadata blocks.',
   );
+}
+
+/**
+ * Walks `text` looking for the first top-level balanced `{ ... }` object
+ * and parses it. String literals (including nested escape sequences) and
+ * the brace-tracking are handled inline so the scanner is not confused by
+ * a `}` that appears inside a JSON string value (e.g. the embedded
+ * TypeScript source the writer returns inside `artifact.content`).
+ *
+ * Returns the parsed object or `null` when no balanced object exists or
+ * the candidate substring is not valid JSON.
+ */
+export function extractFirstBalancedJsonObject(text: string): Record<string, unknown> | null {
+  for (let start = 0; start < text.length; start += 1) {
+    if (text[start] !== '{') continue;
+    let depth = 0;
+    let inString = false;
+    let escape = false;
+    for (let i = start; i < text.length; i += 1) {
+      const ch = text[i];
+      if (escape) {
+        escape = false;
+        continue;
+      }
+      if (ch === '\\') {
+        if (inString) escape = true;
+        continue;
+      }
+      if (ch === '"') {
+        inString = !inString;
+        continue;
+      }
+      if (inString) continue;
+      if (ch === '{') depth += 1;
+      else if (ch === '}') {
+        depth -= 1;
+        if (depth === 0) {
+          const candidate = text.slice(start, i + 1);
+          const parsed = parseJsonObject(candidate);
+          if (parsed) return parsed;
+          break; // Candidate did not parse; resume scan from the next `{`.
+        }
+      }
+    }
+  }
+  return null;
 }
 
 function parseClarificationResponse(value: Record<string, unknown>): ClarificationRequest | null {

--- a/src/product/generation/workforce-persona-writer.ts
+++ b/src/product/generation/workforce-persona-writer.ts
@@ -104,6 +104,8 @@ export interface WorkforcePersonaWriterOptions {
   installSkills?: boolean;
   installRoot?: string;
   tier?: string;
+  /** Absolute path to the source spec file when known. The writer task references it so the persona can Read the spec instead of receiving it inline. */
+  specPath?: string;
   env?: NodeJS.ProcessEnv;
   signal?: AbortSignal;
   onProgress?: (chunk: { stream: 'stdout' | 'stderr'; text: string }) => void;
@@ -221,6 +223,7 @@ export async function writeWorkflowWithWorkforcePersona(
     relevantFiles,
     skillContext: options.skillContext,
     validationFeedback: options.validationFeedback,
+    ...(options.specPath ? { specPath: options.specPath } : {}),
   });
   const promptDigest = digest(task);
   const selection = resolved.context.selection;
@@ -496,6 +499,22 @@ export async function loadWorkforceSelectionModule(importPackage: WorkforcePacka
   );
 }
 
+/**
+ * Soft caps for the persona writer task body. The total task size is the
+ * sum of these caps plus the boilerplate prose; under default values the
+ * task body is well under 200 KB even for the largest specs we have seen
+ * (1.5 MB raw payload, 81 relevant files, ~600 KB validation feedback).
+ *
+ * The hard cap on description (`MAX_DESCRIPTION_BYTES`) is the one that
+ * matters most because the raw spec text is the dominant cost for natural-
+ * language specs; everything else is bounded by per-item caps.
+ */
+const MAX_DESCRIPTION_BYTES = 32 * 1024;
+const MAX_TARGET_CONTEXT_BYTES = 8 * 1024;
+const MAX_RELEVANT_FILE_BYTES = 8 * 1024;
+const MAX_RELEVANT_FILES_TOTAL_BYTES = 96 * 1024;
+const MAX_VALIDATION_FEEDBACK_PREVIOUS_BYTES = 16 * 1024;
+
 export function buildWorkflowPersonaTask(
   spec: NormalizedWorkflowSpec,
   input: {
@@ -506,6 +525,7 @@ export function buildWorkflowPersonaTask(
     relevantFiles: Array<{ path: string; content?: string }>;
     skillContext?: SkillContext;
     validationFeedback?: WorkforcePersonaValidationFeedback;
+    specPath?: string;
   },
 ): string {
   const contract = {
@@ -535,13 +555,28 @@ export function buildWorkflowPersonaTask(
     },
   };
 
+  const summarizedSpec = summarizeSpecForPersona(spec);
+  const summarizedRelevantFiles = summarizeRelevantFilesForPersona(input.relevantFiles);
+
+  const specReference =
+    input.specPath && summarizedSpec.descriptionTruncated
+      ? [
+          `Spec source file (read it directly when you need more detail than the summary below): ${input.specPath}`,
+          `The summarized spec below truncates description and target context for prompt size. Read the spec file for full content.`,
+          '',
+        ]
+      : input.specPath
+        ? [`Spec source file (full content is also included below): ${input.specPath}`, '']
+        : [];
+
   return [
     'Write an Agent Relay workflow artifact for Ricky.',
     'Run as a non-interactive one-shot persona invocation. Return only the response contract.',
     'If the normalized spec has blocking ambiguity or open questions, return needs_clarification with targeted user-facing questions instead of guessing.',
     '',
-    'Normalized spec JSON:',
-    JSON.stringify(spec, null, 2),
+    ...specReference,
+    'Normalized spec JSON (description/targetContext truncated when oversized; raw spec payload elided):',
+    JSON.stringify(summarizedSpec.spec, null, 2),
     '',
     `Workflow name: ${input.workflowName}`,
     `Target mode: ${input.targetMode}`,
@@ -554,13 +589,11 @@ export function buildWorkflowPersonaTask(
       targetMode: input.targetMode,
       repoRoot: input.repoRoot,
       outputPath: input.outputPath,
+      ...(input.specPath ? { specPath: input.specPath } : {}),
     }, null, 2),
     '',
-    'Relevant file context:',
-    safeJson(input.relevantFiles.map((file) => ({
-      path: file.path,
-      content: file.content ?? null,
-    }))),
+    `Relevant file context (${summarizedRelevantFiles.includedCount} of ${input.relevantFiles.length} files; per-file content truncated above ${MAX_RELEVANT_FILE_BYTES} bytes):`,
+    safeJson(summarizedRelevantFiles.files),
     '',
     'Matched Ricky generation skills:',
     renderSkillContextForPersona(input.skillContext),
@@ -611,6 +644,10 @@ function renderValidationFeedbackForPersona(
   feedback: WorkforcePersonaValidationFeedback | undefined,
 ): string[] {
   if (!feedback) return [];
+  const trimmedPreviousContent = truncateText(
+    feedback.previousContent,
+    MAX_VALIDATION_FEEDBACK_PREVIOUS_BYTES,
+  );
   return [
     'Ricky pre-write validation failed on your previous artifact.',
     'Fix every validation issue before returning the complete replacement artifact.',
@@ -627,12 +664,168 @@ function renderValidationFeedbackForPersona(
           '',
         ]
       : []),
-    'Previous rejected artifact:',
+    'Previous rejected artifact (truncated when oversized):',
     '```ts',
-    feedback.previousContent.trimEnd(),
+    trimmedPreviousContent.text.trimEnd(),
     '```',
     '',
   ];
+}
+
+interface SummarizedSpec {
+  spec: NormalizedWorkflowSpec;
+  descriptionTruncated: boolean;
+}
+
+/**
+ * Produces a writer-task-ready clone of the normalized spec with the
+ * raw spec payload elided (it duplicates `description`) and `description`
+ * + `targetContext` truncated when oversized. Keeps every structured
+ * field intact — target files, constraints, evidence requirements, and
+ * acceptance gates are short and are what the persona actually needs to
+ * decompose the workflow.
+ */
+export function summarizeSpecForPersona(spec: NormalizedWorkflowSpec): SummarizedSpec {
+  const description = truncateText(spec.description, MAX_DESCRIPTION_BYTES);
+  const targetContext =
+    typeof spec.targetContext === 'string'
+      ? truncateText(spec.targetContext, MAX_TARGET_CONTEXT_BYTES)
+      : null;
+
+  const elidedSourceSpec = {
+    ...spec.sourceSpec,
+    description: '<<elided: see top-level description field>>',
+    rawPayload: elideRawPayload(spec.sourceSpec.rawPayload),
+  };
+
+  // `desiredAction.summary` and `desiredAction.specText` typically duplicate
+  // the top-level description (see request-normalizer.ts); when the user
+  // passes `--spec-file <large.md>` they grow to the same multi-hundred-KB
+  // size as the spec text. `summary` keeps a short cap because the persona
+  // task lists it separately; `specText` is elided entirely because every
+  // byte of it duplicates `description` for natural-language specs.
+  const SUMMARY_CAP_BYTES = 4 * 1024;
+  const desiredActionSummary = truncateText(spec.desiredAction.summary, SUMMARY_CAP_BYTES);
+  const desiredActionSpecTextElided = typeof spec.desiredAction.specText === 'string';
+
+  const summarized: NormalizedWorkflowSpec = {
+    ...spec,
+    description: description.text,
+    targetContext: targetContext ? targetContext.text : spec.targetContext,
+    desiredAction: {
+      ...spec.desiredAction,
+      summary: desiredActionSummary.text,
+      ...(desiredActionSpecTextElided
+        ? { specText: '<<elided: duplicates description>>' }
+        : {}),
+    },
+    sourceSpec: elidedSourceSpec,
+  };
+
+  return {
+    spec: summarized,
+    descriptionTruncated:
+      description.truncated ||
+      (targetContext?.truncated ?? false) ||
+      desiredActionSummary.truncated,
+  };
+}
+
+type RawSpecPayload = NormalizedWorkflowSpec['sourceSpec']['rawPayload'];
+
+function elideRawPayload(rawPayload: RawSpecPayload): RawSpecPayload {
+  // The raw payload duplicates the spec description on every natural-language
+  // input and adds nothing the persona can act on that the normalized spec
+  // does not already carry; replace its long fields with elision markers so
+  // the kind/surface/requestId metadata stays readable.
+  switch (rawPayload.kind) {
+    case 'natural_language':
+      return {
+        ...rawPayload,
+        text: rawPayloadElisionMarker(rawPayload.text),
+      };
+    case 'structured_json':
+      return {
+        ...rawPayload,
+        data: { '<<elided>>': 'see normalized spec fields' },
+      };
+    case 'mcp':
+      return {
+        ...rawPayload,
+        arguments: { '<<elided>>': 'see normalized spec fields' },
+      };
+    default:
+      return rawPayload;
+  }
+}
+
+function rawPayloadElisionMarker(text: string): string {
+  const size = Buffer.byteLength(text, 'utf8');
+  return `<<elided ${size} bytes of raw spec text — see top-level description and structured spec fields>>`;
+}
+
+interface SummarizedRelevantFiles {
+  files: Array<{ path: string; content: string | null; bytesOmitted?: number; omitted?: true }>;
+  includedCount: number;
+}
+
+/**
+ * Caps the total byte budget of inlined relevant-file contents. Files past
+ * the budget are listed as path-only entries so the persona still sees the
+ * full list, and any individual file body is truncated at
+ * `MAX_RELEVANT_FILE_BYTES`.
+ */
+export function summarizeRelevantFilesForPersona(
+  relevantFiles: Array<{ path: string; content?: string }>,
+): SummarizedRelevantFiles {
+  let totalBytes = 0;
+  let includedCount = 0;
+  const files: SummarizedRelevantFiles['files'] = [];
+  for (const file of relevantFiles) {
+    if (!file.content) {
+      files.push({ path: file.path, content: null });
+      continue;
+    }
+    if (totalBytes >= MAX_RELEVANT_FILES_TOTAL_BYTES) {
+      files.push({ path: file.path, content: null, omitted: true });
+      continue;
+    }
+    const remaining = MAX_RELEVANT_FILES_TOTAL_BYTES - totalBytes;
+    const perFileBudget = Math.min(MAX_RELEVANT_FILE_BYTES, remaining);
+    const trimmed = truncateText(file.content, perFileBudget);
+    totalBytes += Buffer.byteLength(trimmed.text, 'utf8');
+    includedCount += 1;
+    files.push({
+      path: file.path,
+      content: trimmed.text,
+      ...(trimmed.truncated ? { bytesOmitted: trimmed.bytesOmitted } : {}),
+    });
+  }
+  return { files, includedCount };
+}
+
+interface TruncationResult {
+  text: string;
+  truncated: boolean;
+  bytesOmitted: number;
+}
+
+function truncateText(value: string, maxBytes: number): TruncationResult {
+  const buffer = Buffer.from(value, 'utf8');
+  if (buffer.byteLength <= maxBytes) {
+    return { text: value, truncated: false, bytesOmitted: 0 };
+  }
+  const omitted = buffer.byteLength - maxBytes;
+  // Slice on a code-point boundary by re-decoding the trimmed buffer.
+  const headBytes = Math.floor(maxBytes * 0.75);
+  const tailBytes = maxBytes - headBytes;
+  const head = buffer.subarray(0, headBytes).toString('utf8');
+  const tail = buffer.subarray(buffer.byteLength - tailBytes).toString('utf8');
+  return {
+    text: `${head}\n\n<<truncated ${omitted} bytes>>\n\n${tail}`,
+    truncated: true,
+    bytesOmitted: omitted,
+  };
 }
 
 function renderSkillContextForPersona(skillContext: SkillContext | undefined): string {

--- a/src/product/generation/workforce-persona-writer.ts
+++ b/src/product/generation/workforce-persona-writer.ts
@@ -1,7 +1,7 @@
 import { createHash } from 'node:crypto';
 import { readFileSync } from 'node:fs';
-import { readFile } from 'node:fs/promises';
-import { isAbsolute, resolve } from 'node:path';
+import { mkdir, readFile, writeFile } from 'node:fs/promises';
+import { dirname, isAbsolute, join, resolve } from 'node:path';
 
 import type { ClarificationQuestion, ClarificationRequest, NormalizedWorkflowSpec } from '../spec-intake/types.js';
 import type { RenderedArtifact, SkillContext, WorkflowExecutionTarget } from './types.js';
@@ -250,22 +250,44 @@ export async function writeWorkflowWithWorkforcePersona(
     run,
     run.runId.catch(() => null),
   ]);
+  const dumpDebug = (reason: 'noncompletion' | 'parse-error' | 'no-content' | 'success') =>
+    dumpPersonaDebug({
+      kind: 'writer',
+      reason,
+      repoRoot: options.repoRoot,
+      promptDigest,
+      task,
+      result,
+      selection,
+      resolved,
+      outputPath: options.outputPath,
+    });
+
   if (result.status !== 'completed') {
+    await dumpDebug('noncompletion');
     throw new WorkforcePersonaWriterError(
       `Workforce persona writer did not complete: ${result.status}.`,
       [...resolved.warnings, result.stderr].filter(Boolean),
     );
   }
 
-  const parsed = parsePersonaWorkflowResponse(result.output, options.outputPath, {
-    repoRoot: options.repoRoot,
-  });
+  let parsed: ParsedPersonaResponse;
+  try {
+    parsed = parsePersonaWorkflowResponse(result.output, options.outputPath, {
+      repoRoot: options.repoRoot,
+    });
+  } catch (error) {
+    await dumpDebug('parse-error');
+    throw error;
+  }
   if (parsed.clarification) {
     throw new WorkforcePersonaClarificationError(parsed.clarification.questions, resolved.warnings);
   }
   if (!parsed.content) {
+    await dumpDebug('no-content');
     throw new WorkforcePersonaWriterError('Workforce persona response did not include workflow artifact content.');
   }
+  await dumpDebug('success');
   const responseFormat = parsed.responseFormat as WorkforcePersonaWriterMetadata['responseFormat'];
   return {
     artifact: {
@@ -1311,4 +1333,108 @@ function safeReadSkillText(path: string): string {
 
 function errorMessage(error: unknown): string {
   return error instanceof Error ? error.message : String(error);
+}
+
+export interface PersonaDebugDumpInput {
+  /** Which persona pass produced the output — keeps writer and reviewer dumps separate on disk. */
+  kind: 'writer' | 'reviewer';
+  /** Coarse reason for the dump so the operator can tell parse failures from non-completions at a glance. */
+  reason: 'noncompletion' | 'parse-error' | 'no-content' | 'success';
+  repoRoot: string;
+  /** SHA-256 digest of the task prompt, used as the dump directory name so repeated runs against the same prompt overwrite a single entry. */
+  promptDigest: string;
+  /** The full task prompt that was sent to the harness; written so the operator can replay the spawn outside Ricky. */
+  task: string;
+  result: WorkforcePersonaExecutionResult;
+  selection: WorkforcePersonaSelection;
+  resolved: ResolvedWorkforcePersonaContext;
+  /** Artifact path Ricky asked the persona to produce; recorded in the dump metadata for cross-referencing with the run state. */
+  outputPath: string;
+}
+
+/**
+ * Persists the raw persona output, the prompt that produced it, and the
+ * selection metadata under `<repoRoot>/.workflow-artifacts/ricky-persona-debug/`
+ * so operators can inspect what a Workforce persona actually returned when
+ * the parser rejected it (or when explicit debug capture is requested via
+ * `RICKY_PERSONA_DEBUG=1`).
+ *
+ * - On every failure path (`noncompletion` / `parse-error` / `no-content`)
+ *   the dump is always written so failed runs are self-debuggable.
+ * - On the `success` path the dump only runs when `RICKY_PERSONA_DEBUG=1`
+ *   is set, so green production runs do not litter the artifact tree.
+ *
+ * Dump layout (one directory per `(kind, promptDigest)` pair):
+ * - `output.raw.txt`   — the persona's stdout as captured by harness-kit
+ * - `task.prompt.txt`  — the task body that was sent to the persona
+ * - `meta.json`        — selection, status, exit code, stderr, durationMs
+ *
+ * Failures inside this helper are swallowed and surfaced through stderr —
+ * the dump is debugging telemetry; it must never mask the original
+ * writer/reviewer error.
+ */
+export async function dumpPersonaDebug(input: PersonaDebugDumpInput): Promise<void> {
+  if (input.reason === 'success' && process.env.RICKY_PERSONA_DEBUG !== '1') {
+    return;
+  }
+  try {
+    const dir = join(
+      input.repoRoot,
+      '.workflow-artifacts',
+      'ricky-persona-debug',
+      input.kind,
+      `${input.promptDigest.slice(0, 16)}-${input.reason}`,
+    );
+    await mkdir(dir, { recursive: true });
+    await Promise.all([
+      writeFile(join(dir, 'output.raw.txt'), input.result.output ?? '', 'utf8'),
+      writeFile(join(dir, 'task.prompt.txt'), input.task, 'utf8'),
+      writeFile(
+        join(dir, 'meta.json'),
+        JSON.stringify(
+          {
+            kind: input.kind,
+            reason: input.reason,
+            outputPath: input.outputPath,
+            selection: {
+              personaId: input.selection.personaId,
+              tier: input.selection.tier,
+              harness: input.selection.runtime.harness,
+              model: input.selection.runtime.model,
+            },
+            result: {
+              status: input.result.status,
+              exitCode: input.result.exitCode,
+              durationMs: input.result.durationMs,
+              workflowRunId: input.result.workflowRunId,
+              stepName: input.result.stepName,
+              stderr: input.result.stderr,
+            },
+            resolverIntent: input.resolved.intent,
+            resolverWarnings: input.resolved.warnings,
+            promptDigest: input.promptDigest,
+            recordedAt: new Date().toISOString(),
+          },
+          null,
+          2,
+        ),
+        'utf8',
+      ),
+    ]);
+    if (process.env.RICKY_PERSONA_DEBUG_VERBOSE === '1' || input.reason !== 'success') {
+      // Surface the dump location so the operator can find it without
+      // grepping the artifacts tree; success dumps are silent unless
+      // explicitly opted into via the verbose flag.
+      // eslint-disable-next-line no-console
+      console.error(`[ricky] persona ${input.kind} debug dump → ${dir}`);
+    }
+  } catch (error) {
+    if (process.env.RICKY_PERSONA_DEBUG_VERBOSE === '1') {
+      // Dump failures are typically permission/path issues in tests and other
+      // non-real-repo callers. Stay quiet unless the operator explicitly
+      // asked for verbose debug telemetry.
+      // eslint-disable-next-line no-console
+      console.error(`[ricky] failed to persist persona debug dump: ${errorMessage(error)}`);
+    }
+  }
 }


### PR DESCRIPTION
## Summary

Fixes a silent regression where Ricky's workflow writer falls back to the built-in `persona-maker` persona on Codex GPT-5.3 because no persona pack ships `agent-relay-workflow` in workload-router 0.19's catalog. The fallback is invisible to callers and produces the kind of structurally-wrong workflows seen on `docs/plans/deploy-v1-schema-cascade-spec.md` (missed `## Track` headings, serial pipeline instead of parallel DAG, inlined spec, missing per-track review loop).

- Installs `@agent-relay/personas@^6.0.18` as a dependency (the canonical pack — kept for parity / future use even though workload-router 0.19 doesn't auto-discover packs).
- Adds two Ricky-local persona JSONs in `personas/`:
  - `agent-relay-workflow.json` — writer, `harness: claude`, `best=opus-4-7`, `best-value=sonnet-4-6`, `minimum=haiku-4-5`. Writer-prompt rewritten to enforce `## Track` decomposition, parallel-branch fan-out, per-child review nesting, spec-by-path (no inlining), and `retryDelayMs >= 10000`.
  - `agent-relay-workflow-review.json` — reviewer, intent `review`, same Claude ladder. Produces structured `{verdict: pass|fix|block, summary, fixes[]}` JSON.
- Adds `src/product/generation/ricky-local-persona-resolver.ts` — a `WorkforcePersonaResolver` that loads Ricky-local Claude personas first via `useRunnableSelection` from harness-kit, and falls through to the existing package resolver for everything else.
- Adds `src/product/generation/workforce-persona-reviewer.ts` — a post-write reviewer pass that resolves through the `review` intent at tier `best` (Opus) by default, audits the generated workflow against the spec, and returns a verdict.
- Wires resolver + reviewer pass into `pipeline.ts:generateWithWorkforcePersona`:
  - `verdict=pass` → ship writer artifact as-is.
  - `verdict=fix` → feed structured fix list back into one writer repair attempt via `validationFeedback.errors`; ship the repaired artifact if it passes deterministic validation, otherwise keep the writer's output and surface a warning.
  - `verdict=block` → keep the writer artifact; verdict is recorded on metadata.
- Surfaces a `WorkforcePersonaReviewSummary` (verdict + fixes + appliedFix + model + runId) on `WorkforcePersonaGenerationMetadata` so CLI/Cloud callers can see what the reviewer did.
- Reviewer pass can be disabled via `RICKY_PERSONA_REVIEW=0` env or `workforcePersonaWriter.review: false` option.

### What gets called today (before this PR) vs after

| | Writer | Reviewer |
|---|---|---|
| Before | `persona-maker` / harness `codex` / `openai-codex/gpt-5.3-codex` (silent fallback) | — |
| After  | `agent-relay-workflow` / harness `claude` / `claude-sonnet-4-6` | `agent-relay-workflow-review` / harness `claude` / `claude-opus-4-7` |

### Note on workload-router 3.x

`@agentworkforce/persona-kit@3.0.1` collapsed `PersonaSpec.tiers.{best,best-value,minimum}` into single top-level `harness`/`model` fields. `@agentworkforce/harness-kit@0.19.0` still pins `workload-router@0.19.0`, so a clean 3.x bump is its own refactor (there is no harness-kit 3.x release yet). This PR stays on 0.19's tier shape — the persona JSONs use `tiers.best/best-value/minimum` accordingly.

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] `npx vitest run` → 1087 passing, no new failures
- [x] 4 new tests in `workforce-persona-writer.test.ts` cover pass / fix-with-repair / block-unparseable / opt-out paths
- [x] Existing writer-in-isolation tests updated to `review: false` (writer is tested independently of the new review pass)
- [x] `npm run evals` → 43 needs-human, 0 automated failures
- [ ] Smoke `ricky --mode local --spec-file docs/plans/deploy-v1-schema-cascade-spec.md` to verify the Claude persona resolves end-to-end against a real spec (deferred — requires CLAUDE_API_KEY / Claude Code harness in the runner env)

🤖 Generated with [Claude Code](https://claude.com/claude-code)