### PR TITLE
Expose Ricky SDK package entry

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ Slack is a surface, not the product identity.
 
 ## Install and Run
 
-Ricky is an npm package: `@agentworkforce/ricky`. It publishes the `ricky` bin from `dist/ricky.js`.
+Ricky is an npm package: `@agentworkforce/ricky`. It publishes the `ricky` bin from `dist/ricky.js` and the SDK from `dist/index.js`.
 
 For local development from the repo:
 
@@ -55,6 +55,28 @@ For package consumers, the intended command form is:
 npx @agentworkforce/ricky --help
 ricky --help
 ```
+
+## SDK Usage
+
+Projects can import Ricky directly instead of shelling out to the CLI:
+
+```ts
+import { createRickySdk } from '@agentworkforce/ricky';
+
+const ricky = createRickySdk({ cwd: process.cwd() });
+
+const generated = await ricky.generateLocalWorkflow({
+  spec: 'Generate a workflow that checks package health',
+  workflowName: 'package-health',
+});
+
+const run = await ricky.runLocalWorkflow({
+  workflowPath: 'workflows/generated/package-health.ts',
+  autoFixAttempts: 3,
+});
+```
+
+The SDK also exposes `generateCloudWorkflow`, `scheduleWorkflow`, `listWorkflowSchedules`, and `runCli`. The published CLI uses `runRickyCli` from the SDK, so command behavior and package imports share the same implementation boundary.
 
 ## CLI Reference
 

--- a/package.json
+++ b/package.json
@@ -25,6 +25,14 @@
     "node": ">=22.14.0"
   },
   "type": "module",
+  "main": "./dist/index.js",
+  "types": "./dist/sdk/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/sdk/index.d.ts",
+      "import": "./dist/index.js"
+    }
+  },
   "bin": {
     "ricky": "./dist/ricky.js"
   },

--- a/scripts/bundle-cli.mjs
+++ b/scripts/bundle-cli.mjs
@@ -1,6 +1,7 @@
 #!/usr/bin/env node
 /**
- * Bundle the ricky CLI into a single self-contained ESM file at dist/ricky.js.
+ * Bundle the ricky CLI into a single self-contained ESM file at dist/ricky.js
+ * and the public SDK into dist/index.js.
  *
  * The published @agentworkforce/ricky package ships a precompiled bundle so
  * global installs work without a separate tsc pass and without devDeps like
@@ -9,14 +10,17 @@
  */
 
 import { build } from 'esbuild';
-import { readFileSync } from 'node:fs';
+import { readFileSync, rmSync } from 'node:fs';
 import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
+import ts from 'typescript';
 
 const repoRoot = dirname(dirname(fileURLToPath(import.meta.url)));
 
 const rootPkg = JSON.parse(readFileSync(join(repoRoot, 'package.json'), 'utf8'));
 const externals = Object.keys(rootPkg.dependencies ?? {});
+
+rmSync(join(repoRoot, 'dist'), { recursive: true, force: true });
 
 await build({
   entryPoints: [join(repoRoot, 'src/surfaces/cli/bin/ricky.ts')],
@@ -31,5 +35,63 @@ await build({
   logLevel: 'info',
 });
 
+await build({
+  entryPoints: [join(repoRoot, 'src/sdk/index.ts')],
+  bundle: true,
+  platform: 'node',
+  format: 'esm',
+  target: 'node20',
+  outfile: join(repoRoot, 'dist/index.js'),
+  external: externals,
+  resolveExtensions: ['.ts', '.tsx', '.mjs', '.js'],
+  sourcemap: 'inline',
+  logLevel: 'info',
+});
+
+emitDeclarations();
+
 console.log('Bundled ricky CLI →', join(repoRoot, 'dist/ricky.js'));
+console.log('Bundled Ricky SDK →', join(repoRoot, 'dist/index.js'));
 console.log('Externals (resolved at install time):', externals.join(', '));
+
+function emitDeclarations() {
+  const configPath = ts.findConfigFile(repoRoot, ts.sys.fileExists, 'tsconfig.json');
+  if (!configPath) {
+    throw new Error('Could not find tsconfig.json for declaration emit.');
+  }
+
+  const parsedConfig = ts.parseJsonConfigFileContent(
+    ts.readConfigFile(configPath, ts.sys.readFile).config,
+    ts.sys,
+    repoRoot,
+    {
+      declaration: true,
+      declarationMap: false,
+      emitDeclarationOnly: true,
+      noEmit: false,
+      outDir: join(repoRoot, 'dist'),
+      rootDir: join(repoRoot, 'src'),
+      sourceMap: false,
+    },
+    configPath,
+  );
+
+  const srcRoot = join(repoRoot, 'src');
+  const sourceFiles = ts.sys
+    .readDirectory(srcRoot, ['.ts'], undefined, undefined)
+    .filter((file) => !file.endsWith('.test.ts'));
+  const program = ts.createProgram(sourceFiles, parsedConfig.options);
+  const emit = program.emit();
+  const diagnostics = ts
+    .getPreEmitDiagnostics(program)
+    .concat(emit.diagnostics)
+    .filter((diagnostic) => diagnostic.category === ts.DiagnosticCategory.Error);
+
+  if (diagnostics.length > 0) {
+    throw new Error(ts.formatDiagnosticsWithColorAndContext(diagnostics, {
+      getCanonicalFileName: (fileName) => fileName,
+      getCurrentDirectory: () => repoRoot,
+      getNewLine: () => '\n',
+    }));
+  }
+}

--- a/src/sdk/index.test.ts
+++ b/src/sdk/index.test.ts
@@ -1,0 +1,142 @@
+import { describe, expect, it, vi } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+
+import { createRickySdk, runRickyCli } from './index.js';
+import type { LocalResponse } from '../local/index.js';
+import type { CloudGenerateResponse } from '../cloud/api/index.js';
+
+function okLocalResponse(overrides: Partial<LocalResponse> = {}): LocalResponse {
+  return {
+    ok: true,
+    artifacts: [{ path: 'workflows/generated/release-health.ts', type: 'text/typescript' }],
+    logs: [],
+    warnings: [],
+    nextActions: [],
+    exitCode: 0,
+    ...overrides,
+  };
+}
+
+describe('Ricky SDK', () => {
+  it('generates local workflows through the local entrypoint without shelling through the CLI', async () => {
+    const runLocal = vi.fn().mockResolvedValue(okLocalResponse());
+    const sdk = createRickySdk({ cwd: '/repo', runLocal });
+
+    const result = await sdk.generateLocalWorkflow({
+      spec: 'build a package health workflow',
+      workflowName: 'release-health',
+      bestJudgement: true,
+    });
+
+    expect(result.ok).toBe(true);
+    expect(runLocal).toHaveBeenCalledWith(
+      {
+        source: 'cli',
+        spec: {
+          intent: 'generate',
+          description: 'build a package health workflow',
+          workflowName: 'release-health',
+          name: 'release-health',
+          artifactPath: 'workflows/generated/release-health.ts',
+        },
+        invocationRoot: '/repo',
+        mode: 'local',
+        stageMode: 'generate',
+        bestJudgement: true,
+        cliMetadata: {
+          handoff: 'sdk',
+          workflowName: 'release-health',
+          bestJudgement: true,
+        },
+      },
+      {},
+    );
+  });
+
+  it('runs existing workflow artifacts locally with retry and auto-fix metadata', async () => {
+    const runLocal = vi.fn().mockResolvedValue(okLocalResponse());
+    const sdk = createRickySdk({ cwd: '/repo', runLocal });
+
+    await sdk.runLocalWorkflow({
+      workflowPath: 'workflows/generated/release-health.ts',
+      autoFixAttempts: 3,
+      startFromStep: 'review',
+      previousRunId: 'relay-run-123',
+    });
+
+    expect(runLocal).toHaveBeenCalledWith(
+      expect.objectContaining({
+        source: 'workflow-artifact',
+        artifactPath: 'workflows/generated/release-health.ts',
+        invocationRoot: '/repo',
+        mode: 'local',
+        stageMode: 'run',
+        autoFix: { maxAttempts: 3 },
+        retry: {
+          attempt: 1,
+          reason: 'manual resume requested from Ricky SDK',
+          startFromStep: 'review',
+          previousRunId: 'relay-run-123',
+          retryOfRunId: 'relay-run-123',
+        },
+      }),
+      {},
+    );
+  });
+
+  it('delegates Cloud generation through the Cloud API handler contract', async () => {
+    const response: CloudGenerateResponse = {
+      ok: true,
+      status: 200,
+      artifacts: [],
+      warnings: [],
+      assumptions: [],
+      validation: { ok: true, status: 'passed', issues: [] },
+      runReceipt: {
+        executionRequested: false,
+        requestId: 'req-sdk',
+        status: 'not_requested',
+      },
+      followUpActions: [],
+      requestId: 'req-sdk',
+    };
+    const handleCloudGenerate = vi.fn().mockResolvedValue(response);
+    const sdk = createRickySdk({ handleCloudGenerate });
+
+    const result = await sdk.generateCloudWorkflow({
+      auth: { token: 'token' },
+      workspace: { workspaceId: 'workspace-1' },
+      body: { spec: 'build a Cloud workflow', mode: 'cloud' },
+    });
+
+    expect(result).toBe(response);
+    expect(handleCloudGenerate).toHaveBeenCalledWith({
+      auth: { token: 'token' },
+      workspace: { workspaceId: 'workspace-1' },
+      body: { spec: 'build a Cloud workflow', mode: 'cloud' },
+    }, {});
+  });
+
+  it('exposes the CLI as an SDK call so the bin can stay thin', async () => {
+    const runCli = vi.fn().mockResolvedValue({ exitCode: 0, output: ['ricky 1.2.3'] });
+    const sdk = createRickySdk({ runCli });
+
+    await expect(sdk.runCli({ argv: ['version'], version: '1.2.3' })).resolves.toEqual({
+      exitCode: 0,
+      output: ['ricky 1.2.3'],
+    });
+    await expect(runRickyCli({ argv: ['version'], version: '1.2.3', runCli })).resolves.toEqual({
+      exitCode: 0,
+      output: ['ricky 1.2.3'],
+    });
+  });
+
+  it('keeps the published bin routed through the SDK instead of importing cli-main directly', () => {
+    const binPath = fileURLToPath(new URL('../surfaces/cli/bin/ricky.ts', import.meta.url));
+    const source = readFileSync(binPath, 'utf8');
+
+    expect(source).toContain("from '../../../sdk/index.js'");
+    expect(source).not.toContain("../commands/cli-main.js");
+  });
+});

--- a/src/sdk/index.ts
+++ b/src/sdk/index.ts
@@ -1,0 +1,210 @@
+/**
+ * Public Ricky SDK.
+ *
+ * This module is the package root export. It exposes programmatic entrypoints
+ * for local/BYOH generation and execution, Cloud generation, scheduling, and
+ * the CLI command runner used by the published `ricky` bin.
+ */
+
+import { handleCloudGenerate as defaultHandleCloudGenerate } from '../cloud/api/generate-endpoint.js';
+import type {
+  CloudGenerateEndpointOptions,
+  CloudGenerateResponse,
+  CloudGenerateRequest,
+  ListRickyWorkflowSchedulesResult,
+  ScheduleRickyWorkflowOptions,
+  ScheduleRickyWorkflowResult,
+} from '../cloud/api/index.js';
+import {
+  listRickyWorkflowSchedules as defaultListRickyWorkflowSchedules,
+  scheduleRickyWorkflow as defaultScheduleRickyWorkflow,
+} from '../cloud/api/index.js';
+import { runLocal as defaultRunLocal } from '../local/entrypoint.js';
+import type {
+  LocalEntrypointOptions,
+  LocalResponse,
+  RawHandoff,
+} from '../local/index.js';
+import { cliMain as defaultCliMain } from '../surfaces/cli/commands/cli-main.js';
+import type {
+  CliMainDeps,
+  CliMainResult,
+} from '../surfaces/cli/commands/cli-main.js';
+import { defaultArtifactPathForWorkflowName } from '../surfaces/cli/flows/spec-intake-flow.js';
+
+export type RickyRunLocal = (
+  handoff: RawHandoff,
+  options?: LocalEntrypointOptions,
+) => Promise<LocalResponse>;
+
+export type RickyHandleCloudGenerate = (
+  request: CloudGenerateRequest,
+  options?: CloudGenerateEndpointOptions,
+) => Promise<CloudGenerateResponse>;
+
+export type RickyRunCli = (deps?: CliMainDeps) => Promise<CliMainResult>;
+
+export interface RickySdkOptions {
+  /** Default caller root used when a method input does not provide `cwd`. */
+  cwd?: string;
+  /** Local entrypoint override for tests or custom runtime wiring. */
+  runLocal?: RickyRunLocal;
+  /** Cloud generate handler override for tests or custom server adapters. */
+  handleCloudGenerate?: RickyHandleCloudGenerate;
+  /** CLI command runner override for tests. */
+  runCli?: RickyRunCli;
+  /** Cloud workflow scheduler override for tests or custom Cloud adapters. */
+  scheduleWorkflow?: (
+    workflowPath: string,
+    options?: ScheduleRickyWorkflowOptions,
+  ) => Promise<ScheduleRickyWorkflowResult>;
+  /** Cloud workflow schedule lister override for tests or custom Cloud adapters. */
+  listWorkflowSchedules?: () => Promise<ListRickyWorkflowSchedulesResult>;
+}
+
+export interface RickyGenerateLocalWorkflowInput {
+  spec: string;
+  cwd?: string;
+  workflowName?: string;
+  run?: boolean;
+  bestJudgement?: boolean;
+  refine?: false | { model?: string };
+  autoFixAttempts?: number;
+  localOptions?: LocalEntrypointOptions;
+}
+
+export interface RickyRunLocalWorkflowInput {
+  workflowPath: string;
+  cwd?: string;
+  autoFixAttempts?: number;
+  startFromStep?: string;
+  previousRunId?: string;
+  localOptions?: LocalEntrypointOptions;
+}
+
+export interface RickySdk {
+  generateLocalWorkflow(input: RickyGenerateLocalWorkflowInput): Promise<LocalResponse>;
+  runLocalWorkflow(input: RickyRunLocalWorkflowInput): Promise<LocalResponse>;
+  generateCloudWorkflow(
+    request: CloudGenerateRequest,
+    options?: CloudGenerateEndpointOptions,
+  ): Promise<CloudGenerateResponse>;
+  scheduleWorkflow(
+    workflowPath: string,
+    options?: ScheduleRickyWorkflowOptions,
+  ): Promise<ScheduleRickyWorkflowResult>;
+  listWorkflowSchedules(): Promise<ListRickyWorkflowSchedulesResult>;
+  runCli(deps?: CliMainDeps): Promise<CliMainResult>;
+}
+
+export function createRickySdk(options: RickySdkOptions = {}): RickySdk {
+  const runLocal = options.runLocal ?? defaultRunLocal;
+  const handleCloudGenerate = options.handleCloudGenerate ?? defaultHandleCloudGenerate;
+  const runCli = options.runCli ?? defaultCliMain;
+  const scheduleWorkflow = options.scheduleWorkflow ?? defaultScheduleRickyWorkflow;
+  const listWorkflowSchedules = options.listWorkflowSchedules ?? defaultListRickyWorkflowSchedules;
+
+  return {
+    generateLocalWorkflow(input): Promise<LocalResponse> {
+      return runLocal(localGenerateHandoff(input, options.cwd), input.localOptions ?? {});
+    },
+
+    runLocalWorkflow(input): Promise<LocalResponse> {
+      return runLocal(localArtifactRunHandoff(input, options.cwd), input.localOptions ?? {});
+    },
+
+    generateCloudWorkflow(request, cloudOptions = {}): Promise<CloudGenerateResponse> {
+      return handleCloudGenerate(request, cloudOptions);
+    },
+
+    scheduleWorkflow(workflowPath, scheduleOptions = {}): Promise<ScheduleRickyWorkflowResult> {
+      return scheduleWorkflow(workflowPath, scheduleOptions);
+    },
+
+    listWorkflowSchedules(): Promise<ListRickyWorkflowSchedulesResult> {
+      return listWorkflowSchedules();
+    },
+
+    runCli(deps = {}): Promise<CliMainResult> {
+      return runCli(deps);
+    },
+  };
+}
+
+export function runRickyCli(deps: CliMainDeps & { runCli?: RickyRunCli } = {}): Promise<CliMainResult> {
+  const { runCli, ...cliDeps } = deps;
+  return createRickySdk({ runCli }).runCli(cliDeps);
+}
+
+function localGenerateHandoff(input: RickyGenerateLocalWorkflowInput, defaultCwd: string | undefined): RawHandoff {
+  const invocationRoot = input.cwd ?? defaultCwd ?? process.cwd();
+  const hasWorkflowName = typeof input.workflowName === 'string' && input.workflowName.trim().length > 0;
+  const workflowName = hasWorkflowName ? input.workflowName!.trim() : undefined;
+  const handoff: RawHandoff = {
+    source: 'cli',
+    spec: workflowName
+      ? {
+          intent: 'generate',
+          description: input.spec,
+          workflowName,
+          name: workflowName,
+          artifactPath: defaultArtifactPathForWorkflowName(workflowName),
+        }
+      : input.spec,
+    invocationRoot,
+    mode: 'local',
+    stageMode: input.run ? 'run' : 'generate',
+    ...(input.run && input.autoFixAttempts && input.autoFixAttempts > 0
+      ? { autoFix: { maxAttempts: input.autoFixAttempts } }
+      : {}),
+    ...(input.refine ? { refine: input.refine } : {}),
+    ...(input.bestJudgement ? { bestJudgement: true } : {}),
+    cliMetadata: {
+      handoff: 'sdk',
+      ...(workflowName ? { workflowName } : {}),
+      ...(input.bestJudgement ? { bestJudgement: true } : {}),
+    },
+  };
+  return handoff;
+}
+
+function localArtifactRunHandoff(input: RickyRunLocalWorkflowInput, defaultCwd: string | undefined): RawHandoff {
+  const retry = input.startFromStep || input.previousRunId
+    ? {
+        attempt: 1,
+        reason: 'manual resume requested from Ricky SDK',
+        ...(input.startFromStep ? { startFromStep: input.startFromStep } : {}),
+        ...(input.previousRunId ? { previousRunId: input.previousRunId, retryOfRunId: input.previousRunId } : {}),
+      }
+    : undefined;
+
+  return {
+    source: 'workflow-artifact',
+    artifactPath: input.workflowPath,
+    invocationRoot: input.cwd ?? defaultCwd ?? process.cwd(),
+    mode: 'local',
+    stageMode: 'run',
+    ...(input.autoFixAttempts && input.autoFixAttempts > 0
+      ? { autoFix: { maxAttempts: input.autoFixAttempts } }
+      : {}),
+    ...(retry ? { retry } : {}),
+    metadata: { handoff: 'sdk' },
+  };
+}
+
+export type {
+  CloudGenerateEndpointOptions,
+  CloudGenerateRequest,
+  CloudGenerateResponse,
+  CliMainDeps,
+  CliMainResult,
+  LocalEntrypointOptions,
+  LocalResponse,
+  RawHandoff,
+};
+
+export * as cloud from '../cloud/index.js';
+export * as local from '../local/index.js';
+export * as runtime from '../runtime/index.js';
+export * as product from '../product/index.js';
+export * as shared from '../shared/index.js';

--- a/src/surfaces/cli/bin/ricky.ts
+++ b/src/surfaces/cli/bin/ricky.ts
@@ -1,8 +1,8 @@
 #!/usr/bin/env node
 
-import { cliMain } from '../commands/cli-main.js';
+import { runRickyCli } from '../../../sdk/index.js';
 
-const result = await cliMain();
+const result = await runRickyCli();
 
 if (result.output.length > 0) {
   process.stdout.write(`${result.output.join('\n')}\n`);

--- a/test/package-proof/package-layout-proof.test.ts
+++ b/test/package-proof/package-layout-proof.test.ts
@@ -65,6 +65,10 @@ describe('Ricky package layout and npm-default proof', () => {
       [
         'package.json name: @agentworkforce/ricky',
         'package.json type: module',
+        'package.json exports["."].import: ./dist/index.js',
+        'package.json exports["."].types: ./dist/sdk/index.d.ts',
+        'package.json main: ./dist/index.js',
+        'package.json types: ./dist/sdk/index.d.ts',
         'package.json files is non-empty array: true',
         'package.json publishConfig.access: public',
         'package.json bin.ricky present: true',
@@ -92,6 +96,7 @@ describe('Ricky package layout and npm-default proof', () => {
         'package.json bin.ricky: ./dist/ricky.js',
         'published files include dist: true',
         'scripts/bundle-cli.mjs exists: true',
+        'src/sdk/index.ts exists: true',
         'src/surfaces/cli/bin/ricky.ts exists: true',
         'src/surfaces/cli/commands/cli-main.ts exists: true',
       ],

--- a/test/package-proof/package-layout-proof.ts
+++ b/test/package-proof/package-layout-proof.ts
@@ -53,6 +53,9 @@ interface PackageManifest {
   description?: unknown;
   license?: unknown;
   type?: unknown;
+  main?: unknown;
+  types?: unknown;
+  exports?: unknown;
   engines?: { node?: unknown };
   packageManager?: unknown;
   bin?: unknown;
@@ -367,6 +370,17 @@ export function getPackageLayoutProofCases(): PackageLayoutProofCase[] {
           typeof value === 'string' && value.length > 0 ? [] : [`Missing or empty package.json field: ${field}`],
         );
         const filesIsArray = Array.isArray(rootPkg.files) && rootPkg.files.length > 0;
+        const rootExport = rootPkg.exports && typeof rootPkg.exports === 'object'
+          ? (rootPkg.exports as Record<string, unknown>)['.']
+          : undefined;
+        const rootExportRecord = rootExport && typeof rootExport === 'object'
+          ? rootExport as Record<string, unknown>
+          : {};
+        const rootExportImport = rootExportRecord.import;
+        const rootExportTypes = rootExportRecord.types;
+        const hasSdkMain = rootPkg.main === './dist/index.js';
+        const hasSdkTypes = rootPkg.types === './dist/sdk/index.d.ts';
+        const hasSdkRootExport = rootExportImport === './dist/index.js' && rootExportTypes === './dist/sdk/index.d.ts';
         const publishAccess = rootPkg.publishConfig?.access;
         const hasPublishAccess = publishAccess === 'public' || publishAccess === 'restricted';
         const hasBin = packageBinTarget(rootPkg).length > 0;
@@ -377,12 +391,27 @@ export function getPackageLayoutProofCases(): PackageLayoutProofCase[] {
 
         return result(
           'package-shape-required-fields',
-          [stringIssues.length === 0, filesIsArray, hasPublishAccess, hasBin, isModule, !isPrivate, noFileProtocolDeps],
+          [
+            stringIssues.length === 0,
+            filesIsArray,
+            hasSdkMain,
+            hasSdkTypes,
+            hasSdkRootExport,
+            hasPublishAccess,
+            hasBin,
+            isModule,
+            !isPrivate,
+            noFileProtocolDeps,
+          ],
           [
             `package.json name: ${typeof rootPkg.name === 'string' ? rootPkg.name : '(missing)'}`,
             `package.json version: ${typeof rootPkg.version === 'string' ? rootPkg.version : '(missing)'}`,
             `package.json license: ${typeof rootPkg.license === 'string' ? rootPkg.license : '(missing)'}`,
             `package.json type: ${typeof rootPkg.type === 'string' ? rootPkg.type : '(missing)'}`,
+            `package.json exports["."].import: ${typeof rootExportImport === 'string' ? rootExportImport : '(missing)'}`,
+            `package.json exports["."].types: ${typeof rootExportTypes === 'string' ? rootExportTypes : '(missing)'}`,
+            `package.json main: ${typeof rootPkg.main === 'string' ? rootPkg.main : '(missing)'}`,
+            `package.json types: ${typeof rootPkg.types === 'string' ? rootPkg.types : '(missing)'}`,
             `package.json files is non-empty array: ${filesIsArray}`,
             `package.json publishConfig.access: ${typeof publishAccess === 'string' ? publishAccess : '(missing)'}`,
             `package.json bin.ricky present: ${hasBin}`,
@@ -394,6 +423,9 @@ export function getPackageLayoutProofCases(): PackageLayoutProofCase[] {
           [
             ...stringIssues,
             ...(filesIsArray ? [] : ['package.json files is missing or empty']),
+            ...(hasSdkMain ? [] : ['package.json main does not point at ./dist/index.js']),
+            ...(hasSdkTypes ? [] : ['package.json types does not point at ./dist/sdk/index.d.ts']),
+            ...(hasSdkRootExport ? [] : ['package.json exports["."] does not expose the SDK import and types targets']),
             ...(hasPublishAccess ? [] : ['package.json publishConfig.access is missing or unrecognized']),
             ...(hasBin ? [] : ['package.json bin.ricky is missing']),
             ...(isModule ? [] : ['package.json type is not "module"']),
@@ -479,17 +511,19 @@ export function getPackageLayoutProofCases(): PackageLayoutProofCase[] {
         const prepackBuilds = prepack.includes('build') || prepack.includes('bundle');
         const filesIncludesDist = Array.isArray(rootPkg.files) && rootPkg.files.includes('dist');
         const bundlerScriptExists = fileExists('scripts/bundle-cli.mjs');
+        const sdkSourceExists = fileExists('src/sdk/index.ts');
         const cliBinSourceExists = fileExists('src/surfaces/cli/bin/ricky.ts');
         const cliMainExists = fileExists('src/surfaces/cli/commands/cli-main.ts');
 
         return result(
           'bin-points-to-published-bundle',
-          [targetIsBundle, prepackBuilds, filesIncludesDist, bundlerScriptExists, cliBinSourceExists, cliMainExists],
+          [targetIsBundle, prepackBuilds, filesIncludesDist, bundlerScriptExists, sdkSourceExists, cliBinSourceExists, cliMainExists],
           [
             `package.json bin.ricky: ${binTarget || '(missing)'}`,
             `package.json scripts.prepack: ${prepack || '(missing)'}`,
             `published files include dist: ${filesIncludesDist}`,
             `scripts/bundle-cli.mjs exists: ${bundlerScriptExists}`,
+            `src/sdk/index.ts exists: ${sdkSourceExists}`,
             `src/surfaces/cli/bin/ricky.ts exists: ${cliBinSourceExists}`,
             `src/surfaces/cli/commands/cli-main.ts exists: ${cliMainExists}`,
           ],
@@ -499,6 +533,7 @@ export function getPackageLayoutProofCases(): PackageLayoutProofCase[] {
             ...(prepackBuilds ? [] : ['package.json scripts.prepack does not run the bundle/build']),
             ...(filesIncludesDist ? [] : ['package.json files does not include dist']),
             ...(bundlerScriptExists ? [] : ['Missing scripts/bundle-cli.mjs; bundle path is broken']),
+            ...(sdkSourceExists ? [] : ['Missing src/sdk/index.ts; SDK package source is gone']),
             ...(cliBinSourceExists ? [] : ['Missing src/surfaces/cli/bin/ricky.ts; CLI bin source is gone']),
             ...(cliMainExists ? [] : ['Missing src/surfaces/cli/commands/cli-main.ts; CLI main entry is gone']),
           ],


### PR DESCRIPTION
## Summary
- add a public `createRickySdk` package entry for local generation, local workflow runs, Cloud generation, scheduling, and CLI command execution
- route the published `ricky` bin through `runRickyCli` from the SDK while preserving existing CLI command behavior
- publish `dist/index.js` plus SDK declarations and tighten package proof/build docs around the new export

## Validation
- `npx vitest run src/sdk/index.test.ts src/surfaces/cli/commands/cli-main.test.ts test/package-proof/package-layout-proof.test.ts`
- `npm run typecheck`
- `npm run build`
- `node --input-type=module -e "const sdk = await import('@agentworkforce/ricky'); console.log(typeof sdk.createRickySdk, typeof sdk.runRickyCli, typeof sdk.local.runLocal)"`
- `node dist/ricky.js version`
- `npm pack --dry-run`
- `npm test`
- `npm run premerge`