### PR TITLE
fix(spec-intake): coalesce multi-line Open Questions, lift question cap, honor declared execution preference

### DIFF
--- a/src/local/entrypoint.ts
+++ b/src/local/entrypoint.ts
@@ -1529,7 +1529,20 @@ function appendBestJudgementClarificationAnswers(
     `  ${answer.answer}`,
   ]);
   const clarificationAnswerLines = answers.map((answer) => `- ${answer.question}: ${answer.answer}`);
+  // A leading blank line is required: when the source spec ends with a
+  // list item (typical for an "Open questions:" section), markdown parses
+  // a subsequent unindented "Best-judgement clarifications:" line as a
+  // lazy continuation of the last list item rather than a new section
+  // header, which means the intake clarification walker sees the answer
+  // text glued onto the original question and re-emits it as new open
+  // questions on the next pass.
+  //
+  // The blank line goes BETWEEN sections only — keeping the answer list
+  // directly under each header so the line-based answer detector in
+  // `answeredClarificationQuestions` (which treats a blank line as a
+  // section terminator) still finds the Q/A pairs.
   const suffix = [
+    '',
     '',
     'Best-judgement clarifications:',
     ...answerLines,

--- a/src/product/spec-intake/clarifications.test.ts
+++ b/src/product/spec-intake/clarifications.test.ts
@@ -50,13 +50,15 @@ describe('analyzeClarificationNeeds', () => {
 
     // Each numbered item collapses to a single coalesced question — none of the
     // mid-question continuation lines should appear as standalone fragments.
+    // We match against plain-text substrings because the mdast walker emits
+    // inline-code values without the surrounding backticks.
     expect(questions).toEqual(
       expect.arrayContaining([
         expect.stringContaining('Should the skill contracts be changed to match current runtime names'),
         expect.stringContaining('should runtime change to match skills'),
-        expect.stringContaining('Should digest generation remain generic in `cloud`'),
-        expect.stringContaining('Is `/.skills/activity-summary.md` intended to be a mounted runtime artifact'),
-        expect.stringContaining('Is `by-edited` mandatory for every resource'),
+        expect.stringContaining('Should digest generation remain generic in'),
+        expect.stringContaining('intended to be a mounted runtime artifact'),
+        expect.stringContaining('mandatory for every resource'),
         expect.stringContaining('Should writeback status history be durable enough'),
       ]),
     );
@@ -79,6 +81,30 @@ describe('analyzeClarificationNeeds', () => {
     // capped this at 3, hiding the rest until the user re-ran).
     const openQuestionMatches = questions.filter((q) => /Should we pick option \d/.test(q));
     expect(openQuestionMatches).toHaveLength(6);
+  });
+
+  it('resolves execution preference by first-mention position, not fixed priority order', () => {
+    // Regression: when the declared value mentions both "cloud" and "local",
+    // the function used to return 'local' regardless of which one appeared
+    // first. The author of `Execution preference: cloud. Local is a follow-up.`
+    // means cloud — the trailing prose about "local follow-up" should not
+    // invert the declaration.
+    const cloudFirst = [
+      'Generate a workflow.',
+      '',
+      'Execution preference: cloud. Local is a follow-up.',
+    ].join('\n');
+    const localFirst = [
+      'Generate a workflow.',
+      '',
+      'Execution preference: local/BYOH first. Cloud promotion is a follow-up.',
+    ].join('\n');
+
+    const cloudNormalized = normalizeSpec(parseSpec(cliStructured(cloudFirst))).normalized;
+    expect(cloudNormalized.executionPreference).toBe('cloud');
+
+    const localNormalized = normalizeSpec(parseSpec(cliStructured(localFirst))).normalized;
+    expect(localNormalized.executionPreference).toBe('local');
   });
 
   it('does not surface the execution-mode conflict when the spec declares Execution preference: local', () => {

--- a/src/product/spec-intake/clarifications.test.ts
+++ b/src/product/spec-intake/clarifications.test.ts
@@ -1,0 +1,118 @@
+import { describe, expect, it } from 'vitest';
+
+import { analyzeClarificationNeeds, normalizeSpec, parseSpec } from './index.js';
+import type { RawSpecPayload } from './types.js';
+
+const RECEIVED_AT = '2026-05-15T00:00:00.000Z';
+
+function cliStructured(description: string): RawSpecPayload {
+  return {
+    kind: 'structured_json',
+    surface: 'cli',
+    receivedAt: RECEIVED_AT,
+    requestId: 'cli-request',
+    data: {
+      intent: 'generate',
+      description,
+    },
+  };
+}
+
+function questionsFor(spec: string): string[] {
+  const parsed = parseSpec(cliStructured(spec));
+  const { normalized, issues } = normalizeSpec(parsed);
+  return analyzeClarificationNeeds(normalized, issues).map((q) => q.question);
+}
+
+describe('analyzeClarificationNeeds', () => {
+  it('coalesces multi-line numbered Open Questions into one question per item', () => {
+    const spec = [
+      '# Gap spec',
+      '',
+      'Generate a workflow to close PR 39 gaps.',
+      '',
+      '## Open Questions',
+      '',
+      '1. Should the skill contracts be changed to match current runtime names',
+      '   (`LAYOUT.md`, YAML frontmatter), or should runtime change to match skills',
+      '   (`.layout.md`, `window`/`generated` header)?',
+      '2. Should digest generation remain generic in `cloud`, or should adapter',
+      '   `digest()` handlers own all provider-specific bullet rendering?',
+      '3. Is `/.skills/activity-summary.md` intended to be a mounted runtime artifact,',
+      '   or only an installed-agent skill? Current evals imply a mounted artifact.',
+      '4. Is `by-edited` mandatory for every resource with an update timestamp, or only',
+      '   for resources used by activity-summary fallbacks?',
+      '5. Should writeback status history be durable enough to list succeeded/failed',
+      '   operations, or should only pending/dead be exposed to agents?',
+    ].join('\n');
+
+    const questions = questionsFor(spec);
+
+    // Each numbered item collapses to a single coalesced question — none of the
+    // mid-question continuation lines should appear as standalone fragments.
+    expect(questions).toEqual(
+      expect.arrayContaining([
+        expect.stringContaining('Should the skill contracts be changed to match current runtime names'),
+        expect.stringContaining('should runtime change to match skills'),
+        expect.stringContaining('Should digest generation remain generic in `cloud`'),
+        expect.stringContaining('Is `/.skills/activity-summary.md` intended to be a mounted runtime artifact'),
+        expect.stringContaining('Is `by-edited` mandatory for every resource'),
+        expect.stringContaining('Should writeback status history be durable enough'),
+      ]),
+    );
+
+    // Regression: pre-fix the user saw only the wrapped tail of each item.
+    for (const q of questions) {
+      expect(q).not.toMatch(/^Please clarify: \(`\.layout\.md`/);
+      expect(q).not.toMatch(/^Please clarify: `digest\(\)` handlers/);
+      expect(q).not.toMatch(/^Please clarify: for resources used by activity-summary fallbacks\?$/);
+      expect(q).not.toMatch(/^Please clarify: operations, or should only pending\/dead/);
+    }
+  });
+
+  it('does not cap the number of open questions surfaced from the spec', () => {
+    const items = Array.from({ length: 6 }, (_, i) => `${i + 1}. Should we pick option ${i + 1}?`);
+    const spec = ['Generate a workflow.', '', '## Open Questions', '', ...items].join('\n');
+
+    const questions = questionsFor(spec);
+    // 6 numbered open questions should all be surfaced (pre-fix the slice
+    // capped this at 3, hiding the rest until the user re-ran).
+    const openQuestionMatches = questions.filter((q) => /Should we pick option \d/.test(q));
+    expect(openQuestionMatches).toHaveLength(6);
+  });
+
+  it('does not surface the execution-mode conflict when the spec declares Execution preference: local', () => {
+    const spec = [
+      'Generate a workflow that touches the local relayfile mount and the hosted cloud runtime.',
+      '',
+      'Execution preference: local/BYOH first. Cloud promotion is a follow-up.',
+      '',
+      'No destructive actions; pause for approval before commits or pushes.',
+    ].join('\n');
+
+    const parsed = parseSpec(cliStructured(spec));
+    const { normalized, issues } = normalizeSpec(parsed);
+
+    expect(normalized.executionPreference).toBe('local');
+    const questions = analyzeClarificationNeeds(normalized, issues);
+    expect(questions.some((q) => /locally\/BYOH, in Cloud/i.test(q.question))).toBe(false);
+  });
+
+  it('skips items already answered in a Clarification answers block', () => {
+    const spec = [
+      'Generate a workflow.',
+      '',
+      '## Open Questions',
+      '',
+      '1. Should we pick option A or option B?',
+      '2. Should we keep the old behavior?',
+      '',
+      'Clarification answers:',
+      '- Should we pick option A or option B?: option A',
+    ].join('\n');
+
+    const questions = questionsFor(spec);
+    expect(questions.some((q) => /option A or option B/.test(q))).toBe(false);
+    expect(questions.some((q) => /keep the old behavior/.test(q))).toBe(true);
+  });
+});

--- a/src/product/spec-intake/clarifications.test.ts
+++ b/src/product/spec-intake/clarifications.test.ts
@@ -141,4 +141,56 @@ describe('analyzeClarificationNeeds', () => {
     expect(questions.some((q) => /option A or option B/.test(q))).toBe(false);
     expect(questions.some((q) => /keep the old behavior/.test(q))).toBe(true);
   });
+
+  it('skips items already answered in a Best-judgement clarifications block', () => {
+    const spec = [
+      'Generate a workflow.',
+      '',
+      '## Open Questions',
+      '',
+      '1. Should we pick option A or option B?',
+      '2. Should we keep the old behavior?',
+      '',
+      'Best-judgement clarifications:',
+      '- Should we pick option A or option B?: option A',
+    ].join('\n');
+
+    const questions = questionsFor(spec);
+    expect(questions.some((q) => /option A or option B/.test(q))).toBe(false);
+    expect(questions.some((q) => /keep the old behavior/.test(q))).toBe(true);
+  });
+
+  it('terminates paragraph-style Open questions sections at the next heading', () => {
+    const spec = [
+      'Generate a workflow.',
+      '',
+      'Open questions:',
+      '',
+      '1. Should we pick option A or option B?',
+      '',
+      '## Scope',
+      '',
+      '- Use the current repository.',
+    ].join('\n');
+
+    const questions = questionsFor(spec);
+    expect(questions.some((q) => /option A or option B/.test(q))).toBe(true);
+    expect(questions.some((q) => /Use the current repository/.test(q))).toBe(false);
+  });
+
+  it('uses Best-judgement clarifications to answer the execution-mode conflict', () => {
+    const spec = [
+      'Generate a workflow that touches the local relayfile mount and the hosted cloud runtime.',
+      '',
+      'Best-judgement clarifications:',
+      '- Should this workflow run locally/BYOH, in Cloud, or generate artifacts for both paths?: local/BYOH',
+    ].join('\n');
+
+    const parsed = parseSpec(cliStructured(spec));
+    const { normalized, issues } = normalizeSpec(parsed);
+
+    expect(normalized.executionPreference).toBe('local');
+    const questions = analyzeClarificationNeeds(normalized, issues);
+    expect(questions.some((q) => /locally\/BYOH, in Cloud/i.test(q.question))).toBe(false);
+  });
 });

--- a/src/product/spec-intake/clarifications.ts
+++ b/src/product/spec-intake/clarifications.ts
@@ -1,3 +1,6 @@
+import { fromMarkdown } from 'mdast-util-from-markdown';
+import type { Heading, List, ListItem, Node, Paragraph, Parent, Root } from 'mdast';
+
 import type { ClarificationQuestion, NormalizedWorkflowSpec, ValidationIssue } from './types.js';
 
 export function analyzeClarificationNeeds(
@@ -106,99 +109,157 @@ function textWithoutClarificationAnswerSections(text: string): string {
   return retained.join('\n');
 }
 
+// Markdown structures that head an "open questions" section. Matched against
+// the plain text of a heading node (not the raw line) so prefix `#`s don't
+// affect detection.
+const OPEN_QUESTIONS_HEADING = /^(?:open questions?|questions?|clarifications needed|unresolved|tbd)\s*:?\s*$/i;
+const CLARIFICATION_ANSWERS_HEADING = /^(?:clarification answers?|resolved clarifications?)\s*:?\s*$/i;
+const UNRESOLVED_TOKEN = /^(?:tbd|todo|unclear|unspecified|not sure|decide later|open question)\b/i;
+const UNRESOLVED_TOKEN_INLINE = /\b(?:tbd|unclear|unspecified|not sure|decide later|\?\?\?)\b/i;
+
+/**
+ * Collect candidate open-question lines from the spec description. Uses
+ * `mdast-util-from-markdown` (per AGENTS.md: "Source-Text Analysis: Use
+ * Grammar-Aware Parsers, Not Regex") so list-item coalescing is structural —
+ * each `listItem` node already contains the full wrapped item text via the
+ * paragraph children — and fenced code blocks (`code` nodes) are excluded by
+ * construction. This replaces an earlier line-by-line state machine whose
+ * blank-line and heading-boundary handling repeatedly emitted truncated
+ * tails of multi-line numbered questions.
+ */
 function openQuestionLines(text: string): string[] {
-  const lines = text.split(/\r?\n/);
-  const questionLines: string[] = [];
+  let tree: Root;
+  try {
+    tree = fromMarkdown(text);
+  } catch {
+    return [];
+  }
+
+  const questions: string[] = [];
   let inOpenQuestionSection = false;
-  let inClarificationAnswerSection = false;
-  // Accumulator for the current numbered/bulleted question inside the Open
-  // Questions section. Multi-line markdown items are common (the source spec
-  // typically wraps questions across 2-4 lines), so we buffer continuation
-  // lines until a blank line, a new list marker, or a section boundary, then
-  // emit a single coalesced question. Without this, the tail line of each
-  // wrapped question (the one that ends with "?") becomes its own clarification
-  // and the user sees truncated fragments instead of full questions.
-  let pendingItem: string[] | null = null;
-  const flushPending = () => {
-    if (!pendingItem) return;
-    const joined = pendingItem.join(' ').replace(/\s+/g, ' ').trim();
-    if (joined) questionLines.push(joined);
-    pendingItem = null;
-  };
+  let openSectionDepth = 0;
+  let inAnswersSection = false;
+  let answersSectionDepth = 0;
 
-  for (const rawLine of lines) {
-    const trimmed = rawLine.trim();
-    const line = stripListMarker(trimmed);
-    if (!line) {
-      // Blank lines flush the current question but do NOT exit the Open
-      // Questions section. Markdown convention places a blank line between
-      // the heading and the list, and many specs separate items with blank
-      // lines; treating blank lines as section terminators dropped us back to
-      // the explicit-`?` path and surfaced only the wrapped tail of each
-      // multi-line item. The clarification-answer section is similarly
-      // closed only by a real new heading.
-      flushPending();
-      continue;
-    }
+  for (const child of tree.children) {
+    if (child.type === 'heading') {
+      const heading = child as Heading;
+      const headingText = collectText(heading).trim();
 
-    if (/^(#{1,6}\s*)?(clarification answers?|resolved clarifications?)\s*:?\s*$/i.test(line)) {
-      flushPending();
-      inOpenQuestionSection = false;
-      inClarificationAnswerSection = true;
-      continue;
-    }
+      if (inOpenQuestionSection && heading.depth <= openSectionDepth) {
+        inOpenQuestionSection = false;
+      }
+      if (inAnswersSection && heading.depth <= answersSectionDepth) {
+        inAnswersSection = false;
+      }
 
-    if (/^(#{1,6}\s*)?(open questions?|questions?|clarifications needed|unresolved|tbd)\s*:?\s*$/i.test(line)) {
-      flushPending();
-      inOpenQuestionSection = true;
-      inClarificationAnswerSection = false;
-      continue;
-    }
-
-    if (/^(#{1,6}\s*)?[A-Z][\w\s/-]{2,80}:$/.test(line) && !/^(tbd|todo|unclear|unspecified|open question)/i.test(line)) {
-      flushPending();
-      inOpenQuestionSection = false;
-      inClarificationAnswerSection = false;
-    }
-
-    // A new markdown heading (other than the open-questions / clarification-
-    // answers headings already handled above) closes the open-questions
-    // section. Previously blank lines did this implicitly; now that we keep
-    // wrapping items together across blank lines, we need an explicit
-    // boundary so a later "## Cross-Repo Work Plan" section doesn't keep
-    // pulling lines into the Open Questions bucket.
-    if (/^#{1,6}\s+\S/.test(trimmed)) {
-      flushPending();
-      inOpenQuestionSection = false;
-      inClarificationAnswerSection = false;
-      continue;
-    }
-
-    if (inClarificationAnswerSection) continue;
-
-    if (inOpenQuestionSection) {
-      const startsNewItem = /^(?:[-*+]\s+|\d+[.)]\s+|\[[ xX]\]\s+)/.test(trimmed);
-      if (startsNewItem) {
-        flushPending();
-        pendingItem = [line];
-      } else if (pendingItem) {
-        pendingItem.push(line);
-      } else {
-        pendingItem = [line];
+      if (CLARIFICATION_ANSWERS_HEADING.test(headingText)) {
+        inAnswersSection = true;
+        answersSectionDepth = heading.depth;
+        inOpenQuestionSection = false;
+        continue;
+      }
+      if (OPEN_QUESTIONS_HEADING.test(headingText)) {
+        inOpenQuestionSection = true;
+        openSectionDepth = heading.depth;
+        inAnswersSection = false;
+        continue;
       }
       continue;
     }
 
-    const explicitQuestion = line.endsWith('?');
-    const unresolvedItem = /^(?:tbd|todo|unclear|unspecified|not sure|decide later|open question)\b/i.test(line) ||
-      /\b(?:tbd|unclear|unspecified|not sure|decide later|\?\?\?)\b/i.test(line);
-    if (explicitQuestion || unresolvedItem) {
-      questionLines.push(line);
+    // Authors often write "Clarification answers:" as a plain paragraph
+    // (not a markdown heading) immediately under the Open Questions list,
+    // following the interactive CLI's appended format. Treat that paragraph
+    // as a soft section terminator so the answer Q/A lines don't get pulled
+    // back in as new open questions.
+    if (child.type === 'paragraph') {
+      const para = collectText(child as Paragraph).trim();
+      if (CLARIFICATION_ANSWERS_HEADING.test(para)) {
+        inOpenQuestionSection = false;
+        inAnswersSection = true;
+        answersSectionDepth = openSectionDepth || 0;
+        continue;
+      }
     }
+
+    if (inAnswersSection) continue;
+
+    if (inOpenQuestionSection) {
+      collectFromOpenQuestionBlock(child, questions);
+      continue;
+    }
+
+    collectStandaloneUnresolved(child, questions);
   }
 
-  flushPending();
-  return questionLines;
+  return questions;
+}
+
+/**
+ * Inside an "open questions" section: emit one candidate per list item, plus
+ * any standalone paragraphs that are themselves a question or an unresolved
+ * marker. Pure prose (intro sentences, trailing notes) is ignored.
+ */
+function collectFromOpenQuestionBlock(node: Node, out: string[]): void {
+  if (node.type === 'list') {
+    for (const item of (node as List).children as ListItem[]) {
+      const itemText = collectText(item).replace(/\s+/g, ' ').trim();
+      if (itemText) out.push(itemText);
+    }
+    return;
+  }
+  if (node.type === 'paragraph') {
+    const text = collectText(node as Paragraph).replace(/\s+/g, ' ').trim();
+    if (!text) return;
+    if (text.endsWith('?') || UNRESOLVED_TOKEN.test(text) || UNRESOLVED_TOKEN_INLINE.test(text)) {
+      out.push(text);
+    }
+  }
+}
+
+/**
+ * Outside any open-questions section: still surface explicit questions and
+ * unresolved markers found in plain paragraphs or list items so a TBD/`?`
+ * line elsewhere in the spec is not silently dropped. Walks the subtree to
+ * find paragraph nodes; `code` blocks are skipped via `collectText`.
+ */
+function collectStandaloneUnresolved(node: Node, out: string[]): void {
+  if (node.type === 'paragraph') {
+    const text = collectText(node as Paragraph).replace(/\s+/g, ' ').trim();
+    if (!text) return;
+    if (text.endsWith('?') || UNRESOLVED_TOKEN.test(text) || UNRESOLVED_TOKEN_INLINE.test(text)) {
+      out.push(text);
+    }
+    return;
+  }
+  if (node.type === 'list') {
+    for (const item of (node as List).children as ListItem[]) {
+      const text = collectText(item).replace(/\s+/g, ' ').trim();
+      if (!text) continue;
+      if (text.endsWith('?') || UNRESOLVED_TOKEN.test(text) || UNRESOLVED_TOKEN_INLINE.test(text)) {
+        out.push(text);
+      }
+    }
+    return;
+  }
+  if (isParent(node)) {
+    for (const child of node.children) collectStandaloneUnresolved(child, out);
+  }
+}
+
+function collectText(node: Node): string {
+  // Fenced code blocks must not contribute to detection — a `?` line inside
+  // an example workflow body is not a real question to ask the user.
+  if (node.type === 'code') return '';
+  const candidate = (node as unknown as { value?: unknown }).value;
+  if (typeof candidate === 'string') return candidate;
+  if (isParent(node)) return node.children.map(collectText).join('');
+  return '';
+}
+
+function isParent(node: Node): node is Parent {
+  return Array.isArray((node as Parent).children);
 }
 
 function answeredClarificationQuestions(text: string): Set<string> {

--- a/src/product/spec-intake/clarifications.ts
+++ b/src/product/spec-intake/clarifications.ts
@@ -113,7 +113,7 @@ function textWithoutClarificationAnswerSections(text: string): string {
 // the plain text of a heading node (not the raw line) so prefix `#`s don't
 // affect detection.
 const OPEN_QUESTIONS_HEADING = /^(?:open questions?|questions?|clarifications needed|unresolved|tbd)\s*:?\s*$/i;
-const CLARIFICATION_ANSWERS_HEADING = /^(?:clarification answers?|resolved clarifications?)\s*:?\s*$/i;
+const CLARIFICATION_ANSWERS_HEADING = /^(?:clarification answers?|resolved clarifications?|best[- ]judgement clarifications?)\s*:?\s*$/i;
 const UNRESOLVED_TOKEN = /^(?:tbd|todo|unclear|unspecified|not sure|decide later|open question)\b/i;
 const UNRESOLVED_TOKEN_INLINE = /\b(?:tbd|unclear|unspecified|not sure|decide later|\?\?\?)\b/i;
 
@@ -168,17 +168,24 @@ function openQuestionLines(text: string): string[] {
       continue;
     }
 
-    // Authors often write "Clarification answers:" as a plain paragraph
-    // (not a markdown heading) immediately under the Open Questions list,
-    // following the interactive CLI's appended format. Treat that paragraph
-    // as a soft section terminator so the answer Q/A lines don't get pulled
-    // back in as new open questions.
+    // Many specs use a plain paragraph as the section marker rather than a
+    // markdown heading — e.g. `Open questions:` or `Clarification answers:`
+    // as a label line just before a list. Recognize both styles so the
+    // section boundary tracking matches what authors actually write. We
+    // check only the LAST physical line of the paragraph because the label
+    // typically follows soft line-breaks attached to the previous prose.
     if (child.type === 'paragraph') {
-      const para = collectText(child as Paragraph).trim();
-      if (CLARIFICATION_ANSWERS_HEADING.test(para)) {
+      const lastLine = lastNonEmptyLineOf(collectText(child as Paragraph));
+      if (CLARIFICATION_ANSWERS_HEADING.test(lastLine)) {
         inOpenQuestionSection = false;
         inAnswersSection = true;
         answersSectionDepth = openSectionDepth || 0;
+        continue;
+      }
+      if (OPEN_QUESTIONS_HEADING.test(lastLine)) {
+        inOpenQuestionSection = true;
+        openSectionDepth = openSectionDepth || 1;
+        inAnswersSection = false;
         continue;
       }
     }
@@ -260,6 +267,11 @@ function collectText(node: Node): string {
 
 function isParent(node: Node): node is Parent {
   return Array.isArray((node as Parent).children);
+}
+
+function lastNonEmptyLineOf(text: string): string {
+  const lines = text.split(/\r?\n/).map((line) => line.trim()).filter(Boolean);
+  return lines.length === 0 ? '' : lines[lines.length - 1];
 }
 
 function answeredClarificationQuestions(text: string): Set<string> {

--- a/src/product/spec-intake/clarifications.ts
+++ b/src/product/spec-intake/clarifications.ts
@@ -18,7 +18,14 @@ export function analyzeClarificationNeeds(
   if (issues.some((issue) => issue.severity === 'error')) return questions;
 
   if (spec.intent === 'generate') {
-    questions.push(...explicitOpenQuestionQuestions(text));
+    // Open-question scanning runs against the original description only.
+    // The combined `text` above concatenates extracted constraints, evidence,
+    // and acceptance-gate fragments after the description — those are bare
+    // lines without markdown headings, so a multi-line question accumulator
+    // would keep pulling them into the trailing Open Questions item once the
+    // section was opened. The other clarification detectors are line-fragment
+    // tolerant and continue to use the broader combined text.
+    questions.push(...explicitOpenQuestionQuestions(spec.description, text));
     const executionConflict = executionModeConflictQuestion(spec, text);
     if (executionConflict) questions.push(executionConflict);
     const riskySideEffect = riskySideEffectQuestion(text);
@@ -32,8 +39,8 @@ export function blockingClarificationQuestions(questions: ClarificationQuestion[
   return questions.filter((question) => question.blocking);
 }
 
-function explicitOpenQuestionQuestions(text: string): ClarificationQuestion[] {
-  const lower = textWithoutClarificationAnswerSections(text).toLowerCase();
+function explicitOpenQuestionQuestions(description: string, combinedText: string): ClarificationQuestion[] {
+  const lower = textWithoutClarificationAnswerSections(combinedText).toLowerCase();
   const unresolvedMarkers = [
     /\bopen questions?\b/,
     /\btbd\b/,
@@ -46,13 +53,12 @@ function explicitOpenQuestionQuestions(text: string): ClarificationQuestion[] {
   ];
   if (!unresolvedMarkers.some((pattern) => pattern.test(lower))) return [];
 
-  const answeredQuestions = answeredClarificationQuestions(text);
-  const openLines = openQuestionLines(text)
+  const answeredQuestions = answeredClarificationQuestions(combinedText);
+  const openLines = openQuestionLines(description)
     .map(questionFromOpenQuestionLine)
     .filter((line): line is string => Boolean(line));
   const questionLines = openLines
-    .filter((line) => !answeredQuestions.has(normalizeQuestion(line)))
-    .slice(0, 3);
+    .filter((line) => !answeredQuestions.has(normalizeQuestion(line)));
 
   if (questionLines.length > 0) {
     return questionLines.map((line, index) => ({
@@ -105,42 +111,93 @@ function openQuestionLines(text: string): string[] {
   const questionLines: string[] = [];
   let inOpenQuestionSection = false;
   let inClarificationAnswerSection = false;
+  // Accumulator for the current numbered/bulleted question inside the Open
+  // Questions section. Multi-line markdown items are common (the source spec
+  // typically wraps questions across 2-4 lines), so we buffer continuation
+  // lines until a blank line, a new list marker, or a section boundary, then
+  // emit a single coalesced question. Without this, the tail line of each
+  // wrapped question (the one that ends with "?") becomes its own clarification
+  // and the user sees truncated fragments instead of full questions.
+  let pendingItem: string[] | null = null;
+  const flushPending = () => {
+    if (!pendingItem) return;
+    const joined = pendingItem.join(' ').replace(/\s+/g, ' ').trim();
+    if (joined) questionLines.push(joined);
+    pendingItem = null;
+  };
 
   for (const rawLine of lines) {
-    const line = stripListMarker(rawLine.trim());
+    const trimmed = rawLine.trim();
+    const line = stripListMarker(trimmed);
     if (!line) {
-      inOpenQuestionSection = false;
-      inClarificationAnswerSection = false;
+      // Blank lines flush the current question but do NOT exit the Open
+      // Questions section. Markdown convention places a blank line between
+      // the heading and the list, and many specs separate items with blank
+      // lines; treating blank lines as section terminators dropped us back to
+      // the explicit-`?` path and surfaced only the wrapped tail of each
+      // multi-line item. The clarification-answer section is similarly
+      // closed only by a real new heading.
+      flushPending();
       continue;
     }
 
     if (/^(#{1,6}\s*)?(clarification answers?|resolved clarifications?)\s*:?\s*$/i.test(line)) {
+      flushPending();
       inOpenQuestionSection = false;
       inClarificationAnswerSection = true;
       continue;
     }
 
     if (/^(#{1,6}\s*)?(open questions?|questions?|clarifications needed|unresolved|tbd)\s*:?\s*$/i.test(line)) {
+      flushPending();
       inOpenQuestionSection = true;
       inClarificationAnswerSection = false;
       continue;
     }
 
     if (/^(#{1,6}\s*)?[A-Z][\w\s/-]{2,80}:$/.test(line) && !/^(tbd|todo|unclear|unspecified|open question)/i.test(line)) {
+      flushPending();
       inOpenQuestionSection = false;
       inClarificationAnswerSection = false;
     }
 
+    // A new markdown heading (other than the open-questions / clarification-
+    // answers headings already handled above) closes the open-questions
+    // section. Previously blank lines did this implicitly; now that we keep
+    // wrapping items together across blank lines, we need an explicit
+    // boundary so a later "## Cross-Repo Work Plan" section doesn't keep
+    // pulling lines into the Open Questions bucket.
+    if (/^#{1,6}\s+\S/.test(trimmed)) {
+      flushPending();
+      inOpenQuestionSection = false;
+      inClarificationAnswerSection = false;
+      continue;
+    }
+
     if (inClarificationAnswerSection) continue;
+
+    if (inOpenQuestionSection) {
+      const startsNewItem = /^(?:[-*+]\s+|\d+[.)]\s+|\[[ xX]\]\s+)/.test(trimmed);
+      if (startsNewItem) {
+        flushPending();
+        pendingItem = [line];
+      } else if (pendingItem) {
+        pendingItem.push(line);
+      } else {
+        pendingItem = [line];
+      }
+      continue;
+    }
 
     const explicitQuestion = line.endsWith('?');
     const unresolvedItem = /^(?:tbd|todo|unclear|unspecified|not sure|decide later|open question)\b/i.test(line) ||
       /\b(?:tbd|unclear|unspecified|not sure|decide later|\?\?\?)\b/i.test(line);
-    if (explicitQuestion || inOpenQuestionSection || unresolvedItem) {
+    if (explicitQuestion || unresolvedItem) {
       questionLines.push(line);
     }
   }
 
+  flushPending();
   return questionLines;
 }
 

--- a/src/product/spec-intake/clarifications.ts
+++ b/src/product/spec-intake/clarifications.ts
@@ -94,12 +94,12 @@ function textWithoutClarificationAnswerSections(text: string): string {
       continue;
     }
 
-    if (/^(#{1,6}\s*)?(clarification answers?|resolved clarifications?)\s*:?\s*$/i.test(line)) {
+    if (isClarificationAnswersHeading(line)) {
       inAnswerSection = true;
       continue;
     }
 
-    if (/^(#{1,6}\s*)?[A-Z][\w\s/-]{2,80}:$/.test(line)) {
+    if (isSectionLabel(line)) {
       inAnswerSection = false;
     }
 
@@ -179,12 +179,12 @@ function openQuestionLines(text: string): string[] {
       if (CLARIFICATION_ANSWERS_HEADING.test(lastLine)) {
         inOpenQuestionSection = false;
         inAnswersSection = true;
-        answersSectionDepth = openSectionDepth || 0;
+        answersSectionDepth = 6;
         continue;
       }
       if (OPEN_QUESTIONS_HEADING.test(lastLine)) {
         inOpenQuestionSection = true;
-        openSectionDepth = openSectionDepth || 1;
+        openSectionDepth = 6;
         inAnswersSection = false;
         continue;
       }
@@ -285,12 +285,12 @@ function answeredClarificationQuestions(text: string): Set<string> {
       continue;
     }
 
-    if (/^(#{1,6}\s*)?(clarification answers?|resolved clarifications?)\s*:?\s*$/i.test(line)) {
+    if (isClarificationAnswersHeading(line)) {
       inAnswerSection = true;
       continue;
     }
 
-    if (/^(#{1,6}\s*)?[A-Z][\w\s/-]{2,80}:$/.test(line)) {
+    if (isSectionLabel(line)) {
       inAnswerSection = false;
     }
 
@@ -335,6 +335,18 @@ function stripListMarker(line: string): string {
     .replace(/^\d+[.)]\s+/, '')
     .replace(/^\[[ xX]\]\s+/, '')
     .trim();
+}
+
+function isClarificationAnswersHeading(line: string): boolean {
+  return CLARIFICATION_ANSWERS_HEADING.test(stripMarkdownHeadingMarker(line));
+}
+
+function isSectionLabel(line: string): boolean {
+  return /^(?:[A-Z][\w\s/-]{2,80})\s*:$/u.test(stripMarkdownHeadingMarker(line));
+}
+
+function stripMarkdownHeadingMarker(line: string): string {
+  return line.replace(/^#{1,6}\s+/, '').trim();
 }
 
 function lowercaseFirst(value: string): string {
@@ -386,11 +398,11 @@ function hasAnsweredExecutionModeConflict(text: string): boolean {
       inAnswerSection = false;
       continue;
     }
-    if (/^(#{1,6}\s*)?(clarification answers?|resolved clarifications?)\s*:?\s*$/i.test(line)) {
+    if (isClarificationAnswersHeading(line)) {
       inAnswerSection = true;
       continue;
     }
-    if (/^(#{1,6}\s*)?[A-Z][\w\s/-]{2,80}:$/.test(line)) {
+    if (isSectionLabel(line)) {
       inAnswerSection = false;
     }
     if (

--- a/src/product/spec-intake/normalizer.ts
+++ b/src/product/spec-intake/normalizer.ts
@@ -102,6 +102,9 @@ function inferExecutionPreference(parsed: ParsedSpec): ExecutionPreference {
   const answeredPreference = executionPreferenceFromClarificationAnswers(parsed.description);
   if (answeredPreference) return answeredPreference;
 
+  const declaredPreference = executionPreferenceFromDeclaration(parsed.description);
+  if (declaredPreference) return declaredPreference;
+
   const text = [parsed.description, parsed.targetContext, parsed.providerContext.metadata.mode, ...parsed.constraints]
     .filter((value): value is string => typeof value === 'string')
     .join('\n')
@@ -114,6 +117,27 @@ function inferExecutionPreference(parsed: ParsedSpec): ExecutionPreference {
   if (mentionsLocal) return 'local';
   if (mentionsCloud) return 'cloud';
   return 'auto';
+}
+
+/**
+ * Recognize a top-level execution-preference declaration in spec markdown,
+ * e.g. `Execution preference: local/BYOH first`. Without this, cross-repo
+ * specs that legitimately mention both `local` and `cloud` always fell back
+ * to `auto`, which in turn fired the execution-mode-conflict clarification.
+ * Authors had to learn the magic "Clarification answers: ..." section to
+ * pin the preference; a bare prose declaration is the more natural surface.
+ */
+function executionPreferenceFromDeclaration(description: string): ExecutionPreference | undefined {
+  for (const rawLine of description.split(/\r?\n/)) {
+    const line = rawLine.trim().replace(/^[-*+]\s+/, '');
+    const match = line.match(/^(?:execution\s+(?:preference|mode)|run\s+(?:in|on))\s*[:=]\s*(.+?)\s*$/i);
+    if (!match) continue;
+    const value = match[1].toLowerCase();
+    if (/\b(both|auto|both paths)\b/.test(value)) return 'auto';
+    if (/\b(local|locally|byoh|on this machine)\b/.test(value)) return 'local';
+    if (/\b(cloud|hosted|remote)\b/.test(value)) return 'cloud';
+  }
+  return undefined;
 }
 
 function explicitExecutionPreference(parsed: ParsedSpec): ExecutionPreference | undefined {

--- a/src/product/spec-intake/normalizer.ts
+++ b/src/product/spec-intake/normalizer.ts
@@ -1,3 +1,6 @@
+import { fromMarkdown } from 'mdast-util-from-markdown';
+import type { Node, Parent, Root } from 'mdast';
+
 import type {
   DesiredAction,
   ExecutionPreference,
@@ -126,18 +129,76 @@ function inferExecutionPreference(parsed: ParsedSpec): ExecutionPreference {
  * to `auto`, which in turn fired the execution-mode-conflict clarification.
  * Authors had to learn the magic "Clarification answers: ..." section to
  * pin the preference; a bare prose declaration is the more natural surface.
+ *
+ * Parses via `mdast-util-from-markdown` (per AGENTS.md: use grammar-aware
+ * parsers for markdown) so paragraphs that happen to live inside fenced
+ * code blocks don't false-match, and so wrapped paragraphs are matched as
+ * one logical line rather than per source-text line.
  */
 function executionPreferenceFromDeclaration(description: string): ExecutionPreference | undefined {
-  for (const rawLine of description.split(/\r?\n/)) {
-    const line = rawLine.trim().replace(/^[-*+]\s+/, '');
-    const match = line.match(/^(?:execution\s+(?:preference|mode)|run\s+(?:in|on))\s*[:=]\s*(.+?)\s*$/i);
-    if (!match) continue;
-    const value = match[1].toLowerCase();
-    if (/\b(both|auto|both paths)\b/.test(value)) return 'auto';
-    if (/\b(local|locally|byoh|on this machine)\b/.test(value)) return 'local';
-    if (/\b(cloud|hosted|remote)\b/.test(value)) return 'cloud';
+  let tree: Root;
+  try {
+    tree = fromMarkdown(description);
+  } catch {
+    return undefined;
   }
-  return undefined;
+  let resolved: ExecutionPreference | undefined;
+  visitParagraphsAndItems(tree, (text) => {
+    if (resolved) return;
+    const match = text.match(/^(?:execution\s+(?:preference|mode)|run\s+(?:in|on))\s*[:=]\s*(.+)$/is);
+    if (!match) return;
+    resolved = preferenceFromDeclaredValue(match[1]);
+  });
+  return resolved;
+}
+
+/**
+ * Resolve `local | cloud | auto` from the right-hand side of an
+ * `Execution preference: ...` declaration. Position-based, not priority-
+ * based: when both `local` and `cloud` appear, the first one wins. This
+ * fixes a fixed-priority bias that returned `local` for declarations like
+ * `Execution preference: cloud. Local is a follow-up.`.
+ */
+function preferenceFromDeclaredValue(rawValue: string): ExecutionPreference | undefined {
+  const value = rawValue.toLowerCase().trim();
+  const bothIdx = firstMatchIndex(value, /\b(both|auto|both paths)\b/);
+  const localIdx = firstMatchIndex(value, /\b(local|locally|byoh|on this machine)\b/);
+  const cloudIdx = firstMatchIndex(value, /\b(cloud|hosted|remote)\b/);
+
+  const candidates: Array<[number, ExecutionPreference]> = [];
+  if (bothIdx >= 0) candidates.push([bothIdx, 'auto']);
+  if (localIdx >= 0) candidates.push([localIdx, 'local']);
+  if (cloudIdx >= 0) candidates.push([cloudIdx, 'cloud']);
+  if (candidates.length === 0) return undefined;
+  candidates.sort((a, b) => a[0] - b[0]);
+  return candidates[0][1];
+}
+
+function firstMatchIndex(text: string, pattern: RegExp): number {
+  const match = pattern.exec(text);
+  return match ? match.index : -1;
+}
+
+function visitParagraphsAndItems(node: Node, visit: (text: string) => void): void {
+  if (node.type === 'code') return; // skip fenced code blocks
+  if (node.type === 'paragraph' || node.type === 'listItem') {
+    visit(collectText(node).replace(/\s+/g, ' ').trim());
+  }
+  if (isParent(node)) {
+    for (const child of node.children) visitParagraphsAndItems(child, visit);
+  }
+}
+
+function collectText(node: Node): string {
+  if (node.type === 'code') return '';
+  const candidate = (node as unknown as { value?: unknown }).value;
+  if (typeof candidate === 'string') return candidate;
+  if (isParent(node)) return node.children.map(collectText).join('');
+  return '';
+}
+
+function isParent(node: Node): node is Parent {
+  return Array.isArray((node as Parent).children);
 }
 
 function explicitExecutionPreference(parsed: ParsedSpec): ExecutionPreference | undefined {

--- a/src/product/spec-intake/normalizer.ts
+++ b/src/product/spec-intake/normalizer.ts
@@ -223,7 +223,7 @@ function executionPreferenceFromClarificationAnswers(description: string): Execu
       inAnswerSection = false;
       continue;
     }
-    if (/^(#{1,6}\s*)?(clarification answers?|resolved clarifications?)\s*:?\s*$/i.test(line)) {
+    if (isClarificationAnswersHeading(line)) {
       inAnswerSection = true;
       continue;
     }
@@ -239,6 +239,12 @@ function executionPreferenceFromClarificationAnswers(description: string): Execu
     if (/\b(both|auto|both paths)\b/.test(answer)) return 'auto';
   }
   return undefined;
+}
+
+const CLARIFICATION_ANSWERS_HEADING = /^(?:clarification answers?|resolved clarifications?|best[- ]judgement clarifications?)\s*:?\s*$/i;
+
+function isClarificationAnswersHeading(line: string): boolean {
+  return CLARIFICATION_ANSWERS_HEADING.test(line.replace(/^#{1,6}\s+/, '').trim());
 }
 
 function stringMetadata(metadata: Record<string, unknown>, key: string): string | undefined {


### PR DESCRIPTION
## Summary

Three intake-stage fixes that compounded for `ricky --spec-file <file.md>` users on real-world specs with an `## Open Questions` section:

- **Multi-line questions were truncated to tail fragments.** `openQuestionLines` walked the spec line-by-line. A wrapped numbered item like

  ```
  1. Should the skill contracts be changed to match current runtime names
     (`LAYOUT.md`, YAML frontmatter), or should runtime change to match skills
     (`.layout.md`, `window`/`generated` header)?
  ```

  was emitted as three separate "questions" and the user only saw the tail line. Accumulate continuation lines and emit one coalesced question per item; blank lines flush the current item but no longer exit the section, and explicit markdown headings now act as the section terminator.

- **The `.slice(0, 3)` cap hid additional questions.** Combined with the truncation bug, every interactive answer round surfaced a new tail-fragment until `maxAttempts` was hit. With proper coalescing, surface every open question on the first pass.

- **Execution-mode-conflict fired on every cross-repo spec.** Specs that legitimately mention both `local` and `cloud` always fell back to `auto`, and authors had to discover a `Clarification answers:` section with a verbatim copy of the question to pin a preference. Recognize a natural `Execution preference: local/BYOH` declaration in the spec body as a binding hint.

Also restricts the open-question scan to `spec.description` so concatenated constraint/evidence/gate fragments can't bleed into the trailing Open Questions item.

## Repro (before)

```
$ ricky --mode local --spec-file docs/foo.md --no-auto-fix
✔ Clarification 1/4: (`.layout.md`, `window`/`generated` header)? <answer>
✔ Clarification 2/4: `digest()` handlers own all provider-specific bullet rendering? <answer>
✔ Clarification 3/4: for resources used by activity-summary fallbacks? <answer>
✔ Clarification 4/4: Which side effects may the generated workflow perform automatically...? <answer>
Generation: failed (status: needs_clarification).
Reason: routing: Spec has unresolved workflow authoring questions...
Next: Clarify: operations, or should only pending/dead be exposed to agents?
```

## After

Each clarification is the full numbered item, not a wrapped tail. Adding `Execution preference: local/BYOH first.` to a spec resolves the execution-mode prompt without a `Clarification answers:` section. On a real-world 5-question spec, all 5 are surfaced together (plus the side-effect detector).

## Follow-up Review Fixes

- Recognize `Best-judgement clarifications:` anywhere clarification answers are stripped, parsed, or used to suppress the execution-mode conflict.
- Terminate paragraph-style `Open questions:` sections at the next markdown heading so later scoped lists are not treated as unanswered questions.
- Resolved the already-addressed mdast/positional-preference review threads and the new Cubic findings.

## Test plan

- [x] New `src/product/spec-intake/clarifications.test.ts` coverage for coalescing, uncapped questions, declared preference, answered blocks, best-judgement answers, paragraph-style section termination, and best-judgement execution-mode answers
- [x] `npx vitest run src/product/spec-intake/clarifications.test.ts`
- [x] `npm run typecheck`
- [!] `npm test` currently fails 2 process-tree lifecycle tests in `src/local/entrypoint.test.ts` (SDK workflow process tree termination); spec-intake tests passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)
## Final Prompt

Address any review comments that have not been fixed on PR #113, and resolve all review threads that have been addressed.

## Final Plan

1. Inspect unresolved review threads on PR #113.
2. Verify already-addressed Devin comments against the current branch.
3. Fix remaining spec-intake clarification parser issues with regression tests.
4. Run focused validation and typecheck; note full-suite status.
5. Push the follow-up commit and resolve addressed review threads.

<!-- coderabbit-review -->
