### PR TITLE
Detach Ricky background CLI runs

### DIFF
--- a/src/surfaces/cli/commands/cli-main.test.ts
+++ b/src/surfaces/cli/commands/cli-main.test.ts
@@ -1819,7 +1819,10 @@ describe('cliMain', () => {
     const originalRunId = process.env.RICKY_DETACHED_BACKGROUND_RUN_ID;
     const runId = 'ricky-local-detached-child';
     const localExecutor = {
-      execute: vi.fn().mockResolvedValue(stagedLocalResult()),
+      execute: vi.fn(async () => {
+        expect(process.env.RICKY_DETACHED_BACKGROUND_RUN_ID).toBeUndefined();
+        return stagedLocalResult();
+      }),
     };
 
     process.env.RICKY_DETACHED_BACKGROUND_RUN_ID = runId;
@@ -1849,6 +1852,42 @@ describe('cliMain', () => {
         process.env.RICKY_DETACHED_BACKGROUND_RUN_ID = originalRunId;
       }
       await rm(repo, { recursive: true, force: true });
+    }
+  });
+
+  it('does not let an inherited detached run id force nested no-run commands to execute', async () => {
+    const originalRunId = process.env.RICKY_DETACHED_BACKGROUND_RUN_ID;
+    const runner = vi.fn().mockResolvedValue(
+      fakeInteractiveResult({
+        ok: true,
+        localResult: stagedLocalResult({ execution: undefined }),
+      }),
+    );
+    const localExecutor = {
+      execute: vi.fn().mockResolvedValue(stagedLocalResult()),
+    };
+
+    process.env.RICKY_DETACHED_BACKGROUND_RUN_ID = 'ricky-local-inherited-parent';
+    try {
+      const result = await cliMain({
+        argv: ['local', '--spec', 'build a workflow', '--no-run'],
+        runInteractive: runner,
+        localExecutor,
+      });
+
+      expect(result.exitCode).toBe(0);
+      expect(runner).toHaveBeenCalledOnce();
+      expect(localExecutor.execute).not.toHaveBeenCalled();
+      expect(runner.mock.calls[0][0].handoff).toMatchObject({
+        stageMode: 'generate',
+        cliMetadata: expect.objectContaining({ handoff: 'inline-spec' }),
+      });
+    } finally {
+      if (originalRunId === undefined) {
+        delete process.env.RICKY_DETACHED_BACKGROUND_RUN_ID;
+      } else {
+        process.env.RICKY_DETACHED_BACKGROUND_RUN_ID = originalRunId;
+      }
     }
   });
 

--- a/src/surfaces/cli/commands/cli-main.test.ts
+++ b/src/surfaces/cli/commands/cli-main.test.ts
@@ -6,7 +6,7 @@ import { fileURLToPath } from 'node:url';
 import type { InteractiveCliResult } from '../entrypoint/interactive-cli.js';
 import type { OnboardingResult } from '../cli/onboarding.js';
 import type { LocalResponse } from '../../../local/entrypoint.js';
-import { cliMain, parseArgs, renderHelp, type CliProgressSpinner } from './cli-main.js';
+import { cliMain, parseArgs, renderHelp, type CliProgressSpinner, type DetachedProcessSpawner } from './cli-main.js';
 
 // ---------------------------------------------------------------------------
 // parseArgs
