### PR TITLE
fix(auto-fix): don't repair non-executable --spec-file paths as workflows

### DIFF
--- a/src/local/auto-fix-loop.test.ts
+++ b/src/local/auto-fix-loop.test.ts
@@ -1020,6 +1020,40 @@ describe('runWithAutoFix', () => {
     }
   });
 
+  it('does not treat a non-executable --spec-file path as a workflow artifact to repair', async () => {
+    // Regression: when `ricky --spec-file docs/foo.md` failed at the intake
+    // stage (e.g. unresolved clarification questions), `resolveArtifactPath`
+    // used to fall back to `request.specPath`, which pointed at the source
+    // spec markdown. Auto-fix then handed the markdown to the workflow
+    // repairer, re-fed the "repaired" content as source=workflow-artifact,
+    // and looped 7× while the natural-language intent detector misrouted the
+    // spec body to debug. With no executable workflow path available, there
+    // is nothing to repair and auto-fix should bail on attempt 1.
+    const specFileRequest: LocalInvocationRequest = {
+      ...baseRequest,
+      spec: '# Some markdown spec\n\nUnresolved question?',
+      specPath: 'docs/some-spec.md',
+    };
+    const runSingleAttempt = vi.fn().mockResolvedValueOnce(generationOnlyFailureResponse());
+    const workflowRepairer = vi.fn().mockResolvedValue(workflowRepair('should-not-run'));
+    const artifactWriter = vi.fn().mockResolvedValue(undefined);
+
+    const result = await runWithAutoFix(specFileRequest, {
+      maxAttempts: 7,
+      runSingleAttempt,
+      classifyFailure: fakeClassification,
+      debugWorkflowRun: directDebugger,
+      workflowRepairer,
+      artifactWriter,
+    });
+
+    expect(runSingleAttempt).toHaveBeenCalledTimes(1);
+    expect(workflowRepairer).not.toHaveBeenCalled();
+    expect(artifactWriter).not.toHaveBeenCalled();
+    expect(result.ok).toBe(false);
+    expect(result.auto_fix?.attempts).toHaveLength(1);
+  });
+
 });
 
 describe('isSyntheticStageId', () => {
@@ -1058,6 +1092,22 @@ function successResponse(runId: string): LocalResponse {
       execution: execution(runId),
     },
     exitCode: 0,
+  };
+}
+
+function generationOnlyFailureResponse(): LocalResponse {
+  return {
+    ok: false,
+    artifacts: [],
+    logs: [],
+    warnings: ['routing: Spec has unresolved workflow authoring questions'],
+    nextActions: ['Clarify the local workflow request and retry.'],
+    generation: {
+      stage: 'generate',
+      status: 'needs_clarification',
+      error: 'routing: Spec has unresolved workflow authoring questions',
+    },
+    exitCode: 2,
   };
 }
 

--- a/src/local/auto-fix-loop.ts
+++ b/src/local/auto-fix-loop.ts
@@ -7,6 +7,7 @@ import ts from 'typescript';
 
 import type { LocalInvocationRequest } from './request-normalizer.js';
 import type { LocalClassifiedBlocker, LocalExecutionEvidence, LocalResponse } from './entrypoint.js';
+import { isExecutableWorkflowPath } from './entrypoint.js';
 import { classifyFailure as defaultClassifyFailure } from '../runtime/failure/classifier.js';
 import type { FailureClassification } from '../runtime/failure/types.js';
 import { debugWorkflowRun as defaultDebugWorkflowRun } from '../product/specialists/debugger/debugger.js';
@@ -1586,12 +1587,20 @@ async function resolveWorkflowRepairTarget(
 }
 
 function resolveArtifactPath(request: LocalInvocationRequest, response: LocalResponse): string | undefined {
+  // `request.specPath` is the LAST resort because for CLI invocations like
+  // `--spec-file docs/foo.md` it points at the source spec (markdown, etc.),
+  // not an executable workflow. Treating that as the "artifact to repair"
+  // makes auto-fix hand the markdown spec to the workflow repairer and then
+  // re-feed the result as source=workflow-artifact, which loses the original
+  // CLI intent and routes the spec body through natural-language intent
+  // detection — where failure-vocabulary keywords misroute it to debug.
+  // Only fall back to specPath when it actually names an executable workflow.
   return (
     response.execution?.execution.workflow_file ??
     response.execution?.execution.artifact_path ??
     response.generation?.artifact?.path ??
     response.artifacts[0]?.path ??
-    request.specPath
+    (request.specPath && isExecutableWorkflowPath(request.specPath) ? request.specPath : undefined)
   );
 }
 

--- a/src/local/entrypoint.ts
+++ b/src/local/entrypoint.ts
@@ -1700,7 +1700,7 @@ function artifactPathOverrideFor(request: LocalInvocationRequest): string | unde
   return typeof candidate === 'string' && candidate.trim() ? candidate : undefined;
 }
 
-function isExecutableWorkflowPath(path: string): boolean {
+export function isExecutableWorkflowPath(path: string): boolean {
   return /(?:^|\/)workflows\/.+\.(?:ts|js)$|\.workflow\.(?:ts|js|yaml|yml)$/i.test(path);
 }
 


### PR DESCRIPTION
## Summary

- `resolveArtifactPath` in `auto-fix-loop.ts` used to fall back to `request.specPath` unconditionally. For CLI invocations like `ricky --spec-file foo.md`, that pointed at the source markdown spec — not an executable workflow. When intake-stage generation failed (e.g. unresolved clarification questions in the spec), auto-fix handed the markdown to the workflow repairer, re-fed the result as `source: 'workflow-artifact'`, and on the next attempt the natural-language classifier misrouted the spec body to `debug` (triggered by words like "logs", "stderr", "evidence" in the spec). The loop ran the full `maxAttempts` (7×) producing the misleading message `routing: Debug routing requires failed-run evidence, logs, or a run identifier`.
- Gate the `request.specPath` fallback on `isExecutableWorkflowPath` (exported from `entrypoint.ts`). When generation fails before producing an artifact and no executable workflow path exists, auto-fix now bails on attempt 1 with the original failure reason.

## Repro (before)

```
$ ricky --mode local --spec-file docs/some-spec-with-open-questions.md --run
Generation: failed (status: error).
Reason: routing: Debug routing requires failed-run evidence, logs, or a run identifier.
Auto-fix: errored after 7/7 attempt(s)
```

## After

Auto-fix bails on attempt 1 surfacing the actual intake failure (e.g. `routing: Spec has unresolved workflow authoring questions...`) instead of looping.

## Test plan

- [x] New regression test `does not treat a non-executable --spec-file path as a workflow artifact to repair` in `src/local/auto-fix-loop.test.ts`
- [x] `npx vitest run src/local/auto-fix-loop.test.ts` — 36/36 pass
- [x] `npx vitest run src/local/entrypoint.test.ts` — 118/118 pass
- [x] `npx tsc --noEmit` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)