### PR TITLE
fix(generation): drop cross-repo paths from derived test command

### DIFF
--- a/src/product/generation/pipeline.test.ts
+++ b/src/product/generation/pipeline.test.ts
@@ -108,6 +108,54 @@ describe('workflow generation pipeline', () => {
     }
   });
 
+  // Regression: a spec that names test files in a *sibling repo* (e.g.
+  // `relayfile-adapters/packages/core/src/digest-contract.test.ts` while
+  // the workflow ships in the `relayfile` repo) used to render that path
+  // straight into the final-hard-validation vitest invocation. The
+  // generated workflow runs in a single repo's cwd, so vitest's include
+  // glob `packages/**/*.test.ts` cannot reach a path under another
+  // repo's directory, and the file doesn't exist locally anyway → vitest
+  // exits 1 with "No test files found". The auto-fix loop then burns
+  // its full budget (INVALID_ARTIFACT × maxAttempts) chasing a phantom
+  // artifact path it cannot reach because it operates on the workflow
+  // cwd only. The renderer now filters cross-repo paths out of the test
+  // target list before constructing the vitest command, falling through
+  // to the workspace-aware path for any local source targets that
+  // remain.
+  it('drops cross-repo paths from master-rendered final-hard-validation test invocation', () => {
+    const result = generate({
+      spec: spec({
+        description: 'Implement workspace primitives across relayfile and relayfile-adapters.',
+        constraints: ['Use independent child workflows with deterministic 80-to-100 validation.'],
+        acceptanceGates: ['Tests pass.'],
+        targetFiles: [
+          // Local — should drive the workspace-aware command.
+          'packages/core/src/digest.ts',
+          'packages/core/src/digest.test.ts',
+          // Cross-repo — must be filtered out before deriveTestCommand
+          // builds the vitest invocation.
+          'relayfile-adapters/packages/core/src/digest-contract.ts',
+          'relayfile-adapters/packages/core/src/digest-contract.test.ts',
+          '../relayfile-adapters/packages/core/src/digest-contract.test.ts',
+        ],
+      }),
+      artifactPath: 'workflows/generated/workspace-primitives-master.ts',
+    });
+    expect(result.masterExecutionPlan).toBeDefined();
+    const rendered = artifact(result);
+    const gateCommand = gate(rendered, 'final-hard-validation').command;
+    const stepBody = renderedStepCommand(rendered.content, 'final-hard-validation');
+
+    for (const target of [gateCommand, stepBody]) {
+      // The local test path is still validated.
+      expect(target).toContain("npx vitest run 'packages/core/src/digest.test.ts'");
+      // The sibling-repo path must NOT survive into the vitest call —
+      // otherwise vitest exits 1 with "No test files found".
+      expect(target).not.toContain('relayfile-adapters/packages/core/src/digest-contract.test.ts');
+      expect(target).not.toContain('../relayfile-adapters');
+    }
+  });
+
   it('uniqueWorkspacesFromTargetFiles handles npm-scoped workspace paths', () => {
     // CodeRabbit flagged that the previous regex
     //   /^((?:packages|apps|services)\/[^\/]+)\//

--- a/src/product/generation/template-renderer.ts
+++ b/src/product/generation/template-renderer.ts
@@ -1242,7 +1242,16 @@ function describeImplementation(spec: NormalizedWorkflowSpec): string {
  * Resolution order:
  *
  *   1. Explicit `vitest`/`npm test` acceptance gate → `mapAcceptanceGateToCommand`.
- *   2. Test-file targets in `spec.targetFiles` → `npx vitest run <files>`.
+ *   2. Test-file targets in `spec.targetFiles` that are reachable from the
+ *      generated workflow's cwd → `npx vitest run <files>`. Cross-repo
+ *      paths (e.g. `../sibling-repo/...` or `sibling-repo/packages/...`
+ *      where the first segment is not a recognized in-repo source root)
+ *      are dropped because the generated workflow runs in a single
+ *      repo's cwd and vitest's include glob cannot reach them. Without
+ *      this filter, a spec that legitimately spans multiple repos
+ *      produces a `final-hard-validation` gate that always fails with
+ *      "No test files found, exit 1", and the auto-fix loop burns its
+ *      budget chasing a phantom artifact path.
  *   3. Source-file targets that live under monorepo workspaces
  *      (`packages/<pkg>/`, `apps/<pkg>/`, `services/<pkg>/`, including
  *      scoped `packages/@scope/<pkg>/` layouts) → one
@@ -1259,15 +1268,55 @@ export function deriveTestCommand(spec: NormalizedWorkflowSpec): string {
   const explicitTestGate = spec.acceptanceGates.find((gate) => /\b(vitest|npm test)\b/i.test(gate.gate));
   if (explicitTestGate) return mapAcceptanceGateToCommand(explicitTestGate.gate);
 
-  const testTargets = spec.targetFiles.filter((file) => /\.(test|spec)\.(ts|tsx|js|jsx)$/i.test(file));
+  const localTargetFiles = spec.targetFiles.filter(isLocalRepoPath);
+  const testTargets = localTargetFiles.filter((file) => /\.(test|spec)\.(ts|tsx|js|jsx)$/i.test(file));
   if (testTargets.length > 0) return `npx vitest run ${testTargets.map(shellQuote).join(' ')}`;
 
-  const workspaces = uniqueWorkspacesFromTargetFiles(spec.targetFiles);
+  const workspaces = uniqueWorkspacesFromTargetFiles(localTargetFiles);
   if (workspaces.length > 0) {
     return workspaces.map((ws) => `npm test --workspace=${shellQuote(ws)}`).join(' && ');
   }
 
   return 'npx vitest run';
+}
+
+const IN_REPO_SOURCE_ROOTS = new Set([
+  'packages',
+  'apps',
+  'services',
+  'src',
+  'lib',
+  'libs',
+  'tests',
+  'test',
+  'e2e',
+  'integration-tests',
+]);
+
+/**
+ * Heuristic: is this target file path reachable from the generated
+ * workflow's cwd (the repo the workflow ships in)?
+ *
+ * Cross-repo targets are rejected so they don't end up in the vitest
+ * invocation or in the workspace inference. Two forms are treated as
+ * cross-repo:
+ *
+ *   - Parent-dir escapes (`../sibling-repo/...`, `./../...`).
+ *   - Paths whose first segment is not a recognized in-repo source root
+ *     (e.g. `relayfile-adapters/packages/...` — the leading
+ *     `relayfile-adapters/` is a sibling repo directory, not a JS/TS
+ *     workspace root that vitest's include glob can reach).
+ *
+ * Root-level files with no `/` (e.g. `tsconfig.json`, `index.test.ts`)
+ * are treated as local — vitest can resolve them from the cwd.
+ */
+function isLocalRepoPath(file: string): boolean {
+  if (file.startsWith('../') || file.startsWith('./../') || file.includes('/../')) return false;
+  const normalized = file.replace(/^\.\//, '');
+  const firstSegment = normalized.split('/')[0];
+  if (!firstSegment) return false;
+  if (!normalized.includes('/')) return true;
+  return IN_REPO_SOURCE_ROOTS.has(firstSegment);
 }
 
 /**


### PR DESCRIPTION
## Summary

- `deriveTestCommand` now filters cross-repo paths out of `spec.targetFiles` before constructing the `final-hard-validation` vitest invocation, fixing the failure mode that burns the full auto-fix budget when a spec spans multiple repos.
- Adds a regression test mirroring the real-world failure: a spec naming `relayfile-adapters/packages/core/src/digest-contract.test.ts` while the workflow shipped in the `relayfile` repo.

## The bug

A spec that legitimately spans two repos (e.g. `relayfile` + `relayfile-adapters`) produced this `final-hard-validation` command:

```sh
npx vitest run 'relayfile-adapters/packages/core/src/digest-contract.test.ts'
```

The generated workflow runs in a single repo's cwd (`relayfile`). Vitest's `include` glob `packages/**/*.test.ts` can't reach a path under a sibling repo's directory, and the file doesn't exist locally anyway → `No test files found, exit 1`.

The auto-fix loop then tried to repair this 7×, each time regenerating the workflow inside `relayfile`, each time pointing at the same phantom path. It can't fix it: the workflow-persona repairer operates on `repairTarget.cwd`, and the actual test file belongs in `../relayfile-adapters`. The loop burned its full budget (`INVALID_ARTIFACT × maxAttempts`) for a problem it had no instruments to solve.

This is the exact failure class already called out in the source:

- `pipeline.ts:245–248` — *"made the auto-fix loop chase a phantom artifact path… fails INVALID_ARTIFACT every retry until the auto-fix budget burns."*
- `master-workflow-renderer.ts:40` — *"The auto-fix loop then 'repairs' the workflow 7×, all failing identically."*

## The fix

`deriveTestCommand` now drops cross-repo paths before deciding what to emit. A path is treated as cross-repo when:

- It escapes the cwd (`../sibling`, `./..`, embedded `/../`).
- Its first segment isn't one of the recognized in-repo source roots: `packages`, `apps`, `services`, `src`, `lib`, `libs`, `tests`, `test`, `e2e`, `integration-tests`.

Root-level files with no `/` (e.g. `index.test.ts`) are treated as local since vitest can resolve them from the cwd.

The same filtered list is fed into `uniqueWorkspacesFromTargetFiles`, so sibling-repo paths also don't surface as `npm test --workspace=` invocations downstream.

## Test plan

- [x] Added regression test in `pipeline.test.ts`: spec with mixed local + cross-repo test paths now renders only the local test in `final-hard-validation`; sibling-repo path is absent from both the gate command and the rendered step body.
- [x] `npx vitest run src/product/generation/pipeline.test.ts` — 49/49 pass.
- [x] `npx vitest run src/product/generation` — 124/124 pass.
- [x] Full suite: 1107/1107 tests pass (1 pre-existing failure in `scheduled-agent.test.ts` due to missing `@agent-relay/agent` dep, unrelated).
- [x] Manual reproduction: removed the bogus `npx vitest run 'relayfile-adapters/...'` from the failing generated workflow and resumed via `ricky run … --start-from final-hard-validation --previous-run-id …` → succeeded. Confirms this is the right knob.

🤖 Generated with [Claude Code](https://claude.com/claude-code)