@@ -1752,7 +1752,7 @@ describe('cliMain', () => {
     );
 
     await cliMain({
-      argv: ['local', '--spec', 'build a workflow', '--run', '--background', '--yes'],
+      argv: ['local', '--spec', 'build a workflow', '--background', '--yes'],
       runInteractive: runner,
     });
     await cliMain({
@@ -1767,6 +1767,89 @@ describe('cliMain', () => {
     expect(runner.mock.calls[1][0].handoff.cliMetadata).toMatchObject({
       runMode: 'foreground',
     });
+  });
+
+  it('detaches power-user background generate-and-run before local generation', async () => {
+    const { mkdtemp, rm } = await import('node:fs/promises');
+    const { tmpdir } = await import('node:os');
+    const { join } = await import('node:path');
+
+    const repo = await mkdtemp(join(tmpdir(), 'ricky-detached-parent-'));
+    const unref = vi.fn();
+    const spawnDetachedProcess = vi.fn<DetachedProcessSpawner>(() => ({ unref }));
+    const runInteractive = vi.fn();
+
+    try {
+      const result = await cliMain({
+        argv: ['workflow', '--spec-file', './custom-digest-functions-spec.md', '--run', '--background', '--best-judgement'],
+        cwd: repo,
+        readFileText: vi.fn().mockResolvedValue('build the custom digest functions workflow'),
+        runInteractive,
+        spawnDetachedProcess,
+      });
+
+      expect(result.exitCode).toBe(0);
+      expect(runInteractive).not.toHaveBeenCalled();
+      expect(spawnDetachedProcess).toHaveBeenCalledOnce();
+      const [, childArgs, options] = spawnDetachedProcess.mock.calls[0];
+      expect(childArgs).toContain('--foreground');
+      expect(childArgs).not.toContain('--background');
+      expect(options).toMatchObject({
+        cwd: repo,
+        detached: true,
+        stdio: 'ignore',
+      });
+      expect(options.env.RICKY_DETACHED_BACKGROUND_RUN_ID).toMatch(/^ricky-local-/);
+      expect(unref).toHaveBeenCalledOnce();
+      const output = result.output.join('\n');
+      expect(output).toContain('Ricky background run');
+      expect(output).toContain('Status: running');
+      expect(output).toContain('Status command: ricky status --run');
+    } finally {
+      await rm(repo, { recursive: true, force: true });
+    }
+  });
+
+  it('runs a detached background child under the parent run id', async () => {
+    const { mkdtemp, readFile, rm } = await import('node:fs/promises');
+    const { tmpdir } = await import('node:os');
+    const { join } = await import('node:path');
+
+    const repo = await mkdtemp(join(tmpdir(), 'ricky-detached-child-'));
+    const originalRunId = process.env.RICKY_DETACHED_BACKGROUND_RUN_ID;
+    const runId = 'ricky-local-detached-child';
+    const localExecutor = {
+      execute: vi.fn().mockResolvedValue(stagedLocalResult()),
+    };
+
+    process.env.RICKY_DETACHED_BACKGROUND_RUN_ID = runId;
+    try {
+      const result = await cliMain({
+        argv: ['workflow', '--spec-file', './custom-digest-functions-spec.md', '--run', '--foreground', '--best-judgement'],
+        cwd: repo,
+        readFileText: vi.fn().mockResolvedValue('build the custom digest functions workflow'),
+        localExecutor,
+        runInteractive: vi.fn(),
+      });
+
+      expect(result.exitCode).toBe(0);
+      expect(result.output).toEqual([]);
+      expect(localExecutor.execute).toHaveBeenCalledOnce();
+      const statePath = join(repo, '.workflow-artifacts', 'ricky-local-runs', runId, 'state.json');
+      const state = JSON.parse(await readFile(statePath, 'utf8'));
+      expect(state).toMatchObject({
+        runId,
+        status: 'completed',
+        reattachCommand: `ricky status --run ${runId}`,
+      });
+    } finally {
+      if (originalRunId === undefined) {
+        delete process.env.RICKY_DETACHED_BACKGROUND_RUN_ID;
+      } else {
+        process.env.RICKY_DETACHED_BACKGROUND_RUN_ID = originalRunId;
+      }
+      await rm(repo, { recursive: true, force: true });
+    }
   });
 
   it('uses a TTY spinner for foreground local progress and stops before the final summary', async () => {
@@ -1892,6 +1975,9 @@ describe('cliMain', () => {
   });
 
   it('does not attach spinner progress for JSON, quiet, non-TTY, background, or ordinary injected output streams', async () => {
+    const { mkdtemp, rm } = await import('node:fs/promises');
+    const { tmpdir } = await import('node:os');
+    const { join } = await import('node:path');
     const cases = [
       { argv: ['run', 'workflows/generated/issue-3.ts', '--json'], isTTY: true, output: undefined, create: true },
       { argv: ['run', 'workflows/generated/issue-3.ts', '--quiet'], isTTY: true, output: undefined, create: true },
@@ -1903,18 +1989,33 @@ describe('cliMain', () => {
     for (const testCase of cases) {
       const createProgressSpinner = vi.fn();
       const runner = vi.fn().mockResolvedValue(fakeInteractiveResult({ localResult: stagedLocalResult() }));
+      const isBackground = testCase.argv.includes('--background');
+      const repo = isBackground ? await mkdtemp(join(tmpdir(), 'ricky-spinner-background-')) : undefined;
+      const unref = vi.fn();
+      const spawnDetachedProcess = vi.fn<DetachedProcessSpawner>(() => ({ unref }));
 
-      await cliMain({
-        argv: testCase.argv,
-        isTTY: testCase.isTTY,
-        ...(testCase.output ? { output: testCase.output } : {}),
-        ...(testCase.create ? { createProgressSpinner } : {}),
-        runInteractive: runner,
-      });
+      try {
+        await cliMain({
+          argv: testCase.argv,
+          isTTY: testCase.isTTY,
+          ...(repo ? { cwd: repo } : {}),
+          ...(testCase.output ? { output: testCase.output } : {}),
+          ...(testCase.create ? { createProgressSpinner } : {}),
+          ...(isBackground ? { spawnDetachedProcess } : {}),
+          runInteractive: runner,
+        });
 
-      expect(runner.mock.calls[0][0].localProgress).toBeUndefined();
-      expect(runner.mock.calls[0][0].localRuntimeOutput).toBeUndefined();
-      expect(createProgressSpinner).not.toHaveBeenCalled();
+        if (isBackground) {
+          expect(runner).not.toHaveBeenCalled();
+          expect(spawnDetachedProcess).toHaveBeenCalledOnce();
+        } else {
+          expect(runner.mock.calls[0][0].localProgress).toBeUndefined();
+          expect(runner.mock.calls[0][0].localRuntimeOutput).toBeUndefined();
+        }
+        expect(createProgressSpinner).not.toHaveBeenCalled();
+      } finally {
+        if (repo) await rm(repo, { recursive: true, force: true });
+      }
     }
   });
 

--- a/src/surfaces/cli/commands/cli-main.ts
+++ b/src/surfaces/cli/commands/cli-main.ts
@@ -713,6 +713,17 @@ function shouldLaunchDetachedBackgroundRun(parsed: ParsedArgs, cliHandoff: RawHa
   );
 }
 
+function shouldRunDetachedBackgroundChild(parsed: ParsedArgs, cliHandoff: RawHandoff): boolean {
+  return Boolean(
+    parsed.command === 'run' &&
+    parsed.runRequested === true &&
+    parsed.foreground === true &&
+    parsed.noRun !== true &&
+    parsed.mode !== 'cloud' &&
+    process.env[DETACHED_BACKGROUND_RUN_ID_ENV],
+  );
+}
+
 async function launchDetachedBackgroundRun(
   argv: string[],
   parsed: ParsedArgs,
@@ -771,6 +782,7 @@ async function runDetachedBackgroundChild(
     };
   }
   const cwd = resolveInvocationRoot(deps.cwd);
+  delete process.env[DETACHED_BACKGROUND_RUN_ID_ENV];
   const finalState = await startLocalRunMonitor({
     cwd,
     artifactPath: backgroundArtifactPathFor(parsed, cliHandoff),
@@ -1864,7 +1876,7 @@ export async function cliMain(deps: CliMainDeps = {}): Promise<CliMainResult> {
     };
   }
 
-  if (cliHandoff && process.env[DETACHED_BACKGROUND_RUN_ID_ENV]) {
+  if (cliHandoff && shouldRunDetachedBackgroundChild(parsed, cliHandoff)) {
     return runDetachedBackgroundChild(parsed, cliHandoff, deps);
   }
 

--- a/src/surfaces/cli/commands/cli-main.ts
+++ b/src/surfaces/cli/commands/cli-main.ts
@@ -22,7 +22,12 @@ import type {
 } from '../../../cloud/api/workflow-schedules.js';
 import type { ConnectProviderOptions, ConnectProviderResult, StoredAuth, WhoAmIResponse } from '@agent-relay/cloud';
 import type { LocalRunMonitorState } from '../flows/local-run-monitor.js';
-import { legacyLocalRunStatePath, localRunStatePath } from '../flows/local-run-monitor.js';
+import {
+  initializeLocalRunMonitorState,
+  legacyLocalRunStatePath,
+  localRunStatePath,
+  startLocalRunMonitor,
+} from '../flows/local-run-monitor.js';
 import type {
   CloudAgentReadiness,
   CloudImplementationAgent,
@@ -32,6 +37,7 @@ import type {
 } from '../flows/cloud-workflow-flow.js';
 import { readFileSync } from 'node:fs';
 import { readFile } from 'node:fs/promises';
+import { spawn, type ChildProcess } from 'node:child_process';
 import { dirname, isAbsolute, join, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import ora from 'ora';
@@ -131,6 +137,18 @@ export type CliProgressSpinnerFactory = (options: {
   text: string;
   stream: NodeJS.WritableStream;
 }) => CliProgressSpinner;
+export type DetachedProcessSpawner = (
+  command: string,
+  args: string[],
+  options: {
+    cwd: string;
+    detached: boolean;
+    stdio: 'ignore';
+    env: NodeJS.ProcessEnv;
+  },
+) => Pick<ChildProcess, 'unref'>;
+
+const DETACHED_BACKGROUND_RUN_ID_ENV = 'RICKY_DETACHED_BACKGROUND_RUN_ID';
 
 // ---------------------------------------------------------------------------
 // Injectable dependencies
@@ -159,6 +177,8 @@ export interface CliMainDeps extends InteractiveCliDeps {
   connectTimeoutMs?: number;
   /** Spinner factory override for focused progress tests. */
   createProgressSpinner?: CliProgressSpinnerFactory;
+  /** Detached background process spawner override for deterministic CLI tests. */
+  spawnDetachedProcess?: DetachedProcessSpawner;
   /** Cloud workflow scheduling override for deterministic schedule command tests. */
   scheduleWorkflow?: RickyScheduleWorkflow;
   /** Cloud workflow schedule listing override for deterministic schedule command tests. */
@@ -681,6 +701,108 @@ function cliPackageRoot(): string {
 
 function resolveSpecFilePath(specFile: string, invocationRoot: string): string {
   return isAbsolute(specFile) ? specFile : resolve(invocationRoot, specFile);
+}
+
+function shouldLaunchDetachedBackgroundRun(parsed: ParsedArgs, cliHandoff: RawHandoff | undefined): boolean {
+  return Boolean(
+    cliHandoff &&
+    parsed.command === 'run' &&
+    parsed.runRequested === true &&
+    parsed.background === true &&
+    parsed.mode !== 'cloud',
+  );
+}
+
+async function launchDetachedBackgroundRun(
+  argv: string[],
+  parsed: ParsedArgs,
+  cliHandoff: RawHandoff,
+  deps: CliMainDeps,
+): Promise<CliMainResult> {
+  const cwd = resolveInvocationRoot(deps.cwd);
+  const artifactPath = backgroundArtifactPathFor(parsed, cliHandoff);
+  const runningState = await initializeLocalRunMonitorState({
+    cwd,
+    artifactPath,
+    mode: 'background',
+  });
+  const command = process.execPath;
+  const entrypoint = process.argv[1];
+  if (!entrypoint) {
+    return {
+      exitCode: 1,
+      output: renderCliArgumentRecovery(['Could not start background run: Ricky entrypoint path is unavailable.']),
+    };
+  }
+  const childArgs = [entrypoint, ...backgroundChildArgs(argv)];
+  const spawner = deps.spawnDetachedProcess ?? ((command, args, options) => spawn(command, args, options));
+  const child = spawner(command, childArgs, {
+    cwd,
+    detached: true,
+    stdio: 'ignore',
+    env: {
+      ...process.env,
+      [DETACHED_BACKGROUND_RUN_ID_ENV]: runningState.runId,
+    },
+  });
+  child.unref();
+
+  return {
+    exitCode: 0,
+    output: renderDetachedBackgroundRunStarted(runningState),
+  };
+}
+
+function backgroundChildArgs(argv: string[]): string[] {
+  const args = argv.filter((arg) => arg !== '--background');
+  return args.includes('--foreground') ? args : [...args, '--foreground'];
+}
+
+async function runDetachedBackgroundChild(
+  parsed: ParsedArgs,
+  cliHandoff: RawHandoff,
+  deps: CliMainDeps,
+): Promise<CliMainResult> {
+  const runId = process.env[DETACHED_BACKGROUND_RUN_ID_ENV]?.trim();
+  if (!runId) {
+    return {
+      exitCode: 1,
+      output: renderCliArgumentRecovery([`${DETACHED_BACKGROUND_RUN_ID_ENV} is empty.`]),
+    };
+  }
+  const cwd = resolveInvocationRoot(deps.cwd);
+  const finalState = await startLocalRunMonitor({
+    cwd,
+    artifactPath: backgroundArtifactPathFor(parsed, cliHandoff),
+    handoff: cliHandoff,
+    mode: 'foreground',
+    autoFixAttempts: parsed.autoFix,
+    localOptions: deps.localExecutor ? { executor: deps.localExecutor } : undefined,
+    runIdFactory: () => runId,
+  });
+  return {
+    exitCode: finalState.status === 'completed' ? 0 : 1,
+    output: [],
+  };
+}
+
+function backgroundArtifactPathFor(parsed: ParsedArgs, cliHandoff: RawHandoff): string {
+  if (parsed.artifact) return parsed.artifact;
+  if (parsed.workflowName) return defaultArtifactPathForWorkflowName(parsed.workflowName);
+  if (cliHandoff.source === 'workflow-artifact') return cliHandoff.artifactPath;
+  return 'workflows/generated/background-run.ts';
+}
+
+function renderDetachedBackgroundRunStarted(state: LocalRunMonitorState): string[] {
+  return [
+    'Ricky background run',
+    '',
+    `Workflow run id: ${state.runId}`,
+    `Status: ${state.status}`,
+    `Status command: ${state.reattachCommand}`,
+    `Logs: ${state.logPath}`,
+    `Evidence: ${state.evidencePath}`,
+  ];
 }
 
 class CloudPowerUserSetupError extends Error {
@@ -1740,6 +1862,14 @@ export async function cliMain(deps: CliMainDeps = {}): Promise<CliMainResult> {
       exitCode: 1,
       output: renderCliArgumentRecovery([`Could not read spec handoff: ${message}`]),
     };
+  }
+
+  if (cliHandoff && process.env[DETACHED_BACKGROUND_RUN_ID_ENV]) {
+    return runDetachedBackgroundChild(parsed, cliHandoff, deps);
+  }
+
+  if (shouldLaunchDetachedBackgroundRun(parsed, cliHandoff)) {
+    return launchDetachedBackgroundRun(argv, parsed, cliHandoff!, deps);
   }
 
   // Default: run interactive session

--- a/src/surfaces/cli/flows/local-run-monitor.ts
+++ b/src/surfaces/cli/flows/local-run-monitor.ts
@@ -43,6 +43,28 @@ export interface LocalRunMonitorOptions {
 }
 
 export async function startLocalRunMonitor(options: LocalRunMonitorOptions): Promise<LocalRunMonitorState> {
+  const runningState = await initializeLocalRunMonitorState(options);
+  const handoff = withSafeRunOptions(options.handoff, options.autoFixAttempts, runningState.runId);
+  await options.onMonitorStarted?.(runningState);
+
+  if (options.mode === 'background') {
+    void executeLocalRunMonitor(options, handoff, runningState).catch(async (error: unknown) => {
+      try {
+        await persistFailedRunState(runningState, error);
+      } catch {
+        // The monitor has no caller in background mode. Best-effort persistence
+        // already failed, so avoid surfacing an unhandled rejection.
+      }
+    });
+    return runningState;
+  }
+
+  return executeLocalRunMonitor(options, handoff, runningState);
+}
+
+export async function initializeLocalRunMonitorState(
+  options: Pick<LocalRunMonitorOptions, 'cwd' | 'artifactPath' | 'mode' | 'stateRoot' | 'runIdFactory'>,
+): Promise<LocalRunMonitorState> {
   const runId = options.runIdFactory
     ? options.runIdFactory({ artifactPath: options.artifactPath, mode: options.mode })
     : `ricky-local-${randomUUID()}`;
@@ -67,24 +89,9 @@ export async function startLocalRunMonitor(options: LocalRunMonitorOptions): Pro
   };
   await persistState(initialState);
 
-  const handoff = withSafeRunOptions(options.handoff, options.autoFixAttempts, runId);
   const runningState = { ...initialState, status: 'running' as const };
   await persistState(runningState);
-  await options.onMonitorStarted?.(runningState);
-
-  if (options.mode === 'background') {
-    void executeLocalRunMonitor(options, handoff, runningState).catch(async (error: unknown) => {
-      try {
-        await persistFailedRunState(runningState, error);
-      } catch {
-        // The monitor has no caller in background mode. Best-effort persistence
-        // already failed, so avoid surfacing an unhandled rejection.
-      }
-    });
-    return runningState;
-  }
-
-  return executeLocalRunMonitor(options, handoff, runningState);
+  return runningState;
 }
 
 export function localWorkflowArtifactDir(cwd: string, runId: string): string {


### PR DESCRIPTION
## Summary
- make power-user local --run --background commands persist a run id and spawn a detached child process
- reuse that run id in the child monitor so status, logs, evidence, and fixes land in the normal local run state paths
- add CLI coverage for parent detachment, child run-id reuse, and spinner suppression on detached background runs

## Validation
- npm test -- src/surfaces/cli/commands/cli-main.test.ts src/surfaces/cli/flows/local-run-monitor.test.ts
- npm run typecheck