### PR TITLE
fix(generation): move master workflow payload into sidecars

### DIFF
--- a/scripts/evals/run-ricky-evals.mjs
+++ b/scripts/evals/run-ricky-evals.mjs
@@ -338,24 +338,35 @@ function readGeneratedArtifactContent(stdout, workingDir) {
   const realWorkingDir = safeRealpath(workingDir);
   if (!realWorkingDir) return '';
   for (const artifactPath of artifactPaths) {
-    const fullPath = path.resolve(workingDir, artifactPath);
-    if (!existsSync(fullPath)) continue;
-    const realFullPath = safeRealpath(fullPath);
-    if (!realFullPath) continue;
-    if (realFullPath !== realWorkingDir && !realFullPath.startsWith(`${realWorkingDir}${path.sep}`)) {
-      continue;
+    for (const generatedPath of generatedArtifactAndSidecarPaths(artifactPath)) {
+      const fullPath = path.resolve(workingDir, generatedPath);
+      if (!existsSync(fullPath)) continue;
+      const realFullPath = safeRealpath(fullPath);
+      if (!realFullPath) continue;
+      if (realFullPath !== realWorkingDir && !realFullPath.startsWith(`${realWorkingDir}${path.sep}`)) {
+        continue;
+      }
+      try {
+        if (!statSync(realFullPath).isFile()) continue;
+      } catch {
+        continue;
+      }
+      sections.push([
+        `\n--- GENERATED ARTIFACT: ${generatedPath} ---`,
+        readFileSync(realFullPath, 'utf8'),
+      ].join('\n'));
     }
-    try {
-      if (!statSync(realFullPath).isFile()) continue;
-    } catch {
-      continue;
-    }
-    sections.push([
-      `\n--- GENERATED ARTIFACT: ${artifactPath} ---`,
-      readFileSync(realFullPath, 'utf8'),
-    ].join('\n'));
   }
   return sections.join('\n');
+}
+
+function generatedArtifactAndSidecarPaths(artifactPath) {
+  const paths = [artifactPath];
+  if (artifactPath.startsWith('workflows/generated/') && artifactPath.endsWith('.ts')) {
+    const stem = artifactPath.slice(0, -'.ts'.length);
+    paths.push(`${stem}.spec.md`, `${stem}.children.json`);
+  }
+  return paths;
 }
 
 function safeRealpath(value) {

--- a/scripts/run-ricky-overnight.sh
+++ b/scripts/run-ricky-overnight.sh
@@ -1765,48 +1765,15 @@ repo_has_meaningful_delta() {
 }
 
 commit_if_clean_delta() {
+  # Auto-commit and auto-push directly to origin/main were disabled
+  # intentionally: this loop was shipping unreviewed changes straight to a
+  # shared branch (commits authored as "Miya"). Future progress capture
+  # belongs in a per-run branch + PR. Keep the function as a no-op so the
+  # callers don't need to change.
   local workflow_path="$1"
-  local push_output_file="$ARTIFACT_DIR/git-push.txt"
-  local ahead="0"
-  local behind="0"
-
-  if ! repo_has_meaningful_delta; then
-    log "no tracked/untracked repo delta after $workflow_path"
-    return 0
-  fi
-
-  validate_repo
-
-  local short
-  local head_advanced="false"
-  short="$(basename "$workflow_path" .ts)"
-  if repo_has_captured_head_delta; then
-    head_advanced="true"
-  fi
-
-  if meaningful_tracked_delta_exists || meaningful_untracked_delta_exists; then
-    git add -A ':!tmp/' ':!.workflow-artifacts/' ':!.trajectories/'
-    git commit -m "chore(overnight): capture $short progress" || true
-  elif [[ "$head_advanced" == "true" ]]; then
-    log "repo HEAD already advanced during $workflow_path; capturing committed state"
-  fi
-
-  : > "$push_output_file"
-  if ! git push origin main >"$push_output_file" 2>&1; then
-    cat "$push_output_file" >&2 || true
-    git fetch origin main:refs/remotes/origin/main >/dev/null 2>&1 || true
-    if git show-ref --verify --quiet refs/remotes/origin/main; then
-      read -r ahead behind < <(git rev-list --left-right --count HEAD...refs/remotes/origin/main)
-      log "push rejected after $workflow_path; local main diverged from origin/main (ahead=${ahead}, behind=${behind})"
-    else
-      log "push rejected after $workflow_path; unable to read refs/remotes/origin/main for divergence details"
-    fi
-    inspect_repo_changes
-    return 1
-  fi
-
-  git rev-parse HEAD > "$LAST_COMMIT_FILE"
+  log "auto-commit/auto-push disabled; skipping post-workflow capture for $workflow_path"
   inspect_repo_changes
+  return 0
 }
 
 workflow_hit_claude_rate_limit() {

--- a/src/local/entrypoint.ts
+++ b/src/local/entrypoint.ts
@@ -14,7 +14,7 @@ import type { ChildProcess } from 'node:child_process';
 import { spawn } from 'node:child_process';
 import { createHash, randomUUID } from 'node:crypto';
 import { createRequire } from 'node:module';
-import { delimiter, dirname, isAbsolute, join, resolve } from 'node:path';
+import { delimiter, dirname, isAbsolute, join, resolve, sep } from 'node:path';
 import { createInterface } from 'node:readline';
 import { pathToFileURL } from 'node:url';
 
@@ -924,6 +924,16 @@ function isNoSuchProcessError(error: unknown): boolean {
   return typeof error === 'object' && error !== null && 'code' in error && (error as { code?: unknown }).code === 'ESRCH';
 }
 
+function resolveRepoContainedOutputPath(cwd: string, outputPath: string): string | undefined {
+  if (isAbsolute(outputPath)) return undefined;
+
+  const root = resolve(cwd);
+  const resolved = resolve(root, outputPath);
+  if (resolved === root) return undefined;
+  if (!resolved.startsWith(`${root}${sep}`)) return undefined;
+  return resolved;
+}
+
 async function workflowSdkLoaderNodeOption(cwd: string): Promise<string | undefined> {
   const runtime = await resolveWorkflowSdkRuntime(cwd);
   if (!runtime) return undefined;
@@ -1204,7 +1214,13 @@ export function createLocalExecutor(options: LocalExecutorOptions = {}): LocalEx
         // and child source map here to avoid argv-blow-out from spawn E2BIG).
         if (artifact.sidecarFiles) {
           for (const [sidecarPath, sidecarContent] of Object.entries(artifact.sidecarFiles)) {
-            await artifactWriter.writeArtifact(sidecarPath, sidecarContent, cwd);
+            const resolvedSidecarPath = resolveRepoContainedOutputPath(cwd, sidecarPath);
+            if (!resolvedSidecarPath) {
+              warnings.push(`Skipped unsafe workflow sidecar path outside invocation root: ${sidecarPath}`);
+              logs.push(`[local] skipped unsafe workflow sidecar: ${sidecarPath}`);
+              continue;
+            }
+            await artifactWriter.writeArtifact(resolvedSidecarPath, sidecarContent, cwd);
             logs.push(`[local] wrote workflow sidecar: ${sidecarPath}`);
           }
         }

--- a/src/local/entrypoint.ts
+++ b/src/local/entrypoint.ts
@@ -1199,6 +1199,15 @@ export function createLocalExecutor(options: LocalExecutorOptions = {}): LocalEx
 
         onProgress?.(`Writing workflow artifact to ${artifact.artifactPath}...`);
         await artifactWriter.writeArtifact(artifact.artifactPath, artifact.content, cwd);
+        // Sidecar files travel with the master workflow on disk so the
+        // generated TS can stay small (master-renderer pushes the spec text
+        // and child source map here to avoid argv-blow-out from spawn E2BIG).
+        if (artifact.sidecarFiles) {
+          for (const [sidecarPath, sidecarContent] of Object.entries(artifact.sidecarFiles)) {
+            await artifactWriter.writeArtifact(sidecarPath, sidecarContent, cwd);
+            logs.push(`[local] wrote workflow sidecar: ${sidecarPath}`);
+          }
+        }
         if (options.persistGenerationMetadataArtifacts === true) {
           await writeGenerationMetadataArtifacts(generationResult, artifactWriter, cwd);
         }

--- a/src/product/generation/master-workflow-renderer.ts
+++ b/src/product/generation/master-workflow-renderer.ts
@@ -182,6 +182,16 @@ export function renderMasterExecutionWorkflow(input: RenderMasterWorkflowInput):
   const gates = buildMasterGates(artifactsDir, plan, input.spec);
   const skillApplicationEvidence = buildMasterSkillEvidence(input.skills);
   const toolSelections = buildMasterToolSelections(plan);
+  // Sidecars travel with the generated workflow on disk. Embedding the spec
+  // and the child-source map inline ballooned the master workflow past
+  // ARG_MAX (spawn E2BIG) every time `materialize-child-workflows` ran; the
+  // sidecars push that payload off of argv entirely.
+  const artifactPathNoExt = artifactPath.replace(/\.ts$/, '');
+  const specSidecarPath = `${artifactPathNoExt}.spec.md`;
+  const childrenSidecarPath = `${artifactPathNoExt}.children.json`;
+  const childSources = Object.fromEntries(
+    plan.children.map((child) => [child.workflowFilePath, childWorkflowSource(child, input.spec, specSidecarPath)]),
+  );
   const content = renderMasterSource({
     spec: input.spec,
     pattern: input.pattern,
@@ -191,6 +201,9 @@ export function renderMasterExecutionWorkflow(input: RenderMasterWorkflowInput):
     plan,
     skills: input.skills,
     skillApplicationEvidence,
+    childSources,
+    specSidecarPath,
+    childrenSidecarPath,
   });
 
   return {
@@ -210,6 +223,10 @@ export function renderMasterExecutionWorkflow(input: RenderMasterWorkflowInput):
       skillMatches: input.skills.matches,
       toolSelections,
       artifactsDir,
+      sidecarFiles: {
+        [specSidecarPath]: input.spec.description,
+        [childrenSidecarPath]: `${JSON.stringify(childSources, null, 2)}\n`,
+      },
     },
   };
 }
@@ -240,10 +257,10 @@ function renderMasterSource(input: {
   plan: MasterExecutionPlan;
   skills: SkillContext;
   skillApplicationEvidence: SkillApplicationEvidence[];
+  childSources: Record<string, string>;
+  specSidecarPath: string;
+  childrenSidecarPath: string;
 }): string {
-  const childSources = Object.fromEntries(
-    input.plan.children.map((child) => [child.workflowFilePath, childWorkflowSource(child, input.spec)]),
-  );
   const planJson = JSON.stringify(input.plan, null, 2);
   const skillMatchesJson = JSON.stringify(input.skills.matches, null, 2);
   const skillBoundaryJson = JSON.stringify({
@@ -253,11 +270,14 @@ function renderMasterSource(input: {
     loadedSkills: input.skills.applicableSkillNames,
     applicationEvidence: input.skillApplicationEvidence,
   }, null, 2);
+  // Read the child source map from disk at runtime instead of inlining the
+  // JSON into this shell command. Inlining once N children deep produced a
+  // multi-megabyte argv element and triggered `spawn E2BIG`.
   const materializeCommand = [
     'node --input-type=module <<\'NODE\'',
-    'import { mkdirSync, writeFileSync } from \'node:fs\';',
+    'import { mkdirSync, writeFileSync, readFileSync } from \'node:fs\';',
     'import { dirname } from \'node:path\';',
-    `const childSources = ${JSON.stringify(childSources, null, 2)};`,
+    `const childSources = JSON.parse(readFileSync(${literal(input.childrenSidecarPath)}, 'utf8'));`,
     'for (const [filePath, source] of Object.entries(childSources)) {',
     '  mkdirSync(dirname(filePath), { recursive: true });',
     '  writeFileSync(filePath, source, \'utf8\');',
@@ -330,6 +350,12 @@ function renderMasterSource(input: {
     'echo RICKY_MASTER_FINAL_VALIDATION_READY',
   ];
 
+  // The master workflow's `.description()` is sent to runtime agents as
+  // context. Inlining the full spec text here meant every agent invocation
+  // carried ~100KB+ of markdown that the agents did not need (the spec lives
+  // on disk at specSidecarPath and child slices `cp` it locally). The short
+  // ref keeps the description small without losing the pointer.
+  const masterDescription = `${firstHeadingOrSummary(input.spec.description)} (full spec on disk at ${input.specSidecarPath}; child workflows read it from there).`;
   return `${[
     "import { workflow } from '@agent-relay/sdk/workflows';",
     '',
@@ -339,7 +365,7 @@ function renderMasterSource(input: {
     '',
     'async function main() {',
     `  const result = await workflow(${literal(input.workflowId)})`,
-    `    .description(${literal(input.spec.description)})`,
+    `    .description(${literal(masterDescription)})`,
     `    .pattern(${literal(input.pattern.pattern)})`,
     `    .channel(${literal(input.channel)})`,
     '    .maxConcurrency(4)',
@@ -471,7 +497,7 @@ function renderChildRunStep(child: ChildWorkflowPlan): string[] {
   ];
 }
 
-export function childWorkflowSource(child: ChildWorkflowPlan, spec: NormalizedWorkflowSpec): string {
+export function childWorkflowSource(child: ChildWorkflowPlan, spec: NormalizedWorkflowSpec, specSidecarPath?: string): string {
   const artifactsDir = child.signoffArtifactPath.replace(/\/signoff\.md$/, '');
   const validationCommand = child.validationCommands[0] ?? 'npm run typecheck';
   const targetScope = child.targetFiles.length > 0 ? child.targetFiles.join(' ') : 'NO_TARGET_FILES_DECLARED';
@@ -515,7 +541,14 @@ export function childWorkflowSource(child: ChildWorkflowPlan, spec: NormalizedWo
     `      command: ${literal([
       'set -e',
       `mkdir -p ${shellQuote(artifactsDir)}`,
-      `printf '%s\\n' ${shellQuote(spec.description)} > ${shellQuote(`${artifactsDir}/normalized-spec.txt`)}`,
+      // Copy the spec from its sidecar file rather than embedding it via
+      // `printf '%s\\n' '<huge spec text>'`. The embedded form pushed every
+      // child's prepare-context heredoc to ~100KB and made the materialize
+      // step's argv multi-megabyte. When the sidecar path isn't known
+      // (legacy call sites), fall back to a no-op so this child still runs.
+      specSidecarPath
+        ? `cp ${shellQuote(specSidecarPath)} ${shellQuote(`${artifactsDir}/normalized-spec.txt`)}`
+        : `: > ${shellQuote(`${artifactsDir}/normalized-spec.txt`)}`,
       `printf '%s\\n' ${shellQuote(targetScope)} > ${shellQuote(`${artifactsDir}/target-files.txt`)}`,
       // Snapshot the worktree's dirty set BEFORE this child touches anything.
       // The master executor runs every child in the SAME checkout, so by the
@@ -897,6 +930,18 @@ function titleCase(value: string): string {
 
 function literal(value: string | string[]): string {
   return JSON.stringify(value);
+}
+
+function firstHeadingOrSummary(specText: string): string {
+  // Pull the first H1 / H2 line from the spec to use as a short description.
+  // Falls back to the first non-empty line, then to a generic label. Output
+  // is capped so the master `.description()` never approaches argv limits.
+  const lines = specText.split('\n');
+  const heading = lines.find((line) => /^#{1,2}\s+\S/.test(line));
+  const candidate = heading?.replace(/^#{1,2}\s+/, '').trim()
+    ?? lines.find((line) => line.trim().length > 0)?.trim()
+    ?? 'Ricky master workflow';
+  return candidate.length > 200 ? `${candidate.slice(0, 197)}...` : candidate;
 }
 
 function templateLiteral(value: string): string {

--- a/src/product/generation/master-workflow-renderer.ts
+++ b/src/product/generation/master-workflow-renderer.ts
@@ -933,15 +933,55 @@ function literal(value: string | string[]): string {
 }
 
 function firstHeadingOrSummary(specText: string): string {
-  // Pull the first H1 / H2 line from the spec to use as a short description.
-  // Falls back to the first non-empty line, then to a generic label. Output
-  // is capped so the master `.description()` never approaches argv limits.
-  const lines = specText.split('\n');
-  const heading = lines.find((line) => /^#{1,2}\s+\S/.test(line));
-  const candidate = heading?.replace(/^#{1,2}\s+/, '').trim()
-    ?? lines.find((line) => line.trim().length > 0)?.trim()
+  const candidate = firstMarkdownHeadingOrParagraph(specText)
+    ?? specText.split('\n').find((line) => line.trim().length > 0)?.trim()
     ?? 'Ricky master workflow';
   return candidate.length > 200 ? `${candidate.slice(0, 197)}...` : candidate;
+}
+
+function firstMarkdownHeadingOrParagraph(specText: string): string | undefined {
+  let root: Nodes;
+  try {
+    root = fromMarkdown(specText);
+  } catch {
+    return undefined;
+  }
+
+  let fallback: string | undefined;
+  const visit = (node: Nodes): string | undefined => {
+    if (node.type === 'heading' && 'depth' in node && (node.depth === 1 || node.depth === 2)) {
+      const text = markdownNodeText(node);
+      if (text) return text;
+    }
+
+    if (!fallback && (node.type === 'paragraph' || node.type === 'text')) {
+      fallback = markdownNodeText(node);
+    }
+
+    if ('children' in node) {
+      for (const child of node.children) {
+        const found = visit(child);
+        if (found) return found;
+      }
+    }
+
+    return undefined;
+  };
+
+  return visit(root) ?? fallback;
+}
+
+function markdownNodeText(node: Nodes): string | undefined {
+  if ('value' in node && typeof node.value === 'string') {
+    return node.value.replace(/\s+/g, ' ').trim() || undefined;
+  }
+  if (!('children' in node)) return undefined;
+  const text = node.children
+    .map((child) => markdownNodeText(child) ?? '')
+    .join(' ')
+    .replace(/\s+/g, ' ')
+    .trim();
+  return text || undefined;
 }
 
 function templateLiteral(value: string): string {

--- a/src/product/generation/pipeline.test.ts
+++ b/src/product/generation/pipeline.test.ts
@@ -12,6 +12,15 @@ interface StepConfig {
   agent?: string;
   type?: string;
   dependsOn?: string[];
+  position: number;
+}
+
+interface OnErrorConfig {
+  strategy?: string;
+  maxRetries?: number;
+  retryDelayMs?: number;
+  repairAgent?: string;
+  repairRetries?: number;
 }
 
 /**
@@ -43,7 +52,7 @@ function extractStepConfigs(source: string): Map<string, StepConfig> {
       && ts.isObjectLiteralExpression(node.arguments[1])
     ) {
       const id = node.arguments[0].text;
-      const cfg: StepConfig = {};
+      const cfg: StepConfig = { position: node.getStart(sourceFile) };
       for (const prop of node.arguments[1].properties) {
         if (!ts.isPropertyAssignment(prop) || !prop.name) continue;
         const key = ts.isIdentifier(prop.name) || ts.isStringLiteralLike(prop.name) ? prop.name.text : undefined;
@@ -63,6 +72,53 @@ function extractStepConfigs(source: string): Map<string, StepConfig> {
   };
   visit(sourceFile);
   return steps;
+}
+
+function extractOnErrorConfigs(source: string): OnErrorConfig[] {
+  const sourceFile = ts.createSourceFile('workflow.ts', source, ts.ScriptTarget.Latest, false, ts.ScriptKind.TS);
+  const configs: OnErrorConfig[] = [];
+
+  const literalText = (node: ts.Expression): string | undefined => {
+    if (ts.isStringLiteralLike(node)) return node.text;
+    if (ts.isNoSubstitutionTemplateLiteral(node)) return node.text;
+    return undefined;
+  };
+  const literalNumber = (node: ts.Expression): number | undefined => {
+    if (ts.isNumericLiteral(node)) return Number(node.text);
+    if (ts.isPrefixUnaryExpression(node) && node.operator === ts.SyntaxKind.MinusToken && ts.isNumericLiteral(node.operand)) {
+      return -Number(node.operand.text);
+    }
+    return undefined;
+  };
+  const objectValue = (node: ts.Expression): Partial<OnErrorConfig> => {
+    if (!ts.isObjectLiteralExpression(node)) return {};
+    const cfg: Partial<OnErrorConfig> = {};
+    for (const prop of node.properties) {
+      if (!ts.isPropertyAssignment(prop) || !prop.name) continue;
+      const key = ts.isIdentifier(prop.name) || ts.isStringLiteralLike(prop.name) ? prop.name.text : undefined;
+      if (key === 'repairAgent') cfg.repairAgent = literalText(prop.initializer);
+      if (key === 'maxRetries') cfg.maxRetries = literalNumber(prop.initializer);
+      if (key === 'retryDelayMs') cfg.retryDelayMs = literalNumber(prop.initializer);
+      if (key === 'repairRetries') cfg.repairRetries = literalNumber(prop.initializer);
+    }
+    return cfg;
+  };
+  const visit = (node: ts.Node): void => {
+    if (
+      ts.isCallExpression(node)
+      && ts.isPropertyAccessExpression(node.expression)
+      && node.expression.name.text === 'onError'
+    ) {
+      configs.push({
+        strategy: node.arguments[0] && ts.isExpression(node.arguments[0]) ? literalText(node.arguments[0]) : undefined,
+        ...(node.arguments[1] && ts.isExpression(node.arguments[1]) ? objectValue(node.arguments[1]) : {}),
+      });
+    }
+    ts.forEachChild(node, visit);
+  };
+
+  visit(sourceFile);
+  return configs;
 }
 
 const RECEIVED_AT = '2026-04-26T00:00:00.000Z';
@@ -117,12 +173,42 @@ describe('workflow generation pipeline', () => {
     const childrenSidecarPath = 'workflows/generated/runtime-master.children.json';
     expect(rendered.sidecarFiles?.[childrenSidecarPath], 'children sidecar attached').toBeDefined();
     const childrenSidecar = rendered.sidecarFiles![childrenSidecarPath];
-    expect(childrenSidecar).toContain('review-claude');
-    expect(childrenSidecar).toContain('final-fix-codex');
-    expect(childrenSidecar).toContain('RICKY_CHILD_FRESH_EYES_LOOP_READY');
-    expect(rendered.content).toContain(".onError('retry', { maxRetries: 2, retryDelayMs: 10000, repairAgent: \"master-lead\", repairRetries: 2 })");
-    // validator-claude is a child-side agent; assert against the sidecar.
-    expect(childrenSidecar.replace(/\\+"/g, '"')).toContain(".onError('retry', { maxRetries: 2, retryDelayMs: 10000, repairAgent: \"validator-claude\", repairRetries: 2 })");
+    const childSources = JSON.parse(childrenSidecar) as Record<string, string>;
+    expect(Object.keys(childSources), 'child sidecar contains child workflow sources').not.toHaveLength(0);
+    const expectedChildStepOrder = [
+      'review-claude',
+      'fix-loop',
+      'final-review-claude',
+      'final-fix-claude',
+      'review-codex',
+      'fix-loop-codex',
+      'final-review-codex',
+      'final-fix-codex',
+      'final-review-pass-gate',
+      'final-hard-validation',
+    ];
+    for (const [childPath, childSource] of Object.entries(childSources)) {
+      const childStepConfigs = extractStepConfigs(childSource);
+      expect(extractOnErrorConfigs(childSource), `${childPath} child workflow retry policy`).toContainEqual({
+        strategy: 'retry',
+        maxRetries: 2,
+        retryDelayMs: 10000,
+        repairAgent: 'validator-claude',
+        repairRetries: 2,
+      });
+      const childStepPositions = expectedChildStepOrder.map((step) => childStepConfigs.get(step)?.position);
+      expect(childStepPositions, `${childPath} declares every fresh-eyes step`).not.toContain(undefined);
+      expect(childStepPositions, `${childPath} fresh-eyes step order`)
+        .toEqual([...childStepPositions].sort((a, b) => a! - b!));
+      expect(childStepConfigs.get('final-review-pass-gate')?.command, `${childPath} child fresh-eyes marker`).toContain('RICKY_CHILD_FRESH_EYES_LOOP_READY');
+    }
+    expect(extractOnErrorConfigs(rendered.content), 'master workflow retry policy').toContainEqual({
+      strategy: 'retry',
+      maxRetries: 2,
+      retryDelayMs: 10000,
+      repairAgent: 'master-lead',
+      repairRetries: 2,
+    });
     expect(rendered.content.replace(/\\+"/g, '"')).toMatch(
       /\.step\("final-hard-validation"[\s\S]*?failOnError: true,[\s\S]*?\.step\("final-signoff"/,
     );

--- a/src/product/generation/pipeline.test.ts
+++ b/src/product/generation/pipeline.test.ts
@@ -111,11 +111,18 @@ describe('workflow generation pipeline', () => {
     expect(rendered.content).not.toMatch(/^\s*command: "set -e\\nricky run .*--no-auto-fix/m);
     expect(rendered.content).toContain('MASTER_EXECUTOR_RESULT_READY');
     expect(rendered.content).toContain('RICKY_CHILD_WORKFLOW_COMPLETE');
-    expect(rendered.content).toContain('review-claude');
-    expect(rendered.content).toContain('final-fix-codex');
-    expect(rendered.content).toContain('RICKY_CHILD_FRESH_EYES_LOOP_READY');
+    // Child workflow sources live in the .children.json sidecar so the
+    // master content stays under ARG_MAX. Assert child-only strings are in
+    // the sidecar payload rather than inlined into the master TS.
+    const childrenSidecarPath = 'workflows/generated/runtime-master.children.json';
+    expect(rendered.sidecarFiles?.[childrenSidecarPath], 'children sidecar attached').toBeDefined();
+    const childrenSidecar = rendered.sidecarFiles![childrenSidecarPath];
+    expect(childrenSidecar).toContain('review-claude');
+    expect(childrenSidecar).toContain('final-fix-codex');
+    expect(childrenSidecar).toContain('RICKY_CHILD_FRESH_EYES_LOOP_READY');
     expect(rendered.content).toContain(".onError('retry', { maxRetries: 2, retryDelayMs: 10000, repairAgent: \"master-lead\", repairRetries: 2 })");
-    expect(rendered.content.replace(/\\+"/g, '"')).toContain(".onError('retry', { maxRetries: 2, retryDelayMs: 10000, repairAgent: \"validator-claude\", repairRetries: 2 })");
+    // validator-claude is a child-side agent; assert against the sidecar.
+    expect(childrenSidecar.replace(/\\+"/g, '"')).toContain(".onError('retry', { maxRetries: 2, retryDelayMs: 10000, repairAgent: \"validator-claude\", repairRetries: 2 })");
     expect(rendered.content.replace(/\\+"/g, '"')).toMatch(
       /\.step\("final-hard-validation"[\s\S]*?failOnError: true,[\s\S]*?\.step\("final-signoff"/,
     );

--- a/src/product/generation/types.ts
+++ b/src/product/generation/types.ts
@@ -195,6 +195,14 @@ export interface RenderedArtifact {
   skillMatches: SkillMatch[];
   toolSelections: ToolSelection[];
   artifactsDir: string;
+  /**
+   * Files that must be written alongside `artifactPath` at generation time.
+   * Keys are repo-relative paths. The master executor uses this to ship the
+   * spec text and the child-workflow source map as on-disk sidecars instead
+   * of inlining them into the generated TS — inlining ballooned the master
+   * workflow's argv past ARG_MAX and tripped `spawn E2BIG`.
+   */
+  sidecarFiles?: Record<string, string>;
 }
 
 export interface RefinementMetadata {

--- a/test/generated-workflow-reliability-contract.test.ts
+++ b/test/generated-workflow-reliability-contract.test.ts
@@ -84,15 +84,19 @@ describe('generated workflow reliability contract', () => {
     expect(result.success, result.validation.errors.join('\n')).toBe(true);
     const content = result.artifact!.content;
     const unescaped = content.replace(/\\+"/g, '"');
+    const childrenSidecarPath = 'workflows/generated/reliability-master.children.json';
+    const childrenSidecar = result.artifact!.sidecarFiles?.[childrenSidecarPath];
+    const childrenSidecarUnescaped = childrenSidecar?.replace(/\\+"/g, '"');
 
     expect(content).toContain('RICKY_MASTER_EXECUTOR_WORKFLOW');
     expect(content).toContain(".onError('retry', { maxRetries: 2, retryDelayMs: 10000, repairAgent: \"master-lead\", repairRetries: 2 })");
     expect(content).toContain('ricky run');
     expect(content).not.toContain('--no-auto-fix');
-    expect(unescaped).toContain(".onError('retry', { maxRetries: 2, retryDelayMs: 10000, repairAgent: \"validator-claude\", repairRetries: 2 })");
-    expect(unescaped).toMatch(/\.step\("final-hard-validation"[\s\S]*?failOnError: false,[\s\S]*?\.step\("final-signoff"/);
+    expect(childrenSidecar, 'children sidecar attached').toBeDefined();
+    expect(childrenSidecarUnescaped).toMatch(/\.onError\('retry', \{ maxRetries: 2, retryDelayMs: 10000, repairAgent: \"validator-claude\", repairRetries: 2 \}\)/);
+    expect(childrenSidecar).toContain('RICKY_CHILD_WORKFLOW_COMPLETE');
+    expect(childrenSidecarUnescaped).toMatch(/\.step\("final-hard-validation"[\s\S]*?failOnError: false,[\s\S]*?\.step\("final-signoff"/);
     expect(content).toMatch(/\.step\("final-hard-validation"[\s\S]*?failOnError: true,[\s\S]*?\.step\("final-signoff"/);
-    expect(content).toContain('RICKY_CHILD_WORKFLOW_COMPLETE');
     expect(content).toContain('RICKY_MASTER_FINAL_VALIDATION_READY');
   });
 

--- a/test/overnight-script-contract.test.ts
+++ b/test/overnight-script-contract.test.ts
@@ -80,13 +80,12 @@ describe('overnight harness queue-exhaustion contract', () => {
     expect(overnightScript).toContain('workflow runner produced no meaningful progress for ${IDLE_TIMEOUT_SECONDS}s: $workflow_path');
   });
 
-  it('treats push rejection during delta capture as a blocking divergence instead of silently continuing', () => {
+  it('keeps post-workflow delta capture disabled instead of pushing directly to main', () => {
+    expect(overnightScript).not.toContain('git add -A');
+    expect(overnightScript).not.toContain('git commit -m "chore(overnight): capture $short progress"');
+    expect(overnightScript).not.toContain('git push origin main');
     expect(overnightScript).not.toContain('git push origin main || true');
-    expect(overnightScript).toContain('if ! git push origin main >"$push_output_file" 2>&1; then');
-    expect(overnightScript).toContain('push rejected after $workflow_path; local main diverged from origin/main (ahead=${ahead}, behind=${behind})');
-    expect(overnightScript).toContain('mark_status "blocked" "push rejected after workflow delta capture: $workflow_path"');
-    expect(overnightScript).toContain('mark_status "blocked" "push rejected after failed workflow delta capture: $workflow_path"');
-    expect(overnightScript).toContain('mark_status "blocked" "push rejected after idle workflow delta capture: $workflow_path"');
+    expect(overnightScript).toContain('auto-commit/auto-push disabled; skipping post-workflow capture for $workflow_path');
   });
 
   it('does not quarantine runtime directories that still contain tracked repo files', () => {


### PR DESCRIPTION
## Summary
- move the master workflow payload into sidecar files instead of embedding the full payload inline
- align generation contract tests with the sidecar workflow shape
- disable the overnight runner auto-commit/auto-push path so future runs do not ship directly to origin/main

## Validation
- npm run typecheck
- npx vitest run src/product/generation/pipeline.test.ts test/generated-workflow-reliability-contract.test.ts test/overnight-script-contract.test.ts

## Main branch cleanup
- reverted accidental direct pushes on origin/main with c9a2c36 and 913a655